### PR TITLE
Sc 196635/report builder

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -250,6 +250,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/aanderaaController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cbor_sensor_report_encoder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reportBuilder.cpp
     ${MCUBOOT_FILES}
     ${FREERTOS_FILES}
     ${LIB_FILES}

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -256,8 +256,7 @@ static void runController(void *param) {
             } else {
               printf("ERROR: Failed to print Aanderaa data\n");
             }
-            // Zero is the "sensor type" which is not used rn
-            reportBuilderAddToQueue(curr->node_id, 0, &agg, REPORT_BUILDER_SAMPLE_MESSAGE);
+            reportBuilderAddToQueue(curr->node_id, AANDERAA_SENSOR_TYPE, static_cast<void *>(&agg), sizeof(aanderaa_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
             // TODO - send aggregated data to a "report builder" task that will
             // combine all the data from all the sensors and send it to the spotter
             memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
@@ -272,8 +271,8 @@ static void runController(void *param) {
           curr = curr->next;
         }
         vPortFree(log_buf);
-        // The first three inputs are not used by this message type
-        reportBuilderAddToQueue(0, 0, NULL, REPORT_BUILDER_INCREMENT_SAMPLE_COUNT);
+        // The first four inputs are not used by this message type
+        reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_INCREMENT_SAMPLE_COUNT);
       } else {
         printf("No Aanderaa nodes to aggregate\n");
       }

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -223,21 +223,15 @@ static void runController(void *param) {
         while (curr != NULL) {
           if (xSemaphoreTake(curr->_mutex, portMAX_DELAY)) {
             size_t log_buflen = 0;
-            aanderaa_aggregations_t agg = {.abs_speed_mean_cm_s = 0.0,
-                                           .abs_speed_std_cm_s = 0.0,
-                                           .direction_circ_mean_rad = 0.0,
-                                           .direction_circ_std_rad = 0.0,
-                                           .temp_mean_deg_c = 0.0};
+            aanderaa_aggregations_t agg = {.abs_speed_mean_cm_s = NAN,
+                                           .abs_speed_std_cm_s = NAN,
+                                           .direction_circ_mean_rad = NAN,
+                                           .direction_circ_std_rad = NAN,
+                                           .temp_mean_deg_c = NAN};
             // Check to make sure we have enough sensor readings for a valid aggregation.
             // If not send NaNs for all the values.
             // TODO - verify that we can assume if one sampler is below the min then all of them are.
-            if(curr->abs_speed_cm_s.getNumSamples() < MIN_READINGS_FOR_AGGREGATION) {
-              agg.abs_speed_mean_cm_s = NAN;
-              agg.abs_speed_std_cm_s = NAN;
-              agg.direction_circ_mean_rad = NAN;
-              agg.direction_circ_std_rad = NAN;
-              agg.temp_mean_deg_c = NAN;
-            } else {
+            if(curr->abs_speed_cm_s.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
               agg.abs_speed_mean_cm_s = curr->abs_speed_cm_s.getMean(true);;
               agg.abs_speed_std_cm_s = curr->abs_speed_cm_s.getStd(true);;
               agg.direction_circ_mean_rad = curr->direction_rad.getCircularMean();;
@@ -262,6 +256,7 @@ static void runController(void *param) {
             } else {
               printf("ERROR: Failed to print Aanderaa data\n");
             }
+            // Zero is the "sensor type" which is not used rn
             reportBuilderAddToQueue(curr->node_id, 0, &agg, REPORT_BUILDER_SAMPLE_MESSAGE);
             // TODO - send aggregated data to a "report builder" task that will
             // combine all the data from all the sensors and send it to the spotter
@@ -277,6 +272,7 @@ static void runController(void *param) {
           curr = curr->next;
         }
         vPortFree(log_buf);
+        // The first three inputs are not used by this message type
         reportBuilderAddToQueue(0, 0, NULL, REPORT_BUILDER_INCREMENT_SAMPLE_COUNT);
       } else {
         printf("No Aanderaa nodes to aggregate\n");

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -6,6 +6,7 @@
 #include "bm_pubsub.h"
 #include "bridgeLog.h"
 #include "device_info.h"
+#include "reportBuilder.h"
 #include "semphr.h"
 #include "sys_info_service.h"
 #include "sys_info_svc_reply_msg.h"
@@ -261,6 +262,7 @@ static void runController(void *param) {
             } else {
               printf("ERROR: Failed to print Aanderaa data\n");
             }
+            reportBuilderAddToQueue(curr->node_id, 0, &agg, REPORT_BUILDER_SAMPLE_MESSAGE);
             // TODO - send aggregated data to a "report builder" task that will
             // combine all the data from all the sensors and send it to the spotter
             memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
@@ -275,6 +277,7 @@ static void runController(void *param) {
           curr = curr->next;
         }
         vPortFree(log_buf);
+        reportBuilderAddToQueue(0, 0, NULL, REPORT_BUILDER_INCREMENT_SAMPLE_COUNT);
       } else {
         printf("No Aanderaa nodes to aggregate\n");
       }

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -222,13 +222,11 @@ static void runController(void *param) {
         while (curr != NULL) {
           if (xSemaphoreTake(curr->_mutex, portMAX_DELAY)) {
             size_t log_buflen = 0;
-            aanderaa_aggregations_t agg = {.node_id = 0,
-                                           .abs_speed_mean_cm_s = 0.0,
+            aanderaa_aggregations_t agg = {.abs_speed_mean_cm_s = 0.0,
                                            .abs_speed_std_cm_s = 0.0,
                                            .direction_circ_mean_rad = 0.0,
                                            .direction_circ_std_rad = 0.0,
                                            .temp_mean_deg_c = 0.0};
-            agg.node_id = curr->node_id;
             // Check to make sure we have enough sensor readings for a valid aggregation.
             // If not send NaNs for all the values.
             // TODO - verify that we can assume if one sampler is below the min then all of them are.
@@ -252,7 +250,7 @@ static void runController(void *param) {
                               "%.3f,"        // direction_circ_mean_rad
                               "%.3f,"        // direction_circ_std_rad
                               "%.3f\n",      // temp_mean_deg_c
-                              agg.node_id,
+                              curr->node_id,
                               agg.abs_speed_mean_cm_s,
                               agg.abs_speed_std_cm_s,
                               agg.direction_circ_mean_rad,

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -18,6 +18,8 @@ typedef struct aanderaa_aggregations_s {
   double temp_mean_deg_c;
 } aanderaa_aggregations_t;
 
+#define AANDERAA_NUM_SAMPLE_MEMBERS 5
+
 void aanderaControllerInit(BridgePowerController *power_controller,
                            cfg::Configuration *usr_cfg,
                            cfg::Configuration *sys_cfg);

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -11,7 +11,6 @@
 #define DEFAULT_TRANSMIT_AGGREGATIONS 1
 
 typedef struct aanderaa_aggregations_s {
-  uint64_t node_id;
   double abs_speed_mean_cm_s;
   double abs_speed_std_cm_s;
   double direction_circ_mean_rad;

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -2,6 +2,9 @@
 
 #include "configuration.h"
 
+#define DEFAULT_TRANSMIT_AGGREGATIONS 1
+#define DEFAULT_SAMPLES_PER_REPORT 2
+
 namespace AppConfig {
 
 constexpr const char *SAMPLE_INTERVAL_MS = "sampleIntervalMs";

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -50,6 +50,7 @@
 #include "configuration.h"
 #include "debug_configuration.h"
 #include "ram_partitions.h"
+#include "reportBuilder.h"
 #include "bridgePowerController.h"
 #include "debug_bridge_power_controller.h"
 #include "timer_callback_handler.h"
@@ -367,6 +368,7 @@ static void defaultTask( void *parameters ) {
     debug_ncp_init();
     debugBmServiceInit();
     sys_info_service_init(debug_configuration_system);
+    reportBuilderInit(&debug_configuration_system);
     aanderaControllerInit(&bridge_power_controller, &debug_configuration_user, &debug_configuration_system);
     config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
                                debug_configuration_user);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -452,6 +452,8 @@ static void report_builder_task(void *parameters) {
               size_t temp_node_list_size = sizeof(temp_node_list);
               uint32_t temp_num_nodes;
               if (topology_sampler_get_node_list(temp_node_list, temp_node_list_size, temp_num_nodes, TOPO_TIMEOUT_MS)) {
+                // TODO - we need to use the cbor_map and build a report builder topology map that only
+                // includes aanderaa nodes
                 printf("Got topology in report builder!\n");
                 if (temp_num_nodes >= _ctx._report_period_num_nodes) {
                   printf("Updating CRC and topology in report builder!\n");

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -19,19 +19,141 @@ typedef struct {
 } ReportBuilderContext_t;
 
 static ReportBuilderContext_t _ctx;
-static QueueHandle_t _report_builder_message_queue = NULL;
+static QueueHandle_t _report_builder_queue = NULL;
 
 static void report_builder_task(void *parameters);
+
+// TODO - Build the linked list with insertion so we can "sort" it based on the topology
+class ReportBuilderLinkedList {
+  private:
+
+    struct report_builder_element_s {
+      uint64_t node_id;
+      uint8_t sensor_type;
+      uint8_t *sensor_data;
+      report_builder_element_s *next;
+      report_builder_element_s *prev;
+    };
+
+
+    report_builder_element_s* newElement(uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data);
+    void freeElement(report_builder_element_s **element_pointer);
+
+    report_builder_element_s *head;
+    report_builder_element_s *tail; // TODO - is this needed?
+    size_t size;
+
+  public:
+
+    ReportBuilderLInkedLIst();
+    ~ReportBuilderLInkedLIst();
+
+    bool removeElement(report_builder_element_s *element);
+    void insertAfter(report_builder_element_s *curr, uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data);
+    void insertBefore(report_builder_element_s *curr, uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data);
+    void clear();
+    size_t getSize();
+
+}
+
+ReportBuilderLinkedList::ReportBuilderLinkedList() {
+  head = NULL;
+  tail = NULL;
+  size = 0;
+}
+
+ReportBuilderLinkedList::~ReportBuilderLinkedList() {
+  report_builder_element_s *element = head;
+  while (element != NULL) {
+    report_builder_element_s *next = element->next;
+    freeElement(&element);
+    element = next;
+  }
+}
+
+report_builder_element_s* ReportBuilderLinkedList::newElement(uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data) {
+  report_builder_element_s *element = static_cast<report_builder_element_s *>(pvPortMalloc(sizeof(report_builder_element_s)));
+  configASSERT(element != NULL);
+  element->node_id = node_id;
+  element->sensor_type = sensor_type;
+  element->sensor_data = sensor_data;
+  element->next = NULL;
+  element->prev = NULL;
+  return element;
+}
+
+void ReportBuilderLinkedList::freeElement(report_builder_element_s **element_pointer) {
+  if (element_pointer != NULL && *element_pointer != NULL) {
+    vPortFree((*element_pointer)->sensor_data); // Free the data first
+    vPortFree(*element_pointer);
+    *element_pointer = NULL;
+  }
+}
+
+bool ReportBuilderLinkedList::removeElement(report_builder_element_s *element) {
+  bool rval = false;
+  if (element != NULL) {
+    if (element->prev != NULL) {
+      element->prev->next = element->next;
+    } else {
+      head = element->next;
+    }
+    if (element->next != NULL) {
+      element->next->prev = element->prev;
+    } else {
+      tail = element->prev;
+    }
+    freeElement(&element);
+    size--;
+    rval = true;
+  }
+  return rval;
+}
+
+void ReportBuilderLinkedList::insertAfter(report_builder_element_s *curr, uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data) {
+  if (curr != NULL) {
+    report_builder_element_s *element = newElement(node_id, sensor_type, sensor_data);
+    element->next = curr->next;
+    element->prev = curr;
+    if (curr->next != NULL) {
+      curr->next->prev = element;
+    } else {
+      tail = element;
+    }
+    curr->next = element;
+    size++;
+  } else {
+    head = element;
+    tail = element;
+  }
+}
+
+void ReportBuilderLinkedList::insertBefore(report_builder_element_s *curr, uint64_t node_id, uint8_t sensor_type, uint8_t *sensor_data) {
+  if (curr != NULL) {
+    report_builder_element_s *element = newElement(node_id, sensor_type, sensor_data);
+    element->next = curr;
+    element->prev = curr->prev;
+    if (curr->prev != NULL) {
+      curr->prev->next = element;
+    } else {
+      head = element;
+    }
+    curr->prev = element;
+    size++;
+  } else {
+    head = element;
+    tail = element;
+  }
+}
 
 void reportBuilderInit(cfg::Configuration* sys_cfg) {
   configASSERT(sys_cfg);
   _ctx._samplesPerReport = 0;
   sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT), _ctx._samplesPerReport);
   _ctx._sample_counter = 0;
-  // TODO define the messages so we now how big to make the queue
-  _report_builder_message_queue =
-      xQueueCreate(REPORT_BUILDER_QUEUE_SIZE, sizeof(REPORT_BUILDER_MESSAGES));
-  configASSERT(_report_builder_message_queue);
+  _report_builder_queue =
+      xQueueCreate(REPORT_BUILDER_QUEUE_SIZE, sizeof(report_builder_queue_item_t));
+  configASSERT(_report_builder_queue);
   // create task
   BaseType_t rval = xTaskCreate(report_builder_task, "REPORT_BUILDER", 1024, NULL,
                                 REPORT_BUILDER_TASK_PRIORITY, NULL);
@@ -39,28 +161,33 @@ void reportBuilderInit(cfg::Configuration* sys_cfg) {
 }
 
 static void report_builder_task(void *parameters) {
+  void (parameters);
 
-  // TODO - define the messages so we can use them here
-  // REPORT_BUILDER_MESSAGES message;
+  report_builder_queue_item_t item;
+
   while (1) {
-    if (xQueueReceive(_report_builder_message_queue, &message,
+    if (xQueueReceive(_report_builder_queue, &item,
                       portMAX_DELAY) == pdPASS) {
-      switch (message) {
-      case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT:
-        _ctx._sample_counter++;
-        if (_ctx._sample_counter >= _ctx._samplesPerReport) {
-          if (_ctx._transmitAggregations) {
-            // TODO - compile report into Cbor and send it to spotter
+      switch (item.message_type) {
+        case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT:
+          _ctx._sample_counter++;
+          if (_ctx._sample_counter >= _ctx._samplesPerReport && _ctx._samplesPerReport > 0) {
+            if (_ctx._transmitAggregations) {
+              // TODO - compile report into Cbor and send it to spotter
+            } else {
+              // TODO - is there something we should do with the report if we don't want to send it?
+              // like just log it?
+            }
+            // empty the linked list - I think that this will be easiest and leave us in a clean state instead of
+            // having to deal with a linked list that has a bunch of old nodes in it.
           } else {
             // TODO - is there something we should do with the report if we don't want to send it?
+            // like just log it? Is there a way to combine these two nested if else statements?
           }
-          // empty the linked list
-        }
-        break;
-      case REPORT_BUILDER_SAMPLE_MESSAGE:
-        // TODO - add sample to the linked list
-        break;
+          break;
+        case REPORT_BUILDER_SAMPLE_MESSAGE:
+          // TODO - add sample to the linked list
+          break;
       }
     }
 }
-

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -83,6 +83,7 @@ report_builder_element_t* ReportBuilderLinkedList::newElement(uint64_t node_id, 
   // TODO - use the sensor type to determine the size of the sensor data
   element->sensor_data = static_cast<aanderaa_aggregations_t *>(pvPortMalloc(samples_per_report * sizeof(aanderaa_aggregations_t)));
   configASSERT(element->sensor_data != NULL);
+  memset(element->sensor_data, 0, samples_per_report * sizeof(aanderaa_aggregations_t));
 
   // Back fill the sensor_data with NANs if we are not on sample_count 0.
   uint32_t i;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -17,6 +17,11 @@
 #define REPORT_BUILDER_QUEUE_SIZE (16)
 #define TOPO_TIMEOUT_MS (1000)
 
+// This is the current max length the cbor buffer can be for the sensor report
+// The limiting factor is the max size we can send via Iridium minus the size
+// of the messages header
+#define MAX_SENSOR_REPORT_CBOR_LEN 315
+
 typedef struct report_builder_element_s {
   uint64_t node_id;
   uint8_t sensor_type;
@@ -369,7 +374,7 @@ static void report_builder_task(void *parameters) {
               if (_ctx._report_period_num_nodes > 1) {
                 uint32_t num_sensors = _ctx._report_period_num_nodes - 1; // Minus one since topo includes the bridge
                 sensor_report_encoder_context_t context;
-                uint8_t cbor_buffer[315];
+                uint8_t cbor_buffer[MAX_SENSOR_REPORT_CBOR_LEN];
                 sensor_report_encoder_open_report(cbor_buffer, sizeof(cbor_buffer), num_sensors, context);
                 // Start at index 1 to skip the bridge
                 for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -383,7 +383,7 @@ static void report_builder_task(void *parameters) {
                     BRIDGE_LOG_PRINT("Failed to open report in report_builder_task\n");
                     break;
                   }
-                  bool exit_loop_early = false;
+                  bool abort_cbor_encoding = false;
                   // Start at index 1 to skip the bridge
                   for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
                     report_builder_element_t *element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
@@ -400,23 +400,23 @@ static void report_builder_task(void *parameters) {
                     }
                     if (sensor_report_encoder_open_sensor(context, _ctx._samplesPerReport) != CborNoError) {
                       BRIDGE_LOG_PRINT("Failed to open sensor in report_builder_task\n");
-                      exit_loop_early = true;
+                      abort_cbor_encoding = true;
                       break;
                     }
                     for (uint32_t j = 0; j < _ctx._samplesPerReport; j++) {
                       if (!addSamplesToReport(context, element->sensor_type, element->sensor_data, j)) {
                         BRIDGE_LOG_PRINT("Failed to add samples to report in report_builder_task\n");
-                        exit_loop_early = true;
+                        abort_cbor_encoding = true;
                         break;
                       }
                     }
-                    if (sensor_report_encoder_close_sensor(context) != CborNoError || exit_loop_early) {
+                    if (sensor_report_encoder_close_sensor(context) != CborNoError || abort_cbor_encoding) {
                       BRIDGE_LOG_PRINT("Failed to close sensor in report_builder_task\n");
-                      exit_loop_early = true;
+                      abort_cbor_encoding = true;
                       break;
                     }
                   }
-                  if (exit_loop_early) {
+                  if (abort_cbor_encoding) {
                     break;
                   }
                   if (sensor_report_encoder_close_report(context) != CborNoError) {

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -398,7 +398,7 @@ static void report_builder_task(void *parameters) {
                 }
                 sensor_report_encoder_close_report(context);
                 size_t cbor_buffer_len = sensor_report_encoder_get_report_size_bytes(context);
-                app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = static_cast<app_pub_sub_bm_bridge_sensor_report_data_t *>(pvPortMalloc(sizeof(uint32_t) + sizeof(size_t) + cbor_buffer_len));
+                app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = static_cast<app_pub_sub_bm_bridge_sensor_report_data_t *>(pvPortMalloc(sizeof(app_pub_sub_bm_bridge_sensor_report_data_t) + cbor_buffer_len));
                 configASSERT(message_buff != NULL);
                 message_buff->bm_config_crc32 = _ctx._report_period_max_network_crc32;
                 message_buff->cbor_buffer_len = cbor_buffer_len;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -154,14 +154,14 @@ void ReportBuilderLinkedList::addSensorDataToElement(report_builder_element_t *e
         // Back fill the sensor_data with NANs if we are not on the right sample count
         uint32_t i;
         for (i = 0; i < sample_counter; i++) {
-          memcpy(&(reinterpret_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], &NAN_AGG, sizeof(aanderaa_aggregations_t));
+          memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], &NAN_AGG, sizeof(aanderaa_aggregations_t));
         }
         // Copy the sensor data into the elements array in the correct location within the buffer
         // If it is NULL then just fill it with NAN again
         if (sensor_data != NULL) {
-          memcpy(&(reinterpret_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], sensor_data, sizeof(aanderaa_aggregations_t));
+          memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], sensor_data, sizeof(aanderaa_aggregations_t));
         } else {
-          memcpy(&(reinterpret_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], &NAN_AGG, sizeof(aanderaa_aggregations_t));
+          memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[i], &NAN_AGG, sizeof(aanderaa_aggregations_t));
         }
         break;
       }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -366,7 +366,11 @@ static void report_builder_task(void *parameters) {
       switch (item.message_type) {
         case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT: {
           _ctx._sample_counter++;
-          printf("Incrementing sample counter to %d\n", _ctx._sample_counter);
+          constexpr size_t bufsize = 36; // 36 is the length of the string below + \0
+          static char buffer[bufsize];
+          int len =
+              snprintf(buffer, bufsize, "Incrementing sample counter to %d\n", _ctx._sample_counter);
+          BRIDGE_LOG_PRINTN(buffer, len);
           if (_ctx._sample_counter >= _ctx._samplesPerReport) {
             if (_ctx._samplesPerReport > 0 && _ctx._transmitAggregations) {
               // Need to have more than one node to report anything (1 node would be just the bridge)
@@ -388,7 +392,11 @@ static void report_builder_task(void *parameters) {
                   for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
                     report_builder_element_t *element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
                     if (element == NULL) {
-                      printf("No data for node %" PRIx64 " in report period, adding it to the list\n", _ctx._report_period_node_list[i]);
+                      constexpr size_t bufsize = 65; // 65 is the length of the string below + \0
+                      static char buffer[bufsize];
+                      int len =
+                          snprintf(buffer, bufsize, "No data for node %" PRIx64 " in report period, adding it to the list\n", _ctx._report_period_node_list[i]);
+                      BRIDGE_LOG_PRINTN(buffer, len);
                       // we have a sensor that may have been added at the end of the report period
                       // so lets add it to the list and this wil backfill all of the data so we can still send it
                       // in the report. We will need to pass (_ctx._sample_counter - 1) to make sure we don't overflow the sensor_data buffer.
@@ -396,7 +404,11 @@ static void report_builder_task(void *parameters) {
                       _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(_ctx._report_period_node_list[i], AANDERAA_SENSOR_TYPE, NULL, sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport, (_ctx._sample_counter - 1));
                       element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
                     } else {
-                      printf("Found data for node %" PRIx64 " adding it the the report\n", _ctx._report_period_node_list[i]);
+                      constexpr size_t bufsize = 53; // 53 is the length of the string below + \0
+                      static char buffer[bufsize];
+                      int len =
+                          snprintf(buffer, bufsize, "Found data for node %" PRIx64 " adding it the the report\n", _ctx._report_period_node_list[i]);
+                      BRIDGE_LOG_PRINTN(buffer, len);
                     }
                     if (sensor_report_encoder_open_sensor(context, _ctx._samplesPerReport) != CborNoError) {
                       BRIDGE_LOG_PRINT("Failed to open sensor in report_builder_task\n");
@@ -461,7 +473,11 @@ static void report_builder_task(void *parameters) {
 
         case REPORT_BUILDER_SAMPLE_MESSAGE: {
           if (_ctx._samplesPerReport > 0) {
-            printf("Adding sample for %" PRIx64 " to list\n", item.node_id);
+            constexpr size_t bufsize = 38; // 38 is the length of the string below + \0
+            static char buffer[bufsize];
+            int len =
+                snprintf(buffer, bufsize, "Adding sample for %" PRIx64 " to list\n", item.node_id);
+            BRIDGE_LOG_PRINTN(buffer, len);
             _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(item.node_id, item.sensor_type, item.sensor_data, item.sensor_data_size, _ctx._samplesPerReport, _ctx._sample_counter);
           } else {
             BRIDGE_LOG_PRINT("samplesPerReport is 0, not adding sample to list\n");
@@ -482,7 +498,11 @@ static void report_builder_task(void *parameters) {
           uint32_t temp_cbor_config_size = 0;
           uint8_t *last_network_config = topology_sampler_alloc_last_network_config(temp_network_crc32, temp_cbor_config_size);
           if (last_network_config != NULL) {
-            printf("Got CRC %" PRIx32 " OLD CRC %" PRIx32 "\n", temp_network_crc32, _ctx._report_period_max_network_crc32);
+            constexpr size_t bufsize = 33; // 33 is the length of the string below + \0
+            static char buffer[bufsize];
+            int len =
+                snprintf(buffer, bufsize, "Got CRC %" PRIx32 " OLD CRC %" PRIx32 "\n", temp_network_crc32, _ctx._report_period_max_network_crc32);
+            BRIDGE_LOG_PRINTN(buffer, len);
             if (temp_network_crc32 != _ctx._report_period_max_network_crc32) {
               BRIDGE_LOG_PRINT("Getting topology in report builder!\n");
               uint64_t temp_node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -306,24 +306,31 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       aanderaa_aggregations_t aanderaa_sample = (static_cast<aanderaa_aggregations_t *>(sensor_data))[sample_index];
       if (sensor_report_encoder_open_sample(context, AANDERAA_NUM_SAMPLE_MEMBERS) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open sample in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_speed_mean_cm_s) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_speed_std_cm_s) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.direction_circ_mean_rad) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.direction_circ_std_rad) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.temp_mean_deg_c) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
       }
       if (sensor_report_encoder_close_sample(context) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
+        break;
       }
       rval = true;
       break;
@@ -366,7 +373,7 @@ static void report_builder_task(void *parameters) {
       switch (item.message_type) {
         case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT: {
           _ctx._sample_counter++;
-          constexpr size_t bufsize = 36; // 36 is the length of the string below + \0
+          constexpr size_t bufsize = 50;
           static char buffer[bufsize];
           int len =
               snprintf(buffer, bufsize, "Incrementing sample counter to %d\n", _ctx._sample_counter);
@@ -392,7 +399,7 @@ static void report_builder_task(void *parameters) {
                   for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
                     report_builder_element_t *element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
                     if (element == NULL) {
-                      constexpr size_t bufsize = 65; // 65 is the length of the string below + \0
+                      constexpr size_t bufsize = 80;
                       static char buffer[bufsize];
                       int len =
                           snprintf(buffer, bufsize, "No data for node %" PRIx64 " in report period, adding it to the list\n", _ctx._report_period_node_list[i]);
@@ -404,10 +411,10 @@ static void report_builder_task(void *parameters) {
                       _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(_ctx._report_period_node_list[i], AANDERAA_SENSOR_TYPE, NULL, sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport, (_ctx._sample_counter - 1));
                       element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
                     } else {
-                      constexpr size_t bufsize = 53; // 53 is the length of the string below + \0
+                      constexpr size_t bufsize = 70;
                       static char buffer[bufsize];
                       int len =
-                          snprintf(buffer, bufsize, "Found data for node %" PRIx64 " adding it the the report\n", _ctx._report_period_node_list[i]);
+                          snprintf(buffer, bufsize, "Found data for node %" PRIx64 " adding it to the the report\n", _ctx._report_period_node_list[i]);
                       BRIDGE_LOG_PRINTN(buffer, len);
                     }
                     if (sensor_report_encoder_open_sensor(context, _ctx._samplesPerReport) != CborNoError) {
@@ -473,7 +480,7 @@ static void report_builder_task(void *parameters) {
 
         case REPORT_BUILDER_SAMPLE_MESSAGE: {
           if (_ctx._samplesPerReport > 0) {
-            constexpr size_t bufsize = 38; // 38 is the length of the string below + \0
+            constexpr size_t bufsize = 55;
             static char buffer[bufsize];
             int len =
                 snprintf(buffer, bufsize, "Adding sample for %" PRIx64 " to list\n", item.node_id);
@@ -498,7 +505,7 @@ static void report_builder_task(void *parameters) {
           uint32_t temp_cbor_config_size = 0;
           uint8_t *last_network_config = topology_sampler_alloc_last_network_config(temp_network_crc32, temp_cbor_config_size);
           if (last_network_config != NULL) {
-            constexpr size_t bufsize = 33; // 33 is the length of the string below + \0
+            constexpr size_t bufsize = 50;
             static char buffer[bufsize];
             int len =
                 snprintf(buffer, bufsize, "Got CRC %" PRIx32 " OLD CRC %" PRIx32 "\n", temp_network_crc32, _ctx._report_period_max_network_crc32);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -390,7 +390,7 @@ static void report_builder_task(void *parameters) {
                   sensor_report_encoder_context_t context;
                   cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
                   configASSERT(cbor_buffer != NULL);
-                  if (sensor_report_encoder_open_report(cbor_buffer, sizeof(cbor_buffer), num_sensors, context) != CborNoError) {
+                  if (sensor_report_encoder_open_report(cbor_buffer, MAX_SENSOR_REPORT_CBOR_LEN, num_sensors, context) != CborNoError) {
                     BRIDGE_LOG_PRINT("Failed to open report in report_builder_task\n");
                     break;
                   }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -1,0 +1,66 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "semphr.h"
+#include "task.h"
+#include "task_priorities.h"
+#include "timer_callback_handler.h"
+#include "timers.h"
+#include <string.h>
+#include "app_config.h"
+#include "reportBuilder.h"
+
+#define REPORT_BUILDER_QUEUE_SIZE (16)
+
+typedef struct {
+  uint32_t _sample_counter;
+  uint32_t _samplesPerReport;
+  uint32_t _transmitAggregations;
+  // TODO add a linked list of samples from nodes
+} ReportBuilderContext_t;
+
+static ReportBuilderContext_t _ctx;
+static QueueHandle_t _report_builder_message_queue = NULL;
+
+static void report_builder_task(void *parameters);
+
+void reportBuilderInit(cfg::Configuration* sys_cfg) {
+  configASSERT(sys_cfg);
+  _ctx._samplesPerReport = 0;
+  sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT), _ctx._samplesPerReport);
+  _ctx._sample_counter = 0;
+  // TODO define the messages so we now how big to make the queue
+  _report_builder_message_queue =
+      xQueueCreate(REPORT_BUILDER_QUEUE_SIZE, sizeof(REPORT_BUILDER_MESSAGES));
+  configASSERT(_report_builder_message_queue);
+  // create task
+  BaseType_t rval = xTaskCreate(report_builder_task, "REPORT_BUILDER", 1024, NULL,
+                                REPORT_BUILDER_TASK_PRIORITY, NULL);
+  configASSERT(rval == pdPASS);
+}
+
+static void report_builder_task(void *parameters) {
+
+  // TODO - define the messages so we can use them here
+  // REPORT_BUILDER_MESSAGES message;
+  while (1) {
+    if (xQueueReceive(_report_builder_message_queue, &message,
+                      portMAX_DELAY) == pdPASS) {
+      switch (message) {
+      case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT:
+        _ctx._sample_counter++;
+        if (_ctx._sample_counter >= _ctx._samplesPerReport) {
+          if (_ctx._transmitAggregations) {
+            // TODO - compile report into Cbor and send it to spotter
+          } else {
+            // TODO - is there something we should do with the report if we don't want to send it?
+          }
+          // empty the linked list
+        }
+        break;
+      case REPORT_BUILDER_SAMPLE_MESSAGE:
+        // TODO - add sample to the linked list
+        break;
+      }
+    }
+}
+

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -278,6 +278,7 @@ static void report_builder_task(void *parameters) {
                     // in the report. We will need to pass (_ctx._sample_counter - 1) to make sure we don't overflow the sensor_data buffer.
                     // Also we will pass NULL into the sensor_data since we don't have any data for it yet and we will fill the whole thing with NANs
                     _ctx._reportBuilderLinkedList.addSample(_ctx._report_period_node_list[i], 0, NULL, _ctx._samplesPerReport, (_ctx._sample_counter - 1));
+                    element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
                   } else {
                     printf("Found data for node %" PRIx64 " adding it the the report\n", _ctx._report_period_node_list[i]);
                   }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -374,7 +374,8 @@ static void report_builder_task(void *parameters) {
               if (_ctx._report_period_num_nodes > 1) {
                 uint32_t num_sensors = _ctx._report_period_num_nodes - 1; // Minus one since topo includes the bridge
                 sensor_report_encoder_context_t context;
-                uint8_t cbor_buffer[MAX_SENSOR_REPORT_CBOR_LEN];
+                uint8_t *cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
+                configASSERT(cbor_buffer != NULL);
                 sensor_report_encoder_open_report(cbor_buffer, sizeof(cbor_buffer), num_sensors, context);
                 // Start at index 1 to skip the bridge
                 for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
@@ -411,6 +412,7 @@ static void report_builder_task(void *parameters) {
                     APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE,
                     APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION);
                 vPortFree(message_buff);
+                vPortFree(cbor_buffer);
               } else {
                 printf("No nodes to send data for\n");
               }

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -8,6 +8,7 @@
 typedef enum {
   REPORT_BUILDER_INCREMENT_SAMPLE_COUNT,
   REPORT_BUILDER_SAMPLE_MESSAGE,
+  REPORT_BUILDER_CHECK_CRC,
 } report_builder_message_e;
 
 typedef struct {

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -13,7 +13,8 @@ typedef struct {
   report_builder_message_e message_type;
   uint64_t node_id;
   uint8_t sensor_type;
-  uint8_t *sensor_data;
+  aanderaa_aggregations_t *sensor_data;
 } report_builder_queue_item_t;
 
 void reportBuilderInit(cfg::Configuration* sys_cfg);
+void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, aanderaa_aggregations_t *sensor_data, report_builder_message_e msg_type);

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -11,12 +11,17 @@ typedef enum {
   REPORT_BUILDER_CHECK_CRC,
 } report_builder_message_e;
 
+typedef enum {
+  AANDERAA_SENSOR_TYPE = 0,
+} report_builder_sensor_type_e;
+
 typedef struct {
   report_builder_message_e message_type;
   uint64_t node_id;
   uint8_t sensor_type;
-  aanderaa_aggregations_t *sensor_data;
+  void *sensor_data;
+  uint32_t sensor_data_size;
 } report_builder_queue_item_t;
 
 void reportBuilderInit(cfg::Configuration* sys_cfg);
-void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, aanderaa_aggregations_t *sensor_data, report_builder_message_e msg_type);
+void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, report_builder_message_e msg_type);

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -4,4 +4,16 @@
 #include "queue.h"
 #include "configuration.h"
 
+typedef enum {
+  REPORT_BUILDER_INCREMENT_SAMPLE_COUNT
+  REPORT_BUILDER_SAMPLE_MESSAGE,
+} report_builder_message_e;
+
+typedef struct {
+  report_builder_message_e message_type;
+  uint64_t node_id;
+  uint8_t sensor_type;
+  uint8_t *sensor_data;
+} report_builder_queue_item_t;
+
 void reportBuilderInit(cfg::Configuration* sys_cfg);

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "configuration.h"
+
+void reportBuilderInit(cfg::Configuration* sys_cfg);

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -3,6 +3,7 @@
 #include "FreeRTOS.h"
 #include "queue.h"
 #include "configuration.h"
+#include "aanderaaController.h"
 
 typedef enum {
   REPORT_BUILDER_INCREMENT_SAMPLE_COUNT,

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -5,7 +5,7 @@
 #include "configuration.h"
 
 typedef enum {
-  REPORT_BUILDER_INCREMENT_SAMPLE_COUNT
+  REPORT_BUILDER_INCREMENT_SAMPLE_COUNT,
   REPORT_BUILDER_SAMPLE_MESSAGE,
 } report_builder_message_e;
 

--- a/src/apps/bridge/task_priorities.h
+++ b/src/apps/bridge/task_priorities.h
@@ -24,6 +24,9 @@
 #define MIDDLEWARE_NET_TASK_PRIORITY 4
 #define BRIDGE_POWER_TASK_PRIORITY  4
 
+// TODO - Think about this and determine what level to put it at
+#define REPORT_BUILDER_TASK_PRIORITY 4
+
 #define AANDERAA_CONTROLLER_TASK_PRIORITY 3
 #define USB_TASK_PRIORITY 3
 #define TOPO_SAMPLER_TASK_PRIORITY 3

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -198,9 +198,8 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
       }
     }
 
-    // TODO - send the crc to the report builder so it can pull the topo list and check if it is bigger
-    // than the last one
-    reportBuilderAddToQueue(0, 0, NULL, REPORT_BUILDER_CHECK_CRC);
+    // The first four inputs are not used by this message type
+    reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
 
   } while (0);
   xSemaphoreGive(_node_list.node_list_mutex);


### PR DESCRIPTION
The report builder gathers samples from the aanderaa controller, creates a corresponding element in a linked list, adds the data to element in an array of length `samplesPerReport`. Then after we reach samplesPerReport samples, the report builder searches through its linked list and looks for elements that correspond to the "max topology" during the "report period". The report builder tracks "max topology" by checking the network CRC periodically and updating the CRC and topology it will use to build the report if its current topology is smaller than the new one. If there is an element in the linked list that is also in the topology the array of samples will be copied into the report. If there is no element in the linked list then the report gets filled with NAN's. Once the entire report is built the report builder publishes the Cbor array to spotter via bm_serial. After publishing the report, the linked list is cleared and all of the network tracking (crc, "max topology") are cleared in the report builders local context to be re-created during the next report window.

Example data being sent out of Spotter:
```
343a0f3044f7c28,27.582,30.562,2.127,1.307,26.942
Current bit offset: 166
Rounded bit offset: 168
New bit offset: 552
10858606t [MS] [INFO] Added message(id: 102 len: 69) to queue MS_Q_LEGACY: (1)!
Message: E6 00 00 00 00 D5 AA A0 12 1D 16 D8 00 06 D4 00 01 00 F5 F8 80 81 81 85 FB 40 3B 95 04 54 EB 05 8F FB 40 3E 8F C7 68 0E 66 E9 FB 40 01 04 33 45 30 3F 0E FB 3F F4 E9 1E 81 A3 DA 3F FB 40 3A F1 2B A1 6E 7A 31
Submitted sensor data to sat/cell queue
```
the CBOR buffer is `81 81 85 FB 40 3B 95 04 54 EB 05 8F FB 40 3E 8F C7 68 0E 66 E9 FB 40 01 04 33 45 30 3F 0E FB 3F F4 E9 1E 81 A3 DA 3F FB 40 3A F1 2B A1 6E 7A 31` and can be
decoded on cbor.me to:
```
[[[27.582097346666668, 30.56163645125972, 2.127050915274487, 1.3069138588013087, 26.942072]]]
from the printout on spotter the means/stdevs:
343a0f3044f7c28, 27.582, 30.562, 2.127, 1.307, 26.942
```
