### PR TITLE
Sc 197050/remove current agg period min from bridge

### DIFF
--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -55,7 +55,6 @@ typedef struct aanderaaControllerCtx {
   bool _initialized;
   TimerHandle_t _sample_timer;
   BridgePowerController *_bridge_power_controller;
-  cfg::Configuration *_usr_cfg;
   cfg::Configuration *_sys_cfg;
   uint32_t current_reading_period_ms;
 } aanderaaControllerCtx_t;
@@ -153,13 +152,10 @@ void Aanderaa::aanderaSubCallback(uint64_t node_id, const char *topic, uint16_t 
  * It will also aggregate the data from the Aanderaa nodes and transmit it over the spotter_tx service.
  */
 void aanderaControllerInit(BridgePowerController *power_controller,
-                           cfg::Configuration *usr_cfg,
                            cfg::Configuration *sys_cfg) {
   configASSERT(power_controller);
-  configASSERT(usr_cfg);
   configASSERT(sys_cfg);
   _ctx._bridge_power_controller = power_controller;
-  _ctx._usr_cfg = usr_cfg;
   _ctx._sys_cfg = sys_cfg;
 
   _ctx.current_reading_period_ms = DEFAULT_CURRENT_READING_PERIOD_MS;

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -18,6 +18,13 @@ typedef struct aanderaa_aggregations_s {
   double temp_mean_deg_c;
 } aanderaa_aggregations_t;
 
+typedef enum {
+  SAMPLER_TIMER_BITS = 0x01,
+  AGGREGATION_TIMER_BITS = 0x02,
+} aanderaaControllerBits_t;
+
+extern TaskHandle_t aanderaa_controller_task_handle;
+
 #define AANDERAA_NUM_SAMPLE_MEMBERS 5
 
 void aanderaControllerInit(BridgePowerController *power_controller,

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -28,5 +28,4 @@ extern TaskHandle_t aanderaa_controller_task_handle;
 #define AANDERAA_NUM_SAMPLE_MEMBERS 5
 
 void aanderaControllerInit(BridgePowerController *power_controller,
-                           cfg::Configuration *usr_cfg,
                            cfg::Configuration *sys_cfg);

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -375,7 +375,7 @@ static void defaultTask( void *parameters ) {
     debugBmServiceInit();
     sys_info_service_init(debug_configuration_system);
     reportBuilderInit(&debug_configuration_system);
-    aanderaControllerInit(&bridge_power_controller, &debug_configuration_user, &debug_configuration_system);
+    aanderaControllerInit(&bridge_power_controller, &debug_configuration_system);
     config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
                                debug_configuration_user);
     IOWrite(&ALARM_OUT, 1);

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -1,5 +1,6 @@
 #include "bridgePowerController.h"
 #include "FreeRTOS.h"
+#include "aanderaaController.h"
 #include "app_pub_sub.h"
 #include "bm_l2.h"
 #include "bm_serial.h"
@@ -200,11 +201,11 @@ void BridgePowerController::_update(
             BRIDGE_LOG_PRINT("Bridge State Subsampling Off\n");
             uint32_t nextSubsampleEpochS = _subSampleIntervalStartS + _subsampleIntervalS;
             _subSampleIntervalStartS = nextSubsampleEpochS;
-            time_to_sleep_ms = (currentCycleS < nextSubsampleEpochS) ? 
+            time_to_sleep_ms = (currentCycleS < nextSubsampleEpochS) ?
               MAX((nextSubsampleEpochS - currentCycleS) * 1000, MIN_TASK_SLEEP_MS) :
               MIN_TASK_SLEEP_MS;
             // Prevent bus thrash
-            if (nextSubsampleEpochS > currentCycleS) { 
+            if (nextSubsampleEpochS > currentCycleS) {
               powerBusAndSetSignal(false);
             }
             break;
@@ -227,6 +228,7 @@ void BridgePowerController::_update(
         if (nextSampleEpochS > currentCycleS) {
           powerBusAndSetSignal(false);
         }
+        xTaskNotify(aanderaa_controller_task_handle, AGGREGATION_TIMER_BITS, eSetBits);
         break;
       }
     } else { // Sampling Not Enabled

--- a/test/src/common/CMakeLists.txt
+++ b/test/src/common/CMakeLists.txt
@@ -229,6 +229,9 @@ target_include_directories(bridge_power_controller_tests
     ${SRC_DIR}/lib/bcmp/bm
     ${SRC_DIR}/apps/bridge
     ${SRC_DIR}/lib/bm_common_messages
+    ${SRC_DIR}/lib/bcmp/dfu
+    ${SRC_DIR}/lib/drivers/abstract
+    ${SRC_DIR}/third_party/tinycbor/src
 )
 
 target_sources(bridge_power_controller_tests
@@ -246,6 +249,7 @@ target_sources(bridge_power_controller_tests
     ${TEST_DIR}/stubs/mock_device_info.cpp
     ${TEST_DIR}/stubs/mock_bridgeLog.cpp
     ${TEST_DIR}/stubs/mock_bm_l2.cpp
+    ${TEST_DIR}/stubs/mock_aanderaaController.cpp
 
     # Stubs
     ${TEST_DIR}/stubs/FreeRTOSStubs.c
@@ -283,7 +287,7 @@ target_sources(avgSampler
     # File we're testing
     ${SRC_DIR}/lib/common/avgSampler.cpp
 
-    # Support files 
+    # Support files
     ${SRC_DIR}/lib/common/util.c
 
     # Unit test wrapper for test

--- a/test/stubs/mock_aanderaaController.cpp
+++ b/test/stubs/mock_aanderaaController.cpp
@@ -1,0 +1,3 @@
+#include "aanderaaController.h"
+
+TaskHandle_t aanderaa_controller_task_handle = NULL;


### PR DESCRIPTION
Remove the current agg period min config from the bridge and instead us the sample duration to calculate buffer sizes. Also use the sample period end in the bridgePowerController to send a task notification to the aanderaaController to end and aggregation period and send samples to the report builder.