### PR TITLE
fix: github release action requires permission to create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: bash -l {0}
 
+    permissions:
+      contents: write # Allows the action to create a release
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixing this failure: https://github.com/bristlemouth/bm_protocol/actions/runs/6513088961/job/17692028669