### PR TITLE
fix: bm cfg of non-neighbors with new link-local forwarding

### DIFF
--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -22,4 +22,5 @@ using namespace cfg;
 
 void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration* user_cfg, Configuration* sys_cfg);
 err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len);
+err_t bcmp_ll_forward(struct pbuf *pbuf, uint8_t ingress_port);
 void bcmp_link_change(uint8_t port, bool state);

--- a/src/lib/bcmp/bcmp_cli.cpp
+++ b/src/lib/bcmp/bcmp_cli.cpp
@@ -385,7 +385,7 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer,
         if(!bcmp_config_status_request(node_id,partition,err)){
           printf("Failed to send status request \n");
         } else {
-          printf("Succesfull status request send\n");
+          printf("Successful status request send\n");
         }
       } else if (strncmp("del", cmd_id_str, cmd_id_str_len) == 0){
         const char *node_id_str;

--- a/src/lib/bcmp/bcmp_config.cpp
+++ b/src/lib/bcmp/bcmp_config.cpp
@@ -389,10 +389,15 @@ static void bcmp_process_del_response_message(bm_common_config_delete_key_respon
     vPortFree(keyprintbuf);
 }
 
-void bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t* payload) {
+/*!
+    \return true if the caller should forward the message, false if the message was handled
+*/
+bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload) {
+    bool should_forward = false;
     do {
         bm_common_config_header_t * msg_header = reinterpret_cast<bm_common_config_header_t *>(payload);
-        if(msg_header->target_node_id != getNodeId()){
+        if (msg_header->target_node_id != getNodeId()) {
+            should_forward = true;
             break;
         }
         switch(bcmp_msg_type){
@@ -449,6 +454,8 @@ void bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t* pay
                 break;
         }
     } while(0);
+
+    return should_forward;
 }
 
 void bcmp_config_init(Configuration* user_cfg, Configuration* sys_cfg) {

--- a/src/lib/bcmp/bcmp_config.h
+++ b/src/lib/bcmp/bcmp_config.h
@@ -17,4 +17,4 @@ bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partit
 bool bcmp_config_status_response(uint64_t target_node_id,bm_common_config_partition_e partition, bool commited, err_t &err);
 bool bcmp_config_del_key(uint64_t target_node_id,bm_common_config_partition_e partition, size_t key_len, const char * key);
 
-void bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t* payload);
+bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload);


### PR DESCRIPTION
Prior to this PR, given a topology of 3 nodes A | B | C, running on node A any `bm cfg` command that targeted node C would fail. The reason was that config commands are sent to the link-local multicast address, and node B, upon finding that it was not the target of the message, simply dropped the packet.

This PR adds the ability in BCMP to forward messages in that scenario, using a feature described in section 5.4.4.2 of the Bristlemouth spec that had not previously been implemented.

> One additional requirement relating to the link-local neighbors-only address, which can help cut down on unnecessary transmissions, is that granular messaging limited to a specific Port can be achieved by setting a destination address with the pattern:
> 
> ff02::000X:1
> 
> Wherein X represents the egress port on which to direct the packet (as opposed to all available ports by default). As with the equivalent global all-nodes address pattern, these four bits shall be cleared before transmission on the relevant port.
> 
> This addressing feature can help to support more efficient execution of higher-level Bristlemouth functions relating to neighbor discovery, capability negotiation, and resource discovery, as these exchanges carry information associated with specific neighbors and network segments, which may not be useful or relevant to nodes on other segments.

---

Other minor changes:

- Renaming `src_port` to `egress_port` and `dst_port` to `ingress_port` for clarity using the unambiguous official terminology from the standard
- Noting in TODO comments some places where the current implementation does not conform to the published standard
- Noting in TODO comments that BCMP assumes a 2-port PHY in this forwarding implementation and that future effort should generalize
- Some clang-format cleanup