### PR TITLE
loosen guardrails and support no alignment

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -25,29 +25,34 @@ BridgePowerController::BridgePowerController(IOPinHandle_t &BusPowerPin,
       _subsampleIntervalS(subsampleIntervalMs/1000),
       _subsampleDurationS(subsampleDurationMs/1000), _sampleIntervalStartS(0),
       _subSampleIntervalStartS(0), _alignmentS(alignmentS), _rtcSet(false), _initDone(false),
-      _subSamplingEnabled(subSamplingEnabled), _adin_handle(NULL) {
+      _subSamplingEnabled(subSamplingEnabled), _configError(false), _adin_handle(NULL) {
   if (_sampleIntervalS > MAX_SAMPLE_INTERVAL_S ||
       _sampleIntervalS < MIN_SAMPLE_INTERVAL_S) {
     printf("INVALID SAMPLE INTERVAL, using default.\n");
+    _configError = true;
     _sampleIntervalS = DEFAULT_SAMPLE_INTERVAL_S;
   }
   if (_sampleDurationS > MAX_SAMPLE_DURATION_S ||
       _sampleDurationS < MIN_SAMPLE_DURATION_S) {
     printf("INVALID SAMPLE DURATION, using default.\n");
+    _configError = true;
     _sampleDurationS = DEFAULT_SAMPLE_DURATION_S;
   }
   if (_subsampleIntervalS > MAX_SUBSAMPLE_INTERVAL_S ||
       _subsampleIntervalS < MIN_SUBSAMPLE_INTERVAL_S) {
     printf("INVALID SUBSAMPLE INTERVAL, using default.\n");
+    _configError = true;
     _subsampleIntervalS = DEFAULT_SUBSAMPLE_INTERVAL_S;
   }
   if (_subsampleDurationS > MAX_SUBSAMPLE_DURATION_S ||
       _subsampleDurationS < MIN_SUBSAMPLE_DURATION_S) {
     printf("INVALID SUBSAMPLE DURATION, using default.\n");
+    _configError = true;
     _subsampleDurationS = DEFAULT_SUBSAMPLE_DURATION_S;
   }
   if(_alignmentS > MAX_ALIGNMENT_S) {
     printf("INVALID ALIGNMENT, using default.\n");
+    _configError = true;
     _alignmentS = DEFAULT_ALIGNMENT_S;
   }
   _busPowerEventGroup = xEventGroupCreate();
@@ -149,6 +154,9 @@ void BridgePowerController::_update(
           false); // We start Bus on, no need to signal an eth up / power up event to l2 & adin
       vTaskDelay(
           INIT_POWER_ON_TIMEOUT_MS); // Set bus on for two minutes for init.
+      if(_configError) {
+        BRIDGE_LOG_PRINT("Bridge configuration error! Please check configs, using default.\n");
+      }
       static constexpr size_t printBufSize = 200;
       char *printbuf = static_cast<char *>(pvPortMalloc(printBufSize));
       configASSERT(printbuf);

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -201,7 +201,7 @@ void BridgePowerController::_update(
         }
       } else {
         BRIDGE_LOG_PRINT("Bridge State Sampling Off\n");
-        uint32_t nextSampleEpochS = (_alignmentS) ? alignEpoch(_sampleIntervalStartS + _sampleIntervalS) : _sampleIntervalStartS + _sampleIntervalS;
+        uint32_t nextSampleEpochS = alignEpoch(_sampleIntervalStartS + _sampleIntervalS);
         _sampleIntervalStartS = nextSampleEpochS;
         _subSampleIntervalStartS = nextSampleEpochS;
         time_to_sleep_ms =
@@ -282,7 +282,7 @@ uint32_t BridgePowerController::getEpochS() {
 uint32_t BridgePowerController::alignEpoch(uint32_t epochS) {
   uint32_t alignedEpoch = epochS;
   uint32_t alignmentDeltaS = 0;
-  if(epochS % _alignmentS != 0){
+  if(_alignmentS && epochS % _alignmentS != 0){
     alignmentDeltaS = (_alignmentS - (epochS % _alignmentS));
     alignedEpoch = epochS + alignmentDeltaS;
   }

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -46,8 +46,7 @@ BridgePowerController::BridgePowerController(IOPinHandle_t &BusPowerPin,
     printf("INVALID SUBSAMPLE DURATION, using default.\n");
     _subsampleDurationS = DEFAULT_SUBSAMPLE_DURATION_S;
   }
-  if(_alignmentS > MAX_ALIGNMENT_S ||
-    _alignmentS < MIN_ALIGNMENT_S) {
+  if(_alignmentS > MAX_ALIGNMENT_S) {
     printf("INVALID ALIGNMENT, using default.\n");
     _alignmentS = DEFAULT_ALIGNMENT_S;
   }
@@ -202,7 +201,7 @@ void BridgePowerController::_update(
         }
       } else {
         BRIDGE_LOG_PRINT("Bridge State Sampling Off\n");
-        uint32_t nextSampleEpochS = alignEpoch(_sampleIntervalStartS + _sampleIntervalS);
+        uint32_t nextSampleEpochS = (_alignmentS) ? alignEpoch(_sampleIntervalStartS + _sampleIntervalS) : _sampleIntervalStartS + _sampleIntervalS;
         _sampleIntervalStartS = nextSampleEpochS;
         _subSampleIntervalStartS = nextSampleEpochS;
         time_to_sleep_ms =

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -75,6 +75,7 @@ private:
   bool _rtcSet;
   bool _initDone;
   bool _subSamplingEnabled;
+  bool _configError;
   adin2111_DeviceHandle_t _adin_handle;
   EventGroupHandle_t _busPowerEventGroup;
   TaskHandle_t _task_handle;

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -12,10 +12,10 @@ class BridgePowerController {
 public:
   explicit BridgePowerController(
       IOPinHandle_t &BusPowerPin,
-      uint32_t sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_S,
-      uint32_t sampleDurationMs = DEFAULT_SAMPLE_DURATION_S,
-      uint32_t subsampleIntervalMs = DEFAULT_SUBSAMPLE_INTERVAL_S,
-      uint32_t subsampleDurationMs = DEFAULT_SUBSAMPLE_DURATION_S,
+      uint32_t sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_S * 1000,
+      uint32_t sampleDurationMs = DEFAULT_SAMPLE_DURATION_S * 1000,
+      uint32_t subsampleIntervalMs = DEFAULT_SUBSAMPLE_INTERVAL_S * 1000,
+      uint32_t subsampleDurationMs = DEFAULT_SUBSAMPLE_DURATION_S * 1000,
       bool subSamplingEnabled = false, bool powerControllerEnabled = false,
       uint32_t alignmentS = DEFAULT_ALIGNMENT_S);
   void powerControlEnable(bool enable);
@@ -45,16 +45,15 @@ public:
   static constexpr uint32_t DEFAULT_SUBSAMPLE_ENABLED = 0;
   static constexpr uint32_t DEFAULT_SUBSAMPLE_INTERVAL_S = (60);
   static constexpr uint32_t DEFAULT_SUBSAMPLE_DURATION_S = (30);
-  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S = (5 * 60);
-  static constexpr uint32_t MIN_SAMPLE_DURATION_S = (60);
+  static constexpr uint32_t MIN_SAMPLE_DURATION_S = (1);
+  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S = (1);
   static constexpr uint32_t MAX_SAMPLE_INTERVAL_S = (24 * 60 * 60);
   static constexpr uint32_t MAX_SAMPLE_DURATION_S = (24 * 60 * 60);
-  static constexpr uint32_t MIN_SUBSAMPLE_INTERVAL_S = (12);
-  static constexpr uint32_t MIN_SUBSAMPLE_DURATION_S = (6);
+  static constexpr uint32_t MIN_SUBSAMPLE_INTERVAL_S = (1);
+  static constexpr uint32_t MIN_SUBSAMPLE_DURATION_S = (1);
   static constexpr uint32_t MAX_SUBSAMPLE_INTERVAL_S = (60 * 60);
   static constexpr uint32_t MAX_SUBSAMPLE_DURATION_S = (60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_S = (5 * 60);
-  static constexpr uint32_t MIN_ALIGNMENT_S = (5 * 60);
   static constexpr uint32_t MAX_ALIGNMENT_S = (24 * 60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_5_MIN_INTERVAL = (1);
 

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -45,12 +45,12 @@ public:
   static constexpr uint32_t DEFAULT_SUBSAMPLE_ENABLED = 0;
   static constexpr uint32_t DEFAULT_SUBSAMPLE_INTERVAL_S = (60);
   static constexpr uint32_t DEFAULT_SUBSAMPLE_DURATION_S = (30);
-  static constexpr uint32_t MIN_SAMPLE_DURATION_S = (1);
-  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S = (1);
+  static constexpr uint32_t MIN_SAMPLE_DURATION_S = (6); 
+  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S = (6); // Set to 6s to allow for enough time for devices to broadcast for the topology.
   static constexpr uint32_t MAX_SAMPLE_INTERVAL_S = (24 * 60 * 60);
   static constexpr uint32_t MAX_SAMPLE_DURATION_S = (24 * 60 * 60);
-  static constexpr uint32_t MIN_SUBSAMPLE_INTERVAL_S = (1);
-  static constexpr uint32_t MIN_SUBSAMPLE_DURATION_S = (1);
+  static constexpr uint32_t MIN_SUBSAMPLE_INTERVAL_S = (6);
+  static constexpr uint32_t MIN_SUBSAMPLE_DURATION_S = (6);
   static constexpr uint32_t MAX_SUBSAMPLE_INTERVAL_S = (60 * 60);
   static constexpr uint32_t MAX_SUBSAMPLE_DURATION_S = (60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_S = (5 * 60);


### PR DESCRIPTION
This PR addresses a few things:
* Loosen the sampling guardrails so folks can experiment with the sampling behavior at the lower end. 
* Fix the units of the default parameters in BridgePowerController
* Support a zero-alignment configuration setting 