### PR TITLE
fix: extract bridge power controller config into app_config

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -237,6 +237,7 @@ set(APP_LIBS
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/app_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgePowerController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -1,0 +1,37 @@
+#include "app_config.h"
+#include "bridgePowerController.h"
+
+power_config getPowerConfigs(cfg::Configuration &syscfg) {
+  power_config pwrcfg;
+
+  pwrcfg.sampleIntervalMs = BridgePowerController::DEFAULT_SAMPLE_INTERVAL_S * 1000;
+  syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+                   pwrcfg.sampleIntervalMs);
+
+  pwrcfg.sampleDurationMs = BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000;
+  syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+                   pwrcfg.sampleDurationMs);
+
+  pwrcfg.subSampleIntervalMs = BridgePowerController::DEFAULT_SUBSAMPLE_INTERVAL_S * 1000;
+  syscfg.getConfig(AppConfig::SUBSAMPLE_INTERVAL_MS, strlen(AppConfig::SUBSAMPLE_INTERVAL_MS),
+                   pwrcfg.subSampleIntervalMs);
+
+  pwrcfg.subsampleDurationMs = BridgePowerController::DEFAULT_SUBSAMPLE_DURATION_S * 1000;
+  syscfg.getConfig(AppConfig::SUBSAMPLE_DURATION_MS, strlen(AppConfig::SUBSAMPLE_DURATION_MS),
+                   pwrcfg.subsampleDurationMs);
+
+  pwrcfg.subsampleEnabled = BridgePowerController::DEFAULT_SUBSAMPLE_ENABLED;
+  syscfg.getConfig(AppConfig::SUBSAMPLE_ENABLED, strlen(AppConfig::SUBSAMPLE_ENABLED),
+                   pwrcfg.subsampleEnabled);
+
+  pwrcfg.bridgePowerControllerEnabled = BridgePowerController::DEFAULT_POWER_CONTROLLER_ENABLED;
+  syscfg.getConfig(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED,
+                   strlen(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED),
+                   pwrcfg.bridgePowerControllerEnabled);
+
+  pwrcfg.alignmentInterval5Min = BridgePowerController::DEFAULT_ALIGNMENT_5_MIN_INTERVAL;
+  syscfg.getConfig(AppConfig::ALIGNMENT_INTERVAL_5MIN,
+                   strlen(AppConfig::ALIGNMENT_INTERVAL_5MIN), pwrcfg.alignmentInterval5Min);
+
+  return pwrcfg;
+}

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -1,8 +1,8 @@
 #include "app_config.h"
 #include "bridgePowerController.h"
 
-power_config getPowerConfigs(cfg::Configuration &syscfg) {
-  power_config pwrcfg;
+power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
+  power_config_s pwrcfg;
 
   pwrcfg.sampleIntervalMs = BridgePowerController::DEFAULT_SAMPLE_INTERVAL_S * 1000;
   syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
@@ -12,9 +12,9 @@ power_config getPowerConfigs(cfg::Configuration &syscfg) {
   syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
                    pwrcfg.sampleDurationMs);
 
-  pwrcfg.subSampleIntervalMs = BridgePowerController::DEFAULT_SUBSAMPLE_INTERVAL_S * 1000;
+  pwrcfg.subsampleIntervalMs = BridgePowerController::DEFAULT_SUBSAMPLE_INTERVAL_S * 1000;
   syscfg.getConfig(AppConfig::SUBSAMPLE_INTERVAL_MS, strlen(AppConfig::SUBSAMPLE_INTERVAL_MS),
-                   pwrcfg.subSampleIntervalMs);
+                   pwrcfg.subsampleIntervalMs);
 
   pwrcfg.subsampleDurationMs = BridgePowerController::DEFAULT_SUBSAMPLE_DURATION_S * 1000;
   syscfg.getConfig(AppConfig::SUBSAMPLE_DURATION_MS, strlen(AppConfig::SUBSAMPLE_DURATION_MS),

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "configuration.h"
+
+namespace AppConfig {
+
+constexpr const char *SAMPLE_INTERVAL_MS = "sampleIntervalMs";
+constexpr const char *SAMPLE_DURATION_MS = "sampleDurationMs";
+constexpr const char *SUBSAMPLE_INTERVAL_MS = "subsampleIntervalMs";
+constexpr const char *SUBSAMPLE_DURATION_MS = "subsampleDurationMs";
+constexpr const char *SUBSAMPLE_ENABLED = "subsampleEnabled";
+constexpr const char *BRIDGE_POWER_CONTROLLER_ENABLED = "bridgePowerControllerEnabled";
+constexpr const char *ALIGNMENT_INTERVAL_5MIN = "alignmentInterval5Min";
+
+} // namespace AppConfig
+
+struct power_config {
+  uint32_t sampleIntervalMs, sampleDurationMs, subSampleIntervalMs, subsampleDurationMs,
+      subsampleEnabled, bridgePowerControllerEnabled, alignmentInterval5Min;
+};
+
+power_config getPowerConfigs(cfg::Configuration &syscfg);

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -14,9 +14,9 @@ constexpr const char *ALIGNMENT_INTERVAL_5MIN = "alignmentInterval5Min";
 
 } // namespace AppConfig
 
-struct power_config {
-  uint32_t sampleIntervalMs, sampleDurationMs, subSampleIntervalMs, subsampleDurationMs,
+struct power_config_s {
+  uint32_t sampleIntervalMs, sampleDurationMs, subsampleIntervalMs, subsampleDurationMs,
       subsampleEnabled, bridgePowerControllerEnabled, alignmentInterval5Min;
 };
 
-power_config getPowerConfigs(cfg::Configuration &syscfg);
+power_config_s getPowerConfigs(cfg::Configuration &syscfg);

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -15,6 +15,7 @@
 #include "task.h"
 #include "task_priorities.h"
 
+#include "app_config.h"
 #include "bm_l2.h"
 #include "bm_pubsub.h"
 #include "bristlemouth.h"
@@ -349,24 +350,16 @@ static void defaultTask( void *parameters ) {
     debugDfuInit(&dfu_partition);
     bcl_init(&dfu_partition,&debug_configuration_user, &debug_configuration_system);
 
-    uint32_t sampleIntervalMs = BridgePowerController::DEFAULT_SAMPLE_INTERVAL_S * 1000;
-    debug_configuration_system.getConfig("sampleIntervalMs", strlen("sampleIntervalMs"),sampleIntervalMs);
-    uint32_t sampleDurationMs = BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000;
-    debug_configuration_system.getConfig("sampleDurationMs",strlen("sampleDurationMs"),sampleDurationMs);
-    uint32_t subSampleIntervalMs = BridgePowerController::DEFAULT_SUBSAMPLE_INTERVAL_S * 1000;
-    debug_configuration_system.getConfig("subSampleIntervalMs",strlen("subSampleIntervalMs"),subSampleIntervalMs);
-    uint32_t subsampleDurationMs = BridgePowerController::DEFAULT_SUBSAMPLE_DURATION_S * 1000;
-    debug_configuration_system.getConfig("subsampleDurationMs",strlen("subsampleDurationMs"),subsampleDurationMs);
-    uint32_t subsampleEnabled = BridgePowerController::DEFAULT_SUBSAMPLE_ENABLED;
-    debug_configuration_system.getConfig("subsampleEnabled", strlen("subsampleEnabled"), subsampleEnabled);
-    uint32_t bridgePowerControllerEnabled = BridgePowerController::DEFAULT_POWER_CONTROLLER_ENABLED;
-    debug_configuration_system.getConfig("bridgePowerControllerEnabled", strlen("bridgePowerControllerEnabled"), bridgePowerControllerEnabled);
-    uint32_t alignmentInterval5Min = BridgePowerController::DEFAULT_ALIGNMENT_5_MIN_INTERVAL;
-    debug_configuration_system.getConfig("alignmentInterval5Min", strlen("bridgePowerControllerEnabled"), alignmentInterval5Min);
     printf("Using bridge power controller.\n");
     IOWrite(&BOOST_EN, 1);
-    BridgePowerController bridge_power_controller(VBUS_SW_EN, sampleIntervalMs,
-        sampleDurationMs, subSampleIntervalMs, subsampleDurationMs, static_cast<bool>(subsampleEnabled), static_cast<bool>(bridgePowerControllerEnabled), (alignmentInterval5Min * BridgePowerController::DEFAULT_ALIGNMENT_S));
+    power_config pwrcfg = getPowerConfigs(debug_configuration_system);
+    BridgePowerController bridge_power_controller(
+        VBUS_SW_EN, pwrcfg.sampleIntervalMs, pwrcfg.sampleDurationMs,
+        pwrcfg.subSampleIntervalMs, pwrcfg.subsampleDurationMs,
+        static_cast<bool>(pwrcfg.subsampleEnabled),
+        static_cast<bool>(pwrcfg.bridgePowerControllerEnabled),
+        (pwrcfg.alignmentInterval5Min * BridgePowerController::DEFAULT_ALIGNMENT_S));
+
     ncpInit(&usart3, &dfu_partition, &bridge_power_controller, &debug_configuration_user, &debug_configuration_system, &debug_configuration_hardware);
     topology_sampler_init(&bridge_power_controller, &debug_configuration_hardware, &debug_configuration_system);
     debug_ncp_init();

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -352,10 +352,10 @@ static void defaultTask( void *parameters ) {
 
     printf("Using bridge power controller.\n");
     IOWrite(&BOOST_EN, 1);
-    power_config pwrcfg = getPowerConfigs(debug_configuration_system);
+    power_config_s pwrcfg = getPowerConfigs(debug_configuration_system);
     BridgePowerController bridge_power_controller(
         VBUS_SW_EN, pwrcfg.sampleIntervalMs, pwrcfg.sampleDurationMs,
-        pwrcfg.subSampleIntervalMs, pwrcfg.subsampleDurationMs,
+        pwrcfg.subsampleIntervalMs, pwrcfg.subsampleDurationMs,
         static_cast<bool>(pwrcfg.subsampleEnabled),
         static_cast<bool>(pwrcfg.bridgePowerControllerEnabled),
         (pwrcfg.alignmentInterval5Min * BridgePowerController::DEFAULT_ALIGNMENT_S));


### PR DESCRIPTION
- Define the config key strings only once
- Fix lowercase/uppercase variation
- Fix wrong strlen
- Refactor to extract verbose config code into a function