### PR TITLE
circ mean + std

### DIFF
--- a/src/lib/common/avgSampler.cpp
+++ b/src/lib/common/avgSampler.cpp
@@ -290,6 +290,7 @@ double AveragingSampler::getCircularMean() {
 
 /*!
   Compute circular standard deviation of all the samples
+Per Kuik et al 1988: https://doi.org/10.1175/1520-0485(1988)018%3C1020:AMFTRA%3E2.0.CO;2
 
   \return circular standard deviation of all the samples
  */

--- a/src/lib/common/avgSampler.h
+++ b/src/lib/common/avgSampler.h
@@ -8,6 +8,11 @@
 
 class AveragingSampler {
 public:
+  typedef enum TrigMeanType {
+    TRIG_MEAN_TYPE_SIN,
+    TRIG_MEAN_TYPE_COS,
+  } TrigMeanType_e;
+
   AveragingSampler();
   ~AveragingSampler();
   bool addSample(double sample);
@@ -18,6 +23,10 @@ public:
   double kahanSum(double total, double input, double &c);
   double getMax();
   double getMin();
+  double getTrigSum(TrigMeanType_e type);
+  double getTrigMean(TrigMeanType_e type);
+  double getCircularMean();
+  double getCircularStd();
   void initBuffer(uint32_t maxSamples);
   void clear();
   uint32_t getNumSamples();

--- a/src/lib/common/util.c
+++ b/src/lib/common/util.c
@@ -295,3 +295,13 @@ char *duplicateStr(const char *inStr) {
   }
   return true;
 }
+
+/*!
+  Convert degrees to radians
+
+  \param[in] deg - degrees
+  \return radians
+*/
+double degToRad(double deg) {
+  return deg * (M_PI / 180.0);
+}

--- a/src/lib/common/util.h
+++ b/src/lib/common/util.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include "FreeRTOS.h"
 #include "timers.h"
+#include "math.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,6 +27,7 @@ uint32_t timeRemainingGeneric(uint32_t startTime, uint32_t currentTime, uint32_t
 
 char *duplicateStr(const char *inStr);
 bool isASCIIString(const char *str);
+double degToRad(double deg);
 
 #define timeRemainingTicks(startTicks, timeoutTicks) timeRemainingGeneric(startTicks, xTaskGetTickCount(), timeoutTicks)
 #define timeRemainingTicksFromISR(startTicks, timeoutTicks) timeRemainingGeneric(startTicks, xTaskGetTickCountFromISR(), timeoutTicks)

--- a/test/src/common/CMakeLists.txt
+++ b/test/src/common/CMakeLists.txt
@@ -283,6 +283,9 @@ target_sources(avgSampler
     # File we're testing
     ${SRC_DIR}/lib/common/avgSampler.cpp
 
+    # Support files 
+    ${SRC_DIR}/lib/common/util.c
+
     # Unit test wrapper for test
     avgSampler_ut.cpp
 )

--- a/test/src/common/avgSampler_ut.cpp
+++ b/test/src/common/avgSampler_ut.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "avgSampler.h"
+#include "util.h"
 
 // The fixture for testing class Foo.
 class AvgSamplerTest : public ::testing::Test {
@@ -191,4 +192,19 @@ TEST_F(AvgSamplerTest, timestamp_test) {
   EXPECT_TRUE(sampler.addSampleTimestamped(4.0));
 
   EXPECT_EQ(sampler.getNumSamples(), 3);
+}
+
+
+TEST_F(AvgSamplerTest, circ) {
+  AveragingSampler sampler;
+  sampler.initBuffer(4);
+  double samplesDeg[] = {90, 120, 33, 355};
+  const uint32_t num_samples = sizeof(samplesDeg) / sizeof(double);
+
+  for (uint16_t sample = 0; sample < num_samples; sample++) {
+    // Use sample+1 as timestamp for now
+    EXPECT_TRUE(sampler.addSampleTimestamped(degToRad(samplesDeg[sample]), (sample + 1)));
+  }
+  EXPECT_NEAR(sampler.getCircularStd(),  0.8125, 0.0001);
+  EXPECT_NEAR(sampler.getCircularMean(), 1.0493, 0.0001); // Tested vs https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.circmean.html
 }

--- a/test/src/common/avgSampler_ut.cpp
+++ b/test/src/common/avgSampler_ut.cpp
@@ -205,6 +205,10 @@ TEST_F(AvgSamplerTest, circ) {
     // Use sample+1 as timestamp for now
     EXPECT_TRUE(sampler.addSampleTimestamped(degToRad(samplesDeg[sample]), (sample + 1)));
   }
+  // Tested against custom python impl:
+  // The wave std (in radians) is:
+  // np.sqrt(2 - 2 * np.sqrt(a1 ** 2 + b1 ** 2)
+  // where a1 is the mean of the cosine of the angles, and b1 is the mean of the sine of the angles.
   EXPECT_NEAR(sampler.getCircularStd(),  0.8125, 0.0001);
   EXPECT_NEAR(sampler.getCircularMean(), 1.0493, 0.0001); // Tested vs https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.circmean.html
 }


### PR DESCRIPTION
Adding circular mean and std.

Testing:
Unit test - 
circ mean verified against https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.circmean.html
circ std verified against custom python impl:
```
The wave std (in radians) is:
np.sqrt(2 - 2 * np.sqrt(a1 ** 2 + b1 ** 2)
where a1 is the mean of the cosine of the angles, and b1 is the mean of the sine of the angles.
```
 