### PR TITLE
Feature/aanderaa app configs

### DIFF
--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -89,7 +89,7 @@ static RTCTimeAndDate_t statsEndRtc =
     {}; // Timestamp that tracks the end of aggregation periods.
 
 // app_main passes a handle to the user config partition in NVM.
-extern cfg::Configuration *userConfigurationPartition;
+extern cfg::Configuration *systemConfigurationPartition;
 
 /*
  * Setup a LineParser to turn the ASCII serial data from the Aanderaa into numbers
@@ -186,16 +186,16 @@ static int createAanderaaDataTopic(void) {
 void setup(void) {
   /* USER ONE-TIME SETUP CODE GOES HERE */
   // Retrieve user-set config values out of NVM.
-  configASSERT(userConfigurationPartition);
-  userConfigurationPartition->getConfig("currentAggPeriodMin", strlen("currentAggPeriodMin"),
+  configASSERT(systemConfigurationPartition);
+  systemConfigurationPartition->getConfig("currentAggPeriodMin", strlen("currentAggPeriodMin"),
                                         current_agg_period_min);
-  userConfigurationPartition->getConfig("nSkipReadings", strlen("nSkipReadings"),
+  systemConfigurationPartition->getConfig("nSkipReadings", strlen("nSkipReadings"),
                                         n_skip_readings);
-  userConfigurationPartition->getConfig("readingIntervalMs", strlen("readingIntervalMs"),
+  systemConfigurationPartition->getConfig("readingIntervalMs", strlen("readingIntervalMs"),
                                         reading_interval_ms);
-  userConfigurationPartition->getConfig("payloadWdToS", strlen("payloadWdToS"),
+  systemConfigurationPartition->getConfig("payloadWdToS", strlen("payloadWdToS"),
                                         payload_wd_to_s);
-  userConfigurationPartition->getConfig("plUartBaudRate", strlen("plUartBaudRate"),
+  systemConfigurationPartition->getConfig("plUartBaudRate", strlen("plUartBaudRate"),
                                         baud_rate);
 
   max_readings_in_agg = (((uint64_t)CURRENT_AGG_PERIOD_MS / reading_interval_ms) + N_SAMPLES_PAD);
@@ -220,8 +220,8 @@ void setup(void) {
   // Enable the input to the Vout power supply and ensure PL buck is disabled.
   IOWrite(&BB_VBUS_EN, 0);
   IOWrite(&BB_PL_BUCK_EN, 1);
-  // ensure Vbus stable before enable Vout with a 1.5s delay.
-  vTaskDelay(pdMS_TO_TICKS(1500));
+  // ensure Aanderaa is off for sufficient time to fully reset.
+  vTaskDelay(pdMS_TO_TICKS(AANDERAA_RESET_TIME_MS));
   // enable Vout, 12V by default.
   IOWrite(&BB_PL_BUCK_EN, 0);
 

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -241,7 +241,8 @@ void loop(void) {
   /// This aggregates BMDK sensor readings into stats, and sends them along to Spotter
   static uint32_t sensorStatsTimer = uptimeGetMs();
   static uint32_t statsStartTick = uptimeGetMs();
-  if ((uint32_t)uptimeGetMs() - sensorStatsTimer >= CURRENT_AGG_PERIOD_MS) {
+  if (CURRENT_AGG_PERIOD_MS > 0 &&
+      (uint32_t)uptimeGetMs() - sensorStatsTimer >= CURRENT_AGG_PERIOD_MS) {
     sensorStatsTimer = uptimeGetMs();
     // create additional buffers for convenience, we won't allocate values arrays.
 #ifdef AANDERAA_BLUE

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -232,6 +232,7 @@ void setup(void) {
   printf("\treading_interval_ms: %u\n", reading_interval_ms);
   printf("\tmax_readings_in_agg: %llu\n", max_readings_in_agg);
   printf("\tpayload_wd_to_s: %u\n", payload_wd_to_s);
+  printf("\tbaud_rate: %u\n", baud_rate);
 
   SensorWatchdog::SensorWatchdogAdd(AANDERAA_WATCHDOG_ID, PAYLOAD_WATCHDOG_TIMEOUT_MS,
                                     aanderaaSensorWatchdogHandler,

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -47,6 +47,11 @@ static uint8_t readings_skipped = 0;
 #define DEFAULT_CURRENT_READING_INTERVAL_MS (60*1000)
 static uint32_t reading_interval_ms = DEFAULT_CURRENT_READING_INTERVAL_MS;
 
+// Baud rate for the Payload UART interface
+// - Currently, must take care to manually set Aanderaa and this setting to the same values.
+#define DEFAULT_BAUD_RATE 9600
+static uint32_t baud_rate = DEFAULT_BAUD_RATE;
+
 // Extra sample padding to account for timing slop. Not currently configurable.
 #define N_SAMPLES_PAD 10
 
@@ -190,6 +195,8 @@ void setup(void) {
                                         reading_interval_ms);
   userConfigurationPartition->getConfig("payloadWdToS", strlen("payloadWdToS"),
                                         payload_wd_to_s);
+  userConfigurationPartition->getConfig("plUartBaudRate", strlen("plUartBaudRate"),
+                                        baud_rate);
 
   max_readings_in_agg = (((uint64_t)CURRENT_AGG_PERIOD_MS / reading_interval_ms) + N_SAMPLES_PAD);
 
@@ -204,12 +211,8 @@ void setup(void) {
   parser.init();
   // Setup the UART – the on-board serial driver that talks to the RS232 transceiver.
   PLUART::init(USER_TASK_PRIORITY);
-  // Baud set per expected baud rate of the sensor.
-#ifdef AANDERAA_BLUE
-  PLUART::setBaud(115200);
-#else
-  PLUART::setBaud(9600);
-#endif
+  // Baud set per configuration.
+  PLUART::setBaud(baud_rate);
   // Set a line termination character per protocol of the sensor.
   PLUART::setTerminationCharacter('\n');
   // Turn on the UART.

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -132,6 +132,7 @@ SerialHandle_t usbPcap = {
 };
 
 cfg::Configuration *userConfigurationPartition = NULL;
+cfg::Configuration *systemConfigurationPartition = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
@@ -369,6 +370,7 @@ static void defaultTask(void *parameters) {
                                        strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
+  systemConfigurationPartition = &debug_configuration_system;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   debugConfigurationInit(&debug_configuration_user,


### PR DESCRIPTION
This PR includes:
- :bug: the rtc value from the on-board aggregation is basically always 0, because the system starts the aggregation before the UTC fix from Spotter comes in. -> use rtc_end
- replace the hardcoded `CURRENT_SAMPLE_PERIOD_MS` with a config named "`CURRENT_READING_INTERVAL_MS`, which defaults to 60s - the intended reading interval for Aanderaa DVT2.
- implement a baud rate configuration
- configify nSkipReadings
- configify readingIntervalMs
- configify payloadWdToS

These changes have been tested in DVT1 systems and are dry-soaking through October 30

sc-194765