### PR TITLE
Sc 196416/config map service

### DIFF
--- a/src/apps/adin_test/CMakeLists.txt
+++ b/src/apps/adin_test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/bm_network.cpp
 
@@ -82,6 +83,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/adin2111/src/adin2111.c
     ${SRC_DIR}/lib/drivers/adin2111/src/eth_adin2111.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/drivers/pca9535.c
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c

--- a/src/apps/bm_devkit/bm_loadcell/CMakeLists.txt
+++ b/src/apps/bm_devkit/bm_loadcell/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -61,6 +62,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -55,6 +55,7 @@
 #include "debug_bm_service.h"
 #include "echo_service.h"
 #include "sys_info_service.h"
+#include "config_cbor_map_service.h"
 
 /* USER FILE INCLUDES */
 #include "user_code.h"
@@ -399,7 +400,8 @@ static void defaultTask(void *parameters) {
   bm_sub(APP_PUB_SUB_UTC_TOPIC, handle_bm_subscriptions);
   echo_service_init();
   sys_info_service_init(debug_configuration_system);
-
+  config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
+                               debug_configuration_user);
 #ifdef USE_MICROPYTHON
   micropython_freertos_init(&usbCLI);
 #endif

--- a/src/apps/bm_devkit/devkit_monitor/CMakeLists.txt
+++ b/src/apps/bm_devkit/devkit_monitor/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bm_devkit/hello_world/CMakeLists.txt
+++ b/src/apps/bm_devkit/hello_world/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bm_devkit/nortek/CMakeLists.txt
+++ b/src/apps/bm_devkit/nortek/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -61,6 +62,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/aanderaa_data_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c

--- a/src/apps/bm_devkit/rbr_coda_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/rbr_coda_example/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -63,6 +64,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -26,6 +26,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
 
     ${BCMP_FILES}
@@ -67,6 +68,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/aanderaa_data_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -60,6 +60,7 @@
 #include "debug_bm_service.h"
 #include "sys_info_service.h"
 #include "aanderaaController.h"
+#include "config_cbor_map_service.h"
 #ifdef USE_MICROPYTHON
 #include "micropython_freertos.h"
 #endif
@@ -367,6 +368,8 @@ static void defaultTask( void *parameters ) {
     debugBmServiceInit();
     sys_info_service_init(debug_configuration_system);
     aanderaControllerInit(&bridge_power_controller, &debug_configuration_user, &debug_configuration_system);
+    config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
+                               debug_configuration_user);
     IOWrite(&ALARM_OUT, 1);
     IOWrite(&LED_BLUE, LED_OFF);
 

--- a/src/apps/bringup_bridge/CMakeLists.txt
+++ b/src/apps/bringup_bridge/CMakeLists.txt
@@ -52,6 +52,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_adin_raw.c
@@ -92,6 +94,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/bm_serial/bm_serial.c
     ${SRC_DIR}/lib/middleware/middleware.cpp

--- a/src/apps/bringup_mote/CMakeLists.txt
+++ b/src/apps/bringup_mote/CMakeLists.txt
@@ -21,6 +21,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -58,6 +59,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/nvmPartition.cpp
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp

--- a/src/apps/bristleback_apps/aanderaa/CMakeLists.txt
+++ b/src/apps/bristleback_apps/aanderaa/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -63,6 +64,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/aanderaa_data_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -55,7 +55,7 @@
 #include "debug_bm_service.h"
 #include "sys_info_service.h"
 #include "sensorWatchdog.h"
-
+#include "config_cbor_map_service.h"
 /* USER FILE INCLUDES */
 #include "user_code.h"
 /* USER FILE INCLUDES END */
@@ -388,6 +388,8 @@ static void defaultTask(void *parameters) {
   sensorsInit();
   debugBmServiceInit();
   sys_info_service_init(debug_configuration_system);
+  config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
+                               debug_configuration_user);
   SensorWatchdog::SensorWatchdogInit();
   bm_sub(APP_PUB_SUB_UTC_TOPIC, handle_bm_subscriptions);
 

--- a/src/apps/bristleback_apps/loadcell/CMakeLists.txt
+++ b/src/apps/bristleback_apps/loadcell/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bristleback_apps/nortek/CMakeLists.txt
+++ b/src/apps/bristleback_apps/nortek/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bristleback_apps/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bristleback_apps/serial_payload_example/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -62,6 +63,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/mote_bristlefin/CMakeLists.txt
+++ b/src/apps/mote_bristlefin/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BRISTLEMOUTH_FILES
     ${SRC_DIR}/lib/middleware/bm_service.cpp
     ${SRC_DIR}/lib/middleware/services/echo_service.cpp
     ${SRC_DIR}/lib/middleware/services/sys_info_service.cpp
+    ${SRC_DIR}/lib/middleware/services/config_cbor_map_service.cpp
     ${SRC_DIR}/lib/middleware/bm_service_request.cpp
     ${SRC_DIR}/lib/middleware/middleware.cpp
 
@@ -60,6 +61,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -55,6 +55,7 @@
 #include "watchdog.h"
 #include "debug_bm_service.h"
 #include "sys_info_service.h"
+#include "config_cbor_map_service.h"
 
 #ifdef USE_MICROPYTHON
 #include "micropython_freertos.h"
@@ -368,7 +369,8 @@ static void defaultTask(void *parameters) {
   sensorsInit();
   debugBmServiceInit();
   sys_info_service_init(debug_configuration_system);
-
+  config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
+                               debug_configuration_user);
   bm_sub(APP_PUB_SUB_BUTTON_TOPIC, handle_subscriptions);
   bm_sub(APP_PUB_SUB_UTC_TOPIC, handle_subscriptions);
 

--- a/src/lib/debug/debug_bm_service.cpp
+++ b/src/lib/debug/debug_bm_service.cpp
@@ -106,7 +106,7 @@ static bool config_map_callback(bool ack, uint32_t msg_id, size_t service_strlen
             break;
           }
           printf("%02x ", reply.cbor_data[i]);
-          if(i%16 == 15) {
+          if(i%16 == 15) { // print a newline every 16 bytes (for print pretty-ness)
             printf("\n");
           }
         }

--- a/src/lib/debug/debug_bm_service.cpp
+++ b/src/lib/debug/debug_bm_service.cpp
@@ -13,6 +13,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sys_info_svc_reply_msg.h"
+#include "config_cbor_map_service.h"
+#include "config_cbor_map_srv_reply_msg.h"
+#include "config_cbor_map_srv_request_msg.h"
 
 static BaseType_t bmServiceCmd(char *writeBuffer, size_t writeBufferLen,
                                const char *commandString);
@@ -23,7 +26,8 @@ static const CLI_Command_Definition_t cmdBmService = {
     // Help string
     "bmsrv:\n"
     " * bmsrv req <service> <data> <timeout s>\n"
-    " * bmsrv req sysinfo <node id> <timeout s>\n",
+    " * bmsrv req sysinfo <node id> <timeout s>\n"
+    " * bmsrv req cfgmap <node id> <1(hw)/2(sys)/3(usr)> <timeout s>\n",
     // Command function
     bmServiceCmd,
     // Number of parameters (variable)
@@ -78,6 +82,47 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen, 
   return rval;
 }
 
+static bool config_map_callback(bool ack, uint32_t msg_id, size_t service_strlen, const char *service,
+                         size_t reply_len, uint8_t *reply_data) {
+  bool rval = false;
+  printf("Msg id: %" PRIu32 "\n", msg_id);
+  ConfigCborMapSrvReplyMsg::Data reply = {0, 0, 0, 0, NULL};
+  do {
+    if (ack) {
+      if(ConfigCborMapSrvReplyMsg::decode(reply, reply_data, reply_len) != CborNoError) {
+        printf("Failed to decode sys info reply\n");
+        break;
+      }
+      printf("Service: %.*s\n", service_strlen, service);
+      printf("Reply: \n");
+      printf(" * Node id: %" PRIx64 "\n", reply.node_id);
+      printf(" * Partition: %" PRIu32 "\n", reply.partition_id);
+      printf(" * Success: %d\n", reply.success);
+      printf(" * CBOR encoded map len: %" PRIu32 "\n", reply.cbor_encoded_map_len);
+      if(reply.success) {
+        for(uint32_t i = 0; i<reply.cbor_encoded_map_len; i++) {
+          if(!reply.cbor_data) {
+            printf("NULL map\n");
+            break;
+          }
+          printf("%02x ", reply.cbor_data[i]);
+          if(i%16 == 15) {
+            printf("\n");
+          }
+        }
+      }
+      printf("\n");
+    } else {
+      printf("NACK\n");
+    }
+    rval = true;
+  } while(0);
+  if(reply.cbor_data) {
+    vPortFree(reply.cbor_data);
+  }
+  return rval;
+}
+
 static BaseType_t bmServiceCmd(char *writeBuffer, size_t writeBufferLen,
                                const char *commandString) {
   // Remove unused argument warnings
@@ -126,6 +171,43 @@ static BaseType_t bmServiceCmd(char *writeBuffer, size_t writeBufferLen,
         }
         uint32_t timeout_s = strtoul(timeoutStr, NULL, 10);
         if (sys_info_service_request(nodeId, sys_info_reply_cb, timeout_s)) {
+          printf("OK\n");
+        } else {
+          printf("ERR\n");
+        }
+        break;
+      }  else if (strncmp("cfgmap", serviceStr, serviceStrLen) == 0) {
+        BaseType_t nodeStrLen;
+        const char *nodeStr = FreeRTOS_CLIGetParameter(commandString,
+                                                       3, // Get the third parameter (node id)
+                                                       &nodeStrLen);
+        if (nodeStr == NULL) {
+          printf("ERR Invalid paramters\n");
+          break;
+        }
+        uint64_t nodeId = strtoull(nodeStr, NULL, 16);
+
+        BaseType_t partitionStrLen;
+        const char *partitionStr = FreeRTOS_CLIGetParameter(commandString,
+                                                       4, // Get the third parameter (node id)
+                                                       &partitionStrLen);
+        if (partitionStr == NULL) {
+          printf("ERR Invalid paramters\n");
+          break;
+        }
+        uint32_t partitionId = strtoul(partitionStr, NULL, 10);
+
+        BaseType_t timeoutStrLen;
+        const char *timeoutStr =
+            FreeRTOS_CLIGetParameter(commandString,
+                                     5, // Get the fourth parameter (timeout)
+                                     &timeoutStrLen);
+        if (timeoutStr == NULL) {
+          printf("ERR Invalid paramters\n");
+          break;
+        }
+        uint32_t timeout_s = strtoul(timeoutStr, NULL, 10);
+        if (config_cbor_map_service_request(nodeId, partitionId, config_map_callback, timeout_s)) {
           printf("OK\n");
         } else {
           printf("ERR\n");

--- a/src/lib/middleware/services/config_cbor_map_service.cpp
+++ b/src/lib/middleware/services/config_cbor_map_service.cpp
@@ -1,0 +1,104 @@
+#include "config_cbor_map_service.h"
+#include "FreeRTOS.h"
+#include "bm_service.h"
+#include "bm_service_common.h"
+#include "config_cbor_map_srv_reply_msg.h"
+#include "config_cbor_map_srv_request_msg.h"
+#include "device_info.h"
+
+#define CONFIG_MAP_SUFFIX "/config_map"
+
+cfg::Configuration* _sys_config;
+cfg::Configuration* _hw_config;
+cfg::Configuration* _usr_config;
+
+static bool config_map_service_handler(size_t service_strlen, const char *service,
+                                   size_t req_data_len, uint8_t *req_data, size_t &buffer_len,
+                                   uint8_t *reply_data);
+
+void config_cbor_map_service_init(cfg::Configuration& hw_cfg, cfg::Configuration& sys_config, cfg::Configuration& user_config) {
+  _sys_config = &sys_config;
+  _hw_config = &hw_cfg;
+  _usr_config = &user_config;
+  static char config_map_str[BM_SERVICE_MAX_SERVICE_STRLEN];
+  size_t topic_strlen = snprintf(config_map_str, sizeof(config_map_str),
+                                 "%" PRIx64 "%s", getNodeId(), CONFIG_MAP_SUFFIX);
+  if (topic_strlen > 0) {
+    bm_service_register(topic_strlen, config_map_str, config_map_service_handler);
+  } else {
+    printf("Failed to register sys info service\n");
+  }
+}
+
+bool config_cbor_map_service_request(uint64_t target_node_id, uint32_t partition_id, bm_service_reply_cb reply_cb, uint32_t timeout_s) { 
+  bool rval = false;
+  char *target_service_str = static_cast<char *>(pvPortMalloc(BM_SERVICE_MAX_SERVICE_STRLEN));
+  configASSERT(target_service_str);
+  size_t target_service_strlen =
+      snprintf(target_service_str, BM_SERVICE_MAX_SERVICE_STRLEN, "%" PRIx64 "%s",
+               target_node_id, CONFIG_MAP_SUFFIX);
+  ConfigCborMapSrvRequestMsg::Data req = {partition_id};
+  static constexpr size_t cbor_buflen = sizeof(ConfigCborMapSrvRequestMsg::Data) + 25; // Abitrary padding.
+  uint8_t * cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(cbor_buflen));
+  configASSERT(cbor_buffer);
+  size_t req_data_len;
+  do {
+    if(ConfigCborMapSrvRequestMsg::encode(req, cbor_buffer, cbor_buflen, &req_data_len) != CborNoError) {
+        printf("Failed to encode config map request\n");
+        break;
+    }
+    if (target_service_strlen > 0) {
+        rval = bm_service_request(target_service_strlen, target_service_str, req_data_len, cbor_buffer, reply_cb,
+                                timeout_s);
+    }
+  } while(0);
+  vPortFree(cbor_buffer);
+  vPortFree(target_service_str);
+  return rval;
+}
+
+static bool config_map_service_handler(size_t service_strlen, const char *service,
+                                   size_t req_data_len, uint8_t *req_data, size_t &buffer_len,
+                                   uint8_t *reply_data) {
+    (void) service_strlen;
+    (void) service;
+    bool rval = false;
+    uint8_t * cbor_map = NULL;
+    printf("Data received on config map service\n");
+    do {
+        ConfigCborMapSrvRequestMsg::Data req;
+        if(ConfigCborMapSrvRequestMsg::decode(req, req_data, req_data_len) != CborNoError) {
+            printf("Failed to decode config map request\n");
+            break;
+        }
+        cfg::Configuration* config = NULL;
+        if(req.partition_id == CONFIG_CBOR_MAP_PARTITION_ID_SYS){
+            config = _sys_config;
+        } else if(req.partition_id == CONFIG_CBOR_MAP_PARTITION_ID_HW) {
+            config = _hw_config;
+        } else if(req.partition_id == CONFIG_CBOR_MAP_PARTITION_ID_USER) {
+            config = _usr_config;
+        } else {
+            config = NULL;
+            printf("Invalid partition id\n");
+        }
+        size_t buffer_size;
+        ConfigCborMapSrvReplyMsg::Data reply = {0, 0, 0, 0, NULL};
+        reply.node_id = getNodeId();
+        reply.partition_id = req.partition_id;
+        reply.cbor_data = (config) ? config->asCborMap(buffer_size) : NULL;
+        reply.cbor_encoded_map_len = (reply.cbor_data) ? buffer_size : 0;
+        reply.success = (reply.cbor_data) ? true : false;
+        size_t encoded_len;
+        if(ConfigCborMapSrvReplyMsg::encode(reply, reply_data, buffer_len, &encoded_len)!= CborNoError) {
+            printf("Failed to encode config map reply\n");
+            break;
+        }
+        buffer_len = encoded_len;
+        rval = true;
+    } while(0);
+    if(cbor_map){
+        vPortFree(cbor_map);
+    }
+    return rval;
+}

--- a/src/lib/middleware/services/config_cbor_map_service.h
+++ b/src/lib/middleware/services/config_cbor_map_service.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "bm_service_request.h"
+#include "configuration.h"
+
+constexpr uint32_t CONFIG_CBOR_MAP_PARTITION_ID_SYS = 1;
+constexpr uint32_t CONFIG_CBOR_MAP_PARTITION_ID_HW = 2;
+constexpr uint32_t CONFIG_CBOR_MAP_PARTITION_ID_USER = 3;
+
+void config_cbor_map_service_init(cfg::Configuration& hw_cfg, cfg::Configuration& sys_config, cfg::Configuration& user_config);
+bool config_cbor_map_service_request(uint64_t target_node_id, uint32_t partition_id, bm_service_reply_cb reply_cb, uint32_t timeout_s);


### PR DESCRIPTION
Adding a cbor config map service 

Note that right now, our config system will return a stringz decoded key:
```{"hello unint 1" : 1}```  vs ```{"hello":1}```
This will be handled in an upcoming PR since it's unrelated to the changes in this PR.  