### PR TITLE
Feature/aanderaa ftl improve

### DIFF
--- a/src/lib/common/sensorWatchdog.cpp
+++ b/src/lib/common/sensorWatchdog.cpp
@@ -102,8 +102,10 @@ static void _sensorWatchdogHandler(void *arg) {
         bm_fprintf(0, curr->_logHandle, "[%s] | tick: %" PRIu64 " SensorWatchdog Expired!\n", curr->_id, uptimeGetMs());
     }
     printf("[%s] | tick: %" PRIu64 " SensorWatchdog Expired!\n", curr->_id, uptimeGetMs());
+    configASSERT(xTimerStop(curr->_timerHandle, 0) == pdTRUE);
     curr->_handler(arg);
-    if(curr->_triggerCount < curr->_max_triggers) {
+    configASSERT(xTimerReset(curr->_timerHandle, pdMS_TO_TICKS(WATCHDOG_PET_TIMEOUT_MS)) == pdTRUE);
+  if(curr->_triggerCount < curr->_max_triggers) {
         curr->_triggerCount++;
     } else {
         configASSERT(xTimerStop(curr->_timerHandle, 0) == pdTRUE);


### PR DESCRIPTION
See notion page for testing details: https://www.notion.so/sofarocean/FTL-recovery-works-Manually-stop-aanderaa-to-test-edb988cab3a3467caf2aab9f980fcb11

- When attempting Aanderaa FTL recovery, disable the Mote VBUS switch in addition to Vout buck.
- Add a Tx tickle to drain Aanderaa processor power and allow short `AANDERAA_RESET_TIME_MS` off time.

### Testing
- verify no recovery attempts are made in happy path for ~1 hour bench soak.
- verify successful recovery from a forced `stop` condition ~5 times manually.
- verify successful reset from a running condition when FTL timer set below reading interval ~5 times manually.
- verified new sensorWatchdog timer control allows WD intervals to be << user callback delay.
- verify (3) recovery attempts then give up when Aanderaa disconnected.