### PR TITLE
feat: calculate system config crc using the cbor map representation

### DIFF
--- a/src/lib/sys/configuration.cpp
+++ b/src/lib/sys/configuration.cpp
@@ -31,13 +31,13 @@ bool Configuration::loadAndVerifyNvmConfig(void) {
         if(!_flash_partition.read(CONFIG_START_OFFSET_IN_BYTES, reinterpret_cast<uint8_t *>(_ram_partition), sizeof(ConfigPartition_t), CONFIG_LOAD_TIMEOUT_MS)){
             break;
         }
-        size_t buffer_len = sizeof(ConfigPartition_t);
-        uint8_t buffer[buffer_len];
-        bool encodeSuccess = asCborMap(buffer, buffer_len);
-        if (!encodeSuccess) {
+        size_t buffer_size = 0;
+        uint8_t *buffer = asCborMap(buffer_size);
+        if (!buffer) {
             break;
         }
-        uint32_t computed_crc32 = crc32_ieee(buffer, buffer_len);
+        uint32_t computed_crc32 = crc32_ieee(buffer, buffer_size);
+        vPortFree(buffer);
         if (_ram_partition->header.crc32 != computed_crc32) {
             break;
         }
@@ -252,15 +252,17 @@ bool Configuration::getConfigCbor(const char * key, size_t key_len, uint8_t *val
 }
 
 /*! \brief Encode the entire config partition as a CBOR map.
-    \param[out] buffer The destination for the encoded CBOR bytes.
-    \param[in,out] buffer_len in: The length in bytes of the given buffer.
-                              out: The length in bytes of the encoded CBOR.
-    \return True on success, false on failure.
+    \param buffer_size[out] The size in bytes of the encoded map.
+    \return Pointer to a heap buffer containing the encoded map, or NULL on failure.
+    \warning The caller is responsible for freeing the returned buffer!
  */
-bool Configuration::asCborMap(uint8_t *buffer, size_t &buffer_len) {
-  configASSERT(buffer);
-  bool success = false;
-  size_t original_len = buffer_len;
+uint8_t *Configuration::asCborMap(size_t &buffer_size) {
+  buffer_size = 0;
+  size_t allocated_size = 512;
+  uint8_t *buffer = static_cast<uint8_t *>(pvPortMalloc(allocated_size));
+  if (!buffer) {
+    return NULL;
+  }
 
   uint32_t tmpU;
   int32_t tmpI;
@@ -275,9 +277,11 @@ bool Configuration::asCborMap(uint8_t *buffer, size_t &buffer_len) {
   CborEncoder encoder;
   CborEncoder map;
   CborError err;
-  cbor_encoder_init(&encoder, buffer, buffer_len, 0);
+  bool shouldRetry;
 
   do {
+    shouldRetry = false;
+    cbor_encoder_init(&encoder, buffer, allocated_size, 0);
     err = cbor_encoder_create_map(&encoder, &map, _ram_partition->header.numKeys);
     if (err != CborNoError && err != CborErrorOutOfMemory) {
       break;
@@ -339,16 +343,26 @@ bool Configuration::asCborMap(uint8_t *buffer, size_t &buffer_len) {
 
     if (err == CborErrorOutOfMemory) {
       size_t needed = cbor_encoder_get_extra_bytes_needed(&encoder);
-      printf("Encoding failed, buffer too small. Need %zu more bytes than the %zu originally "
-             "given, or %zu total.\n",
-             needed, original_len, original_len + needed);
+      printf("Encoding failed, buffer too small. Will retry. "
+             "Need %zu more bytes than the %zu originally given, or %zu total.\n",
+             needed, allocated_size, allocated_size + needed);
+      vPortFree(buffer);
+      allocated_size += needed;
+      buffer = static_cast<uint8_t *>(pvPortMalloc(allocated_size));
+      if (!buffer) {
+        break;
+      }
+      shouldRetry = true;
     } else if (err == CborNoError) {
-      buffer_len = cbor_encoder_get_buffer_size(&encoder, buffer);
-      success = true;
+      buffer_size = cbor_encoder_get_buffer_size(&encoder, buffer);
+    } else {
+      printf("Failed to encode config as cbor map, err=%" PRIu32 "\n", err);
+      vPortFree(buffer);
+      buffer = NULL;
     }
-  } while (0);
+  } while (shouldRetry);
 
-  return success;
+  return buffer;
 }
 
 bool Configuration::prepareCborEncoder(const char * key, size_t key_len, CborEncoder &encoder, uint8_t &keyIdx, bool &keyExists) {
@@ -677,13 +691,13 @@ const char* Configuration::dataTypeEnumToStr(ConfigDataTypes_e type) {
 bool Configuration::saveConfig(bool restart) {
     bool rval = false;
     do {
-        size_t buffer_len = sizeof(ConfigPartition_t);
-        uint8_t buffer[buffer_len];
-        bool encodeSuccess = asCborMap(buffer, buffer_len);
-        if (!encodeSuccess) {
+        size_t buffer_size = 0;
+        uint8_t *buffer = asCborMap(buffer_size);
+        if (!buffer) {
             break;
         }
-        _ram_partition->header.crc32 = crc32_ieee(buffer, buffer_len);
+        _ram_partition->header.crc32 = crc32_ieee(buffer, buffer_size);
+        vPortFree(buffer);
         if (!_flash_partition.write(CONFIG_START_OFFSET_IN_BYTES,
                                     reinterpret_cast<uint8_t *>(_ram_partition),
                                     sizeof(ConfigPartition_t), CONFIG_LOAD_TIMEOUT_MS)) {

--- a/src/lib/sys/configuration.h
+++ b/src/lib/sys/configuration.h
@@ -57,7 +57,7 @@ public:
     const ConfigKey_t* getStoredKeys(uint8_t &num_stored_keys);
     bool setConfigCbor(const char * key, size_t key_len, uint8_t *value, size_t value_len);
     bool removeKey(const char * key, size_t key_len);
-    bool asCborMap(uint8_t *buffer, size_t &buffer_len);
+    uint8_t *asCborMap(size_t &buffer_size);
     static const char* dataTypeEnumToStr(ConfigDataTypes_e type);
     bool saveConfig(bool restart=true);
     bool getValueSize(const char * key, size_t key_len, size_t &size);

--- a/test/src/common/configuration_ut.cpp
+++ b/test/src/common/configuration_ut.cpp
@@ -1,10 +1,12 @@
 #include "gtest/gtest.h"
 
-#include "nvmPartition.h"
-#include "mock_storage_driver.h"
-#include "ram_partitions.h"
 #include "configuration.h"
 #include "fff.h"
+#include "mock_storage_driver.h"
+#include "nvmPartition.h"
+#include "ram_partitions.h"
+
+#include "FreeRTOS.h"
 
 DEFINE_FFF_GLOBALS;
 
@@ -298,9 +300,6 @@ TEST_F(ConfigurationTest, BadCborGetSet){
 }
 
 TEST_F(ConfigurationTest, AsCborMap) {
-  uint8_t buffer[100];
-  size_t buffer_size = sizeof(buffer);
-
   const ext_flash_partition_t test_configuration = {
       .fa_off = 4096,
       .fa_size = 10000,
@@ -324,7 +323,9 @@ TEST_F(ConfigurationTest, AsCborMap) {
   uint8_t bytes[] = {0xde, 0xad, 0xbe, 0xef, 0x5a, 0xad, 0xda, 0xad, 0xb0, 0xdd};
   config.setConfig("bytes", strlen("bytes"), bytes, sizeof(bytes));
 
-  EXPECT_EQ(config.asCborMap(buffer, buffer_size), true);
+  size_t buffer_size = 0;
+  uint8_t *buffer = config.asCborMap(buffer_size);
+  EXPECT_NE(buffer, nullptr);
 
   /*
   From https://cbor.me/
@@ -360,4 +361,5 @@ TEST_F(ConfigurationTest, AsCborMap) {
   EXPECT_EQ(buffer[30], 0x2b);
   EXPECT_EQ(buffer[74], 0x65);
   EXPECT_EQ(buffer[80], 0x4a);
+  vPortFree(buffer);
 }


### PR DESCRIPTION
For the same underlying config, this will change the calculated CRC value, since we're using a different representation that is more appropriate for serialization and communication across systems.