### PR TITLE
Sc 196701/cbor sensor encoder

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -249,6 +249,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgePowerController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/aanderaaController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cbor_sensor_report_encoder.cpp
     ${MCUBOOT_FILES}
     ${FREERTOS_FILES}
     ${LIB_FILES}

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -33,6 +33,10 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION     1
 
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC       "bridge/sensor_report"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION     1
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -33,6 +33,12 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION     1
 
+typedef struct app_pub_sub_bm_bridge_sensor_report_data {
+    uint32_t bm_config_crc32;
+    size_t cbor_buffer_len;
+    uint8_t cbor_buffer[0];
+} __attribute__((packed)) app_pub_sub_bm_bridge_sensor_report_data_t;
+
 #define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC       "bridge/sensor_report"
 #define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION     1

--- a/src/apps/bridge/cbor_sensor_report_encoder.cpp
+++ b/src/apps/bridge/cbor_sensor_report_encoder.cpp
@@ -1,0 +1,89 @@
+#include "cbor_sensor_report_encoder.h"
+
+/*!
+ * @brief Open a sensor report for encoding. Must be called before any other encoding functions.
+ * @param[in] cbor_buffer The buffer to encode into.
+ * @param[in] cbor_buffer_len The length of the buffer.
+ * @param[in] num_sensors The number of sensors in the report.
+ * @param[in] context The context to use for the entire encoding.
+ * This context should not persist in between building reports.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_open_report(uint8_t *cbor_buffer, size_t cbor_buffer_len,
+                                            uint8_t num_sensors,
+                                            sensor_report_encoder_context_t &context) {
+  context.buffer = cbor_buffer;
+  cbor_encoder_init(&context.encoder, context.buffer, cbor_buffer_len, 0);
+  return cbor_encoder_create_array(&context.encoder, &context.report_array, num_sensors);
+}
+
+/*!
+ * @brief Close a sensor report for encoding. Must be called when done building report.
+ * @param[in] context The encoding context.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_close_report(sensor_report_encoder_context_t &context) {
+  return cbor_encoder_close_container(&context.encoder, &context.report_array);
+}
+
+/*!
+ * @brief Open a sensor array for encoding.
+ * @param[in] context The encoding context.
+ * @param[in] num_sensors The number of samples in the sensor.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_open_sensor(sensor_report_encoder_context_t &context,
+                                            size_t num_sensors) {
+  return cbor_encoder_create_array(&context.report_array, &context.sensor_array, num_sensors);
+}
+
+/*!
+ * @brief Close a sensor array for encoding. Must be called when all samples for a sensor have been added.
+ * @param[in] context The encoding context.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &context) {
+  return cbor_encoder_close_container(&context.report_array, &context.sensor_array);
+}
+
+/*!
+ * @brief Open a sample array for encoding.
+ * @param[in] context The encoding context.
+ * @param[in] num_samples The number of samples in the sensor.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
+                                            size_t num_samples) {
+  return cbor_encoder_create_array(&context.sensor_array, &context.sample_array, num_samples);
+}
+
+/*!
+ * @brief Add a sample to the sample array.
+ * @param[in] context The encoding context.
+ * @param[in] sample_encoder_cb The callback to encode the sample data.
+ * @param[in] sensor_data The sensor data to encode.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_add_sample(sensor_report_encoder_context_t &context,
+                                           sample_encoder_cb sample_encoder_cb,
+                                           void *sensor_data) {
+  return sample_encoder_cb(context.sample_array, sensor_data);
+}
+
+/*!
+ * @brief Close a sample array for encoding. Must be called when all samples have been added.
+ * @param[in] context The encoding context.
+ * @return Cbor error code.
+ */
+CborError sensor_report_encoder_close_sample(sensor_report_encoder_context_t &context) {
+  return cbor_encoder_close_container(&context.sensor_array, &context.sample_array);
+}
+
+/*!
+ * @brief Get the size of the encoded report.
+ * @param[in] context The encoding context.
+ * @return The size of the encoded report.
+ */
+size_t sensor_report_encoder_get_report_size_bytes(sensor_report_encoder_context_t &context) {
+  return cbor_encoder_get_buffer_size(&context.encoder, context.buffer);
+}

--- a/src/apps/bridge/cbor_sensor_report_encoder.cpp
+++ b/src/apps/bridge/cbor_sensor_report_encoder.cpp
@@ -3,7 +3,7 @@
 /*
 EXAMPLE USAGE:
 
-CborError encode_my_reading(CborEncoder &sample_array, void *sensor_data){
+CborError encode_my_sample_member(CborEncoder &sample_array, void *sensor_data){
     my_sample_t *my_sample = (my_sample_t *)sensor_data;
     CborError err = CborNoError;
     err |= cbor_encode_uint(&sample_array, my_sample->my_uint);
@@ -15,14 +15,14 @@ bool make_a_sensor_report(void){
     uint8_t cbor_buffer[1024];
     size_t num_sensors = 1;
     size_t num_samples = 1;
-    size_t num_readings = 1;
+    size_t num_sample_members = 1;
     sensor_report_encoder_open_report(cbor_buffer, sizeof(cbor_buffer), num_sensors, context);
     for (int i = 0; i < num_sensors; i++){
         sensor_report_encoder_open_sensor(context, num_samples);
         for(int j = 0; j < num_samples; j++) {
             sensor_report_encoder_open_sample(context, 1);
-            for(int k = 0; k < num_readings; k++) {
-                sensor_report_encoder_add_reading(context, encode_my_reading, &my_reading);
+            for(int k = 0; k < num_sample_members; k++) {
+                sensor_report_encoder_add_sample_member(context, encode_my_sample_member, &my_sample_member);
             }
             sensor_report_encoder_close_sample(context);
         }
@@ -89,25 +89,25 @@ CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &co
 /*!
  * @brief Open a sample array for encoding.
  * @param[in] context The encoding context.
- * @param[in] num_readings The number of samples in the sensor.
+ * @param[in] num_sample_members The number of samples in the sensor.
  * @return Cbor error code.
  */
 CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
-                                            size_t num_readings) {
-  return cbor_encoder_create_array(&context.sensor_array, &context.sample_array, num_readings);
+                                            size_t num_sample_members) {
+  return cbor_encoder_create_array(&context.sensor_array, &context.sample_array, num_sample_members);
 }
 
 /*!
- * @brief Add a reading to the sample array.
+ * @brief Add a sample member to the sample array.
  * @param[in] context The encoding context.
  * @param[in] sample_encoder_cb The callback to encode the sample data.
  * @param[in] sensor_data The sensor data to encode.
  * @return Cbor error code.
  */
-CborError sensor_report_encoder_add_reading(sensor_report_encoder_context_t &context,
-                                            sample_encoder_cb sample_encoder_cb,
+CborError sensor_report_encoder_add_sample_member(sensor_report_encoder_context_t &context,
+                                            sample_encoder_cb sample_member_encoder_cb,
                                             void *sensor_data) {
-  return sample_encoder_cb(context.sample_array, sensor_data);
+  return sample_member_encoder_cb(context.sample_array, sensor_data);
 }
 
 /*!

--- a/src/apps/bridge/cbor_sensor_report_encoder.cpp
+++ b/src/apps/bridge/cbor_sensor_report_encoder.cpp
@@ -31,6 +31,12 @@ bool make_a_sensor_report(void){
     sensor_report_encoder_close_report(context);
     size_t cbor_buffer_len = sensor_report_encoder_get_report_size_bytes(context);
     // Send cbor_buffer to the other side.
+    bm_serial_pub(getNodeId(),APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC,
+        sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC),
+        cbor_buffer,
+        cbor_buffer_len,
+        APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE,
+        APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION);
 }
 */
 
@@ -99,8 +105,8 @@ CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &con
  * @return Cbor error code.
  */
 CborError sensor_report_encoder_add_reading(sensor_report_encoder_context_t &context,
-                                           sample_encoder_cb sample_encoder_cb,
-                                           void *sensor_data) {
+                                            sample_encoder_cb sample_encoder_cb,
+                                            void *sensor_data) {
   return sample_encoder_cb(context.sample_array, sensor_data);
 }
 

--- a/src/apps/bridge/cbor_sensor_report_encoder.h
+++ b/src/apps/bridge/cbor_sensor_report_encoder.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "cbor.h"
+#include <stdlib.h>
+
+typedef struct sensor_report_encoder_context {
+  uint8_t *buffer;
+  CborEncoder encoder;
+  CborEncoder report_array;
+  CborEncoder sensor_array;
+  CborEncoder sample_array;
+} sensor_report_encoder_context_t;
+
+typedef CborError (*sample_encoder_cb)(CborEncoder &sample_array, void *sensor_data);
+
+CborError sensor_report_encoder_open_report(uint8_t *cbor_buffer, size_t cbor_buffer_len,
+                                            uint8_t num_sensors,
+                                            sensor_report_encoder_context_t &context);
+
+CborError sensor_report_encoder_close_report(sensor_report_encoder_context_t &context);
+
+CborError sensor_report_encoder_open_sensor(sensor_report_encoder_context_t &context,
+                                            size_t num_sensors);
+
+CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &context);
+
+CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
+                                            size_t num_samples);
+
+CborError sensor_report_encoder_add_sample(sensor_report_encoder_context_t &context,
+                                           sample_encoder_cb sample_encoder_cb,
+                                           void *sensor_data);
+
+CborError sensor_report_encoder_close_sample(sensor_report_encoder_context_t &context);
+
+size_t sensor_report_encoder_get_report_size_bytes(sensor_report_encoder_context_t &context);

--- a/src/apps/bridge/cbor_sensor_report_encoder.h
+++ b/src/apps/bridge/cbor_sensor_report_encoder.h
@@ -19,15 +19,15 @@ CborError sensor_report_encoder_open_report(uint8_t *cbor_buffer, size_t cbor_bu
 CborError sensor_report_encoder_close_report(sensor_report_encoder_context_t &context);
 
 CborError sensor_report_encoder_open_sensor(sensor_report_encoder_context_t &context,
-                                            size_t num_sensors);
+                                            size_t num_samples);
 
 CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &context);
 
 CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
-                                            size_t num_samples);
+                                            size_t num_readings);
 
-CborError sensor_report_encoder_add_sample(sensor_report_encoder_context_t &context,
-                                           sample_encoder_cb sample_encoder_cb,
+CborError sensor_report_encoder_add_reading(sensor_report_encoder_context_t &context,
+                                           sample_encoder_cb reading_encoder_cb,
                                            void *sensor_data);
 
 CborError sensor_report_encoder_close_sample(sensor_report_encoder_context_t &context);

--- a/src/apps/bridge/cbor_sensor_report_encoder.h
+++ b/src/apps/bridge/cbor_sensor_report_encoder.h
@@ -24,10 +24,10 @@ CborError sensor_report_encoder_open_sensor(sensor_report_encoder_context_t &con
 CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &context);
 
 CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
-                                            size_t num_readings);
+                                            size_t num_sample_members);
 
-CborError sensor_report_encoder_add_reading(sensor_report_encoder_context_t &context,
-                                           sample_encoder_cb reading_encoder_cb,
+CborError sensor_report_encoder_add_sample_member(sensor_report_encoder_context_t &context,
+                                           sample_encoder_cb sample_member_encoder_cb,
                                            void *sensor_data);
 
 CborError sensor_report_encoder_close_sample(sensor_report_encoder_context_t &context);


### PR DESCRIPTION
Adding a generic cbor sensor report library for a 3d array.
See example usage at the top of 
`src/apps/bridge/cbor_sensor_report_encoder.cpp`

Test:
Builds - but need an end-to-end data test once the aggregator is built
