### PR TITLE
use partition crc32

### DIFF
--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -79,7 +79,7 @@ static void topology_sample_cb(networkTopology_t* networkTopology) {
 
     bm_common_config_crc_t config_crc = {
       .partition = BM_COMMON_CFG_PARTITION_SYSTEM,
-      .crc32 = _sys_cfg->getCRC32(),
+      .crc32 = _sys_cfg->getCborEncodedConfigurationCrc32(),
     };
 
     network_crc32_calc = crc32_ieee_update(network_crc32_calc, reinterpret_cast<uint8_t *>(&config_crc), sizeof(bm_common_config_crc_t));

--- a/src/lib/middleware/services/sys_info_service.cpp
+++ b/src/lib/middleware/services/sys_info_service.cpp
@@ -77,7 +77,7 @@ static bool sys_info_service_handler(size_t service_strlen, const char *service,
     d.app_name_strlen = strlen(APP_NAME);
     d.git_sha = getGitSHA();
     d.node_id = getNodeId();
-    d.sys_config_crc = _sys_config->getCRC32();
+    d.sys_config_crc = _sys_config->getCborEncodedConfigurationCrc32();
     size_t encoded_len;
     // Will return CborErrorOutOfMemory if buffer_len is too small
     if(SysInfoSvcReplyMsg::encode(d, reply_data, buffer_len, &encoded_len) != CborNoError) {

--- a/src/lib/sys/configuration.h
+++ b/src/lib/sys/configuration.h
@@ -63,7 +63,7 @@ public:
     bool getValueSize(const char * key, size_t key_len, size_t &size);
     bool needsCommit(void);
     static bool cborTypeToConfigType(const CborValue *value, ConfigDataTypes_e &configType);
-    uint32_t getCRC32(void);
+    uint32_t getCborEncodedConfigurationCrc32(void);
 private:
     bool findKeyIndex(const char * key, size_t len, uint8_t &idx);
     bool prepareCborParser(const char * key, size_t key_len, CborValue &it, CborParser &parser);


### PR DESCRIPTION
This PR does two things (which are coupled):
1. Splits the partition validation CRC from the Cbor Configuration CRC (so the partition metadata is protected)
2. Changs `asCborMap` to use string with length rather than stringz. 
So we now get 
```{"hello": 1}```
instead of
```{"hello uint 1": 1}```

