### PR TITLE
Feature/sc 194765/aanderaa app configs

### DIFF
--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -241,7 +241,8 @@ void loop(void) {
   /// This aggregates BMDK sensor readings into stats, and sends them along to Spotter
   static uint32_t sensorStatsTimer = uptimeGetMs();
   static uint32_t statsStartTick = uptimeGetMs();
-  if ((uint32_t)uptimeGetMs() - sensorStatsTimer >= CURRENT_AGG_PERIOD_MS) {
+  if (CURRENT_AGG_PERIOD_MS > 0 &&
+      (uint32_t)uptimeGetMs() - sensorStatsTimer >= CURRENT_AGG_PERIOD_MS) {
     sensorStatsTimer = uptimeGetMs();
     // create additional buffers for convenience, we won't allocate values arrays.
 #ifdef AANDERAA_BLUE


### PR DESCRIPTION
This PR includes:

🐛 the rtc value from the on-board aggregation is basically always 0, because the system starts the aggregation before the UTC fix from Spotter comes in. -> use rtc_end
replace the hardcoded CURRENT_SAMPLE_PERIOD_MS with a config named "CURRENT_READING_INTERVAL_MS. Currently this is hard-coded to 2s, but we actually set them up for 1s...
implement a baud rate configuration
configify nSkipReadings
configify readingIntervalMs
configify payloadWdToS