### PR TITLE
Transmit aggregations config

### DIFF
--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -8,5 +8,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define DEFAULT_TRANSMIT_AGGREGATIONS 1
+
 void aanderaControllerInit(BridgePowerController *power_controller,
-                           cfg::Configuration *usr_cfg);
+                           cfg::Configuration *usr_cfg,
+                           cfg::Configuration *sys_cfg);

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -11,6 +11,7 @@ constexpr const char *SUBSAMPLE_DURATION_MS = "subsampleDurationMs";
 constexpr const char *SUBSAMPLE_ENABLED = "subsampleEnabled";
 constexpr const char *BRIDGE_POWER_CONTROLLER_ENABLED = "bridgePowerControllerEnabled";
 constexpr const char *ALIGNMENT_INTERVAL_5MIN = "alignmentInterval5Min";
+constexpr const char *TRANSMIT_AGGREGATIONS = "transmitAggregations";
 
 } // namespace AppConfig
 

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -366,7 +366,7 @@ static void defaultTask( void *parameters ) {
     debug_ncp_init();
     debugBmServiceInit();
     sys_info_service_init(debug_configuration_system);
-    aanderaControllerInit(&bridge_power_controller, &debug_configuration_user);
+    aanderaControllerInit(&bridge_power_controller, &debug_configuration_user, &debug_configuration_system);
     IOWrite(&ALARM_OUT, 1);
     IOWrite(&LED_BLUE, LED_OFF);
 


### PR DESCRIPTION
Adding a config to the bridge to control when to transmit aggregations.

Testing:
When not set, by default we transmit agg:
<img width="838" alt="Screen Shot 2023-10-27 at 3 04 27 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/6e6754a2-11e5-4163-b609-9739aeaeec07">

When set to 0, we do not transmit agg:
<img width="817" alt="Screen Shot 2023-10-27 at 3 04 14 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/bfcaaaf1-18a7-4503-853b-0784c2c8e468">

When set to 1, we transmit agg:
<img width="822" alt="Screen Shot 2023-10-27 at 3 04 00 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/87e0c786-7411-451b-8012-67dc61d7e223">
