### PR TITLE
set and get the last known config info

### DIFF
--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -147,6 +147,7 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
           printf("\n");
         }
       }
+      // If we have a new configuration, store it. 
       if(_node_list.last_network_configuration_info.network_crc32 != network_crc32_calc) {
         if(_node_list.last_network_configuration_info.cbor_config_map) {
           vPortFree(_node_list.last_network_configuration_info.cbor_config_map);

--- a/src/lib/common/topology_sampler.h
+++ b/src/lib/common/topology_sampler.h
@@ -11,3 +11,4 @@
 
 void topology_sampler_init(BridgePowerController *power_controller, cfg::Configuration* hw_cfg, cfg::Configuration* sys_cfg);
 bool topology_sampler_get_node_list(uint64_t *node_list, size_t &node_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
+uint8_t* topology_sampler_alloc_last_network_config(uint32_t &network_crc32, uint32_t &cbor_config_size);


### PR DESCRIPTION
Store a  "last-known" crc32 and config for retrieval. 

Protected by the topo sampler mutex.