### PR TITLE
get sys info crc from nodes

### DIFF
--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -247,7 +247,8 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
   printf("Reply: %" PRIu32 "\n", msg_id);
   do {
     if (ack) {
-      // Memory is 
+      // Memory is allocated in the decode function, if we fail to decode, we need to free it.
+      // Otherwise, we'll free it in the topology sampler task.
       if (SysInfoSvcReplyMsg::decode(reply, reply_data, reply_len) != CborNoError) {
         printf("Failed to decode sys info reply\n");
         break;
@@ -292,6 +293,8 @@ static bool cbor_config_map_reply_cb(bool ack, uint32_t msg_id, size_t service_s
   printf("Reply: %" PRIu32 "\n", msg_id);
   do {
     if (ack) {
+      // Memory is allocated in the decode function, if we fail to decode, we need to free it.
+      // Otherwise, we'll free it in the topology sampler task.
       if (ConfigCborMapSrvReplyMsg::decode(reply, reply_data, reply_len) != CborNoError) {
         printf("Failed to decode cbor map reply\n");
         break;

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -34,11 +34,11 @@
 
 #define BUS_POWER_ON_DELAY 5000
 #define NODE_SYS_INFO_REQUEST_TIMEOUT_S (3)
-#define NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS (NODE_SYS_INFO_REQUEST_TIMEOUT_S * 1000)
+#define NODE_NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS (NODE_SYS_INFO_REQUEST_TIMEOUT_S * 1000)
 #define NODE_CONFIG_CBOR_MAP_REQUEST_TIMEOUT_S (3)
 #define NODE_CONFIG_CBOR_MAP_REQUEST_TIMEOUT_MS (NODE_CONFIG_CBOR_MAP_REQUEST_TIMEOUT_S * 1000)
-#define NODE_CONFIG_PADDING                                                                    \
-  (512) // Accounts for name of app + cbor config map + encoding inefficiencies
+ // Accounts for name of app + cbor config map + encoding inefficiencies
+#define NODE_CONFIG_PADDING (512)
 #define NUM_CONFIG_FIELDS_PER_NODE (5)
 
 typedef struct node_list {
@@ -370,7 +370,7 @@ static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bu
       }
       // Update the network crc with all of the node crcs
       if (xQueueReceive(_sys_info_queue, &info_reply,
-                        pdMS_TO_TICKS(NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS))) {
+                        pdMS_TO_TICKS(NODE_NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS))) {
         // If we have a sys info reply coming back, request the cbor map
         if (!config_cbor_map_service_request(info_reply.node_id, CONFIG_CBOR_MAP_PARTITION_ID_SYS,
                                            cbor_config_map_reply_cb,

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -410,9 +410,11 @@ static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bu
       // Free the memory allocated in the decode functions every loop.
       if(info_reply.app_name) {
         vPortFree(info_reply.app_name);
+        info_reply.app_name = NULL;
       }
       if(cbor_map_reply.cbor_data) {
         vPortFree(cbor_map_reply.cbor_data);
+        cbor_map_reply.cbor_data = NULL;
       }
     }
     // Free the memory allocated in the decode functions in case we broke out of the loop.

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -123,17 +123,11 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
                                 sizeof(ConfigCborMapSrvReplyMsg::Data) + NODE_CONFIG_PADDING);
     cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(cbor_bufsize));
     configASSERT(cbor_buffer);
-    bool encoding_success = false;
-    do {
-      if (!create_network_info_cbor_array(cbor_buffer, cbor_bufsize)) {
-        printf("Failed to create network info cbor map\n");
-        break;
-      }
-      network_crc32_calc = crc32_ieee(cbor_buffer, cbor_bufsize);
-      encoding_success = true;
-    } while (0);
 
-    if (!encoding_success) {
+    if (create_network_info_cbor_array(cbor_buffer, cbor_bufsize)) {
+      network_crc32_calc = crc32_ieee(cbor_buffer, cbor_bufsize);
+    } else {
+      printf("Failed to create network info cbor array\n");
       break;
     }
 

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -483,7 +483,7 @@ static bool encode_cbor_configuration(CborEncoder &array_encoder,
     if (err != CborNoError) {
       break;
     }
-    err = cbor_encoder_create_map(&array_encoder, &map_encoder, NUM_CONFIG_FIELDS_PER_NODE);
+    err = cbor_encoder_create_map(&array_encoder, &map_encoder, num_fields);
     if(err != CborNoError) {
       break;
     }

--- a/src/lib/middleware/bm_service_request.h
+++ b/src/lib/middleware/bm_service_request.h
@@ -5,6 +5,7 @@
 
 /*!
  * @brief Callback function for bm_service_request
+ * @note Should not call bm_service_request from within this callback.
  * @param[in] ack True if the request was acknowledged, false if it was rejected.
  * @param[in] msg_id The message id of the request.
  * @param[in] service_strlen The length of the service string.

--- a/src/lib/middleware/services/config_cbor_map_service.cpp
+++ b/src/lib/middleware/services/config_cbor_map_service.cpp
@@ -83,10 +83,13 @@ static bool config_map_service_handler(size_t service_strlen, const char *servic
             printf("Invalid partition id\n");
         }
         size_t buffer_size;
+        if(config) {
+            cbor_map = config->asCborMap(buffer_size);
+        }
         ConfigCborMapSrvReplyMsg::Data reply = {0, 0, 0, 0, NULL};
         reply.node_id = getNodeId();
         reply.partition_id = req.partition_id;
-        reply.cbor_data = (config) ? config->asCborMap(buffer_size) : NULL;
+        reply.cbor_data = cbor_map;
         reply.cbor_encoded_map_len = (reply.cbor_data) ? buffer_size : 0;
         reply.success = (reply.cbor_data) ? true : false;
         size_t encoded_len;


### PR DESCRIPTION
This PR aggregates all nodes sys-info crc's into the network's crc.
1. Topology sampler samples the nodes.
2. Open a top level cbor array
3. For each node discovered, request the sys info and add it to subarray
4. As you process each sys info, then send a request for the cbor map configuration
5. On receipt of the cbor map configuration, add it to the subarray and then close
6. When all nodes have been added, close the top level cbor array
7. Now compute the CRC32 over the entire encoded 2D cbor network configuration

TODO - we print the cbor array now for debug, but in another PR, send all this to Spotter.

Also clang-format

Testing:

A bridge, and two motes network config

```
83                                      # array(3)
   85                                   # array(5)
      1B C00F1C4D07116874               # unsigned(13839311297089464436)
      6A                                # text(10)
         6272696467652D646267           # "bridge-dbg"
      1A A64F9410                       # unsigned(2790233104)
      1A A89496A1                       # unsigned(2828310177)
      A1                                # map(1)
         78 1C                          # text(28)
            627269646765506F776572436F6E74726F6C6C6572456E61626C6564 # "bridgePowerControllerEnabled"
         00                             # unsigned(0)
   85                                   # array(5)
      1B D158D85954E1F6AD               # unsigned(15085044830065260205)
      6F                                # text(15)
         68656C6C6F5F776F726C642D646267 # "hello_world-dbg"
      1A 1C4B8AEA                       # unsigned(474712810)
      1A 04D44C65                       # unsigned(81022053)
      A0                                # map(0)
   85                                   # array(5)
      1B 2F58E75E9F6554B5               # unsigned(3411731111320310965)
      6F                                # text(15)
         68656C6C6F5F776F726C642D646267 # "hello_world-dbg"
      1A 1C4B8AEA                       # unsigned(474712810)
      1A 04D44C65                       # unsigned(81022053)
      A0                                # map(0)

```

Turns into:

```
[[13839311297089464436, "bridge-dbg", 2790233104, 2828310177, {"bridgePowerControllerEnabled": 0}], [15085044830065260205, "hello_world-dbg", 474712810, 81022053, {}], [3411731111320310965, "hello_world-dbg", 474712810, 81022053, {}]]
```