### PR TITLE
Sc 196635 - refactor aanderaaController.cpp to use one timer for all aggregations

### DIFF
--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -219,11 +219,12 @@ static void runController(void *param) {
                               "%.3f,"        // direction_circ_mean_rad
                               "%.3f,"        // direction_circ_std_rad
                               "%.3f\n",      // temp_mean_deg_c
-                              node_id, aanderaa->abs_speed_cm_s.getMean(true),
-                              aanderaa->abs_speed_cm_s.getStd(true),
-                              aanderaa->direction_rad.getCircularMean(),
-                              aanderaa->direction_rad.getCircularStd(),
-                              aanderaa->temp_deg_c.getMean(true));
+                              curr->node_id,
+                              curr->abs_speed_cm_s.getMean(true),
+                              curr->abs_speed_cm_s.getStd(true),
+                              curr->direction_rad.getCircularMean(),
+                              curr->direction_rad.getCircularStd(),
+                              curr->temp_deg_c.getMean(true));
             if (log_buflen > 0) {
               BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_AGG, log_buf, log_buflen);
             } else {
@@ -233,9 +234,9 @@ static void runController(void *param) {
             // combine all the data from all the sensors and send it to the spotter
             memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
             // Clear the buffers
-            aanderaa->abs_speed_cm_s.clear();
-            aanderaa->direction_rad.clear();
-            aanderaa->temp_deg_c.clear();
+            curr->abs_speed_cm_s.clear();
+            curr->direction_rad.clear();
+            curr->temp_deg_c.clear();
             xSemaphoreGive(curr->_mutex);
           }
           curr = curr->next;

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -214,11 +214,12 @@ static void runController(void *param) {
       }
     }
     if (task_notify_bits & AGGREGATION_TIMER_BITS) {
+      printf("Aggregation period done!\n");
       if (_ctx._subbed_aanderaas != NULL) {
         Aanderaa_t *curr = _ctx._subbed_aanderaas;
         char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
         configASSERT(log_buf);
-        while (curr->next != NULL) {
+        while (curr != NULL) {
           if (xSemaphoreTake(curr->_mutex, portMAX_DELAY)) {
             size_t log_buflen = 0;
             aanderaa_aggregations_t agg = {.node_id = 0,
@@ -276,6 +277,8 @@ static void runController(void *param) {
           curr = curr->next;
         }
         vPortFree(log_buf);
+      } else {
+        printf("No Aanderaa nodes to aggregate\n");
       }
     }
   }

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -16,15 +16,6 @@
 // TODO - make this a configurable value?
 #define MIN_READINGS_FOR_AGGREGATION 3
 
-typedef struct aanderaa_aggregations_s {
-  uint64_t node_id;
-  double abs_speed_mean_cm_s;
-  double abs_speed_std_cm_s;
-  double direction_circ_mean_rad;
-  double direction_circ_std_rad;
-  double temp_mean_deg_c;
-} aanderaa_aggregations_t;
-
 typedef enum {
   SAMPLER_TIMER_BITS = 0x01,
   AGGREGATION_TIMER_BITS = 0x02,

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -6,11 +6,17 @@
 #include "bm_pubsub.h"
 #include "bridgeLog.h"
 #include "device_info.h"
+#include "semphr.h"
 #include "sys_info_service.h"
 #include "sys_info_svc_reply_msg.h"
 #include "task_priorities.h"
 #include "util.h"
 #include <new>
+
+typedef enum {
+  SAMPLER_TIMER_BITS = 0x01,
+  AGGREGATION_TIMER_BITS = 0x02,
+} aanderaaControllerBits_t;
 
 typedef struct Aanderaa {
   uint64_t node_id;
@@ -23,6 +29,8 @@ typedef struct Aanderaa {
 
   static constexpr uint32_t N_SAMPLES_PAD =
       10; // Extra sample padding to account for timing slop.
+
+  SemaphoreHandle_t _mutex;
 
 public:
   bool subscribe();
@@ -43,9 +51,9 @@ typedef struct aanderaaControllerCtx {
   uint64_t _node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
   bool _initialized;
   TimerHandle_t _sample_timer;
+  TimerHandle_t _aggregations_timer;
   BridgePowerController *_bridge_power_controller;
   cfg::Configuration *_usr_cfg;
-  uint32_t _transmit_aggregations;
 } aanderaaControllerCtx_t;
 
 static aanderaaControllerCtx_t _ctx;
@@ -60,6 +68,7 @@ static void createAanderaaSub(uint64_t node_id);
 static void runController(void *param);
 static Aanderaa_t *findAanderaaById(uint64_t node_id);
 static void sampleTimerCallback(TimerHandle_t timer);
+static void aggregationTimerCallback(TimerHandle_t timer);
 static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
                                const char *service, size_t reply_len, uint8_t *reply_data);
 
@@ -162,10 +171,18 @@ void aanderaControllerInit(BridgePowerController *power_controller,
   configASSERT(sys_cfg);
   _ctx._bridge_power_controller = power_controller;
   _ctx._usr_cfg = usr_cfg;
-  _ctx._transmit_aggregations = DEFAULT_TRANSMIT_AGGREGATIONS;
-  sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS,
-                   strlen(AppConfig::TRANSMIT_AGGREGATIONS),
-                   _ctx._transmit_aggregations);
+
+  uint32_t agg_period_ms = (DEFAULT_CURRENT_AGG_PERIOD_MIN * 60 * 1000);
+  uint32_t agg_period_min;
+  if (_ctx._usr_cfg->getConfig("currentAggPeriodMin", strlen("currentAggPeriodMin"),
+                               agg_period_min)) {
+    agg_period_ms = (agg_period_min * 60 * 1000);
+  }
+  _ctx._aggregations_timer = xTimerCreate("AanderaaAggTim", pdMS_TO_TICKS(agg_period_ms), pdTRUE,
+                                          NULL, aggregationTimerCallback);
+  configASSERT(_ctx._aggregations_timer);
+  configASSERT(xTimerStart(_ctx._aggregations_timer, 10) == pdTRUE);
+
   BaseType_t rval = xTaskCreate(runController, "Aandera Controller", 128 * 4, NULL,
                                 AANDERAA_CONTROLLER_TASK_PRIORITY, &_ctx._task_handle);
   configASSERT(rval == pdTRUE);
@@ -173,11 +190,17 @@ void aanderaControllerInit(BridgePowerController *power_controller,
 
 static void sampleTimerCallback(TimerHandle_t timer) {
   (void)timer;
-  xTaskNotifyGive(_ctx._task_handle);
+  xTaskNotify(_ctx._task_handle, SAMPLER_TIMER_BITS, eSetBits);
+}
+
+static void aggregationTimerCallback(TimerHandle_t timer) {
+  (void)timer;
+  xTaskNotify(_ctx._task_handle, AGGREGATION_TIMER_BITS, eSetBits);
 }
 
 static void runController(void *param) {
   (void)param;
+  uint32_t task_notify_bits;
   if (_ctx._initialized) {
     configASSERT(false); // Should only be initialized once
   }
@@ -189,22 +212,68 @@ static void runController(void *param) {
   configASSERT(xTimerStart(_ctx._sample_timer, 10) == pdTRUE);
   _ctx._initialized = true;
   while (true) {
-    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    if (_ctx._bridge_power_controller->waitForSignal(true, pdMS_TO_TICKS(TOPO_TIMEOUT_MS))) {
-      size_t size_list = sizeof(_ctx._node_list);
-      printf("Sampling for Aanderaa Nodes\n");
-      uint32_t num_nodes = 0;
-      if (topology_sampler_get_node_list(_ctx._node_list, size_list, num_nodes,
-                                         TOPO_TIMEOUT_MS)) {
-        for (size_t i = 0; i < num_nodes; i++) {
-          if (_ctx._node_list[i] != getNodeId()) {
-            if (!sys_info_service_request(_ctx._node_list[i], node_info_reply_cb,
-                                          NODE_INFO_TIMEOUT_MS)) {
-              printf("Failed to send sys_info request to node %" PRIx64 "\n",
-                     _ctx._node_list[i]);
+    // wait for a notification from one of the timers, clear all the bits on exit
+    xTaskNotifyWait(pdFALSE, UINT32_MAX, &task_notify_bits, portMAX_DELAY);
+    if (task_notify_bits & SAMPLER_TIMER_BITS) {
+      if (_ctx._bridge_power_controller->waitForSignal(true, pdMS_TO_TICKS(TOPO_TIMEOUT_MS))) {
+        size_t size_list = sizeof(_ctx._node_list);
+        printf("Sampling for Aanderaa Nodes\n");
+        uint32_t num_nodes = 0;
+        if (topology_sampler_get_node_list(_ctx._node_list, size_list, num_nodes,
+                                          TOPO_TIMEOUT_MS)) {
+          for (size_t i = 0; i < num_nodes; i++) {
+            if (_ctx._node_list[i] != getNodeId()) {
+              if (!sys_info_service_request(_ctx._node_list[i], node_info_reply_cb,
+                                            NODE_INFO_TIMEOUT_MS)) {
+                printf("Failed to send sys_info request to node %" PRIx64 "\n",
+                      _ctx._node_list[i]);
+              }
             }
           }
         }
+      }
+    }
+    if (task_notify_bits & AGGREGATION_TIMER_BITS) {
+      if (_ctx._subbed_aanderaas != NULL) {
+        Aanderaa_t *curr = _ctx._subbed_aanderaas;
+        char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
+        configASSERT(log_buf);
+        while (curr->next != NULL) {
+          if (xSemaphoreTake(curr->_mutex, portMAX_DELAY)) {
+            size_t log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                                "%" PRIx64 "," // Node Id
+                                "%.3f,"        // abs_speed_mean_cm_s
+                                "%.3f,"        // abs_speed_std_cm_s
+                                "%.3f,"        // direction_circ_mean_rad
+                                "%.3f,"        // direction_circ_std_rad
+                                "%.3f\n",      // temp_mean_deg_c
+                                node_id, aanderaa->abs_speed_mean_cm_s.getMean(),
+                                aanderaa->abs_speed_std_cm_s.getStd(),
+                                aanderaa->direction_circ_mean_rad.getCircularMean(),
+                                aanderaa->direction_circ_std_rad.getCircularStd(),
+                                aanderaa->temp_mean_deg_c.getMean());
+            if (log_buflen > 0) {
+              BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_AGG, log_buf, log_buflen);
+            } else {
+              printf("ERROR: Failed to print Aanderaa data\n");
+            }
+
+            // TODO - send data to a "report builder" task that will
+            // combine all the data from all the sensors and send it to the spotter
+
+            memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
+            // Clear the buffer
+            aanderaa->abs_speed_mean_cm_s.clear();
+            aanderaa->abs_speed_std_cm_s.clear();
+            aanderaa->direction_circ_mean_rad.clear();
+            aanderaa->direction_circ_std_rad.clear();
+            aanderaa->temp_mean_deg_c.clear();
+            xSemaphoreGive(curr->_mutex);
+
+          }
+          curr = curr->next;
+        }
+        vPortFree(log_buf);
       }
     }
   }
@@ -214,10 +283,13 @@ static void createAanderaaSub(uint64_t node_id) {
   Aanderaa_t *new_sub = static_cast<Aanderaa_t *>(pvPortMalloc(sizeof(Aanderaa_t)));
   new_sub = new (new_sub) Aanderaa_t();
   configASSERT(new_sub);
+
+  new_sub->_mutex = xSemaphoreCreateMutex();
+  configASSERT(new_sub->_mutex);
+
   new_sub->node_id = node_id;
   new_sub->next = NULL;
   new_sub->current_agg_period_ms = (DEFAULT_CURRENT_AGG_PERIOD_MIN * 60 * 1000);
-  new_sub->sample_start_time_ms = pdTICKS_TO_MS(xTaskGetTickCount());
   uint32_t agg_period_min;
   if (_ctx._usr_cfg->getConfig("currentAggPeriodMin", strlen("currentAggPeriodMin"),
                                agg_period_min)) {

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #define DEFAULT_TRANSMIT_AGGREGATIONS 1
+#define DEFAULT_SAMPLES_PER_REPORT 2
 
 void aanderaControllerInit(BridgePowerController *power_controller,
                            cfg::Configuration *usr_cfg,

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 
 #define DEFAULT_TRANSMIT_AGGREGATIONS 1
-#define DEFAULT_SAMPLES_PER_REPORT 2
 
 void aanderaControllerInit(BridgePowerController *power_controller,
                            cfg::Configuration *usr_cfg,

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -10,6 +10,15 @@
 
 #define DEFAULT_TRANSMIT_AGGREGATIONS 1
 
+typedef struct aanderaa_aggregations_s {
+  uint64_t node_id;
+  double abs_speed_mean_cm_s;
+  double abs_speed_std_cm_s;
+  double direction_circ_mean_rad;
+  double direction_circ_std_rad;
+  double temp_mean_deg_c;
+} aanderaa_aggregations_t;
+
 void aanderaControllerInit(BridgePowerController *power_controller,
                            cfg::Configuration *usr_cfg,
                            cfg::Configuration *sys_cfg);

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -12,6 +12,7 @@ constexpr const char *SUBSAMPLE_ENABLED = "subsampleEnabled";
 constexpr const char *BRIDGE_POWER_CONTROLLER_ENABLED = "bridgePowerControllerEnabled";
 constexpr const char *ALIGNMENT_INTERVAL_5MIN = "alignmentInterval5Min";
 constexpr const char *TRANSMIT_AGGREGATIONS = "transmitAggregations";
+constexpr const char *SAMPLES_PER_REPORT = "samplesPerReport";
 
 } // namespace AppConfig
 

--- a/src/lib/middleware/bm_network.cpp
+++ b/src/lib/middleware/bm_network.cpp
@@ -19,7 +19,7 @@ static constexpr uint8_t networkTopicType = 1;
 bool spotter_tx_data(const void* data, uint16_t data_len, bm_serial_network_type_e type) {
     bool rval = false;
     size_t msg_len = sizeof(bm_serial_network_data_header_t) + data_len;
-    uint8_t * data_buf = reinterpret_cast<uint8_t*>(pvPortMalloc(msg_len));
+    uint8_t * data_buf = static_cast<uint8_t*>(pvPortMalloc(msg_len));
     configASSERT(data_buf);
     bm_serial_network_data_header_t * header = reinterpret_cast<bm_serial_network_data_header_t *>(data_buf);
     header->type = type;


### PR DESCRIPTION
Refactored aanderaaController.cpp to use one timer to mark the end of an aggregation period for all of the aanderaa's instead of one timer **per** aanderaa. 

This entailed creating a new software timer that will fire every `currentAggPeriodMin`. Originally I was going to process the aggregated readings in this timers callback, but realizzed this may involve blocking code(a big no-no in timer callbacks). Instead I modified the existing task notifications to use bits, such that the timer callback will set a bit when it is time to end the aggregation. Now the aandderaa controller task will be notified when the aggregation period is complete and it will do the computations on the buffers, send them to the "report builder" task (just a todo comment now), and then clear the buffers. 

Since the buffers get new readings added to their buffers in the middleware when receive a message we subscribed to, I added a mutex lock so that we can safely access the buffers from the aanderaa controller app to calculate the mean/stdev + clear them for the next aggregation period.

I also added a small check to the buffers to make sure they have a minimum amount of readings within them and if not we will send NAN for the means/stdevs. This will guarantee that the "report builder" will get a struct for every aanderaa, even if the aanderaa node stops working part way through a sample, or between samples.