### PR TITLE
Sc 195977/add bringup uart configurability

### DIFF
--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -306,6 +306,8 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
                       3, // Get the rest of the parameters
                       &parameterStringLength);
 
+      LL_USART_Disable((USART_TypeDef *)handle->device);
+
       if (strncmp("high", parameter, parameterStringLength) == 0) {
         LL_USART_SetRXPinLevel((USART_TypeDef *)handle->device, LL_USART_RXPIN_LEVEL_STANDARD);
       } else if (strncmp("low", parameter, parameterStringLength) == 0) {
@@ -314,6 +316,8 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
         printf("ERR Invalid paramters\n");
         break;
       }
+
+      LL_USART_Enable((USART_TypeDef *)handle->device);
       printf("OK\n");
     } else if (strncmp("baud", parameter, parameterStringLength) == 0) {
       BaseType_t handle_string_len;

--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -172,7 +172,10 @@ static const CLI_Command_Definition_t cmdSerial = {
   "serial:\n"
   " * serial list\n"
   " * serial enable <interface>\n"
-  " * serial tx <interface> <message>\n",
+  " * serial tx <interface> <message>\n"
+  " * serial baud <baudrate>\n"
+  " * serial rxLevel <interface> <high/low>\n"
+  " * serial disable <interface>\n",
   // Command function
   debugSerialCommand,
   // Number of parameters (variable)
@@ -285,6 +288,86 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
       // Transmit bytes
       // should have generic tx task for all interfaces?
 
+    } else if (strncmp("rxLevel", parameter, parameterStringLength) == 0) {
+
+      parameter = FreeRTOS_CLIGetParameter(
+                      commandString,
+                      2, // Get the second parameter (serial interface)
+                      &parameterStringLength);
+      SerialHandle_t *handle = serialFindInterface(parameter, parameterStringLength);
+
+      if (handle == NULL) {
+        printf("ERR Invalid interface\n");
+        break;
+      }
+
+      parameter = FreeRTOS_CLIGetParameter(
+                      commandString,
+                      3, // Get the rest of the parameters
+                      &parameterStringLength);
+
+      if (strncmp("high", parameter, parameterStringLength) == 0) {
+        LL_USART_SetRXPinLevel((USART_TypeDef *)handle, LL_USART_RXPIN_LEVEL_STANDARD);
+      } else if (strncmp("low", parameter, parameterStringLength) == 0) {
+        LL_USART_SetRXPinLevel((USART_TypeDef *)handle, LL_USART_RXPIN_LEVEL_INVERTED);
+      } else {
+        printf("ERR Invalid paramters\n");
+        break;
+      }
+      printf("OK\n");
+    } else if (strncmp("baud", parameter, parameterStringLength) == 0) {
+      BaseType_t handle_string_len;
+      const char* handle_string = FreeRTOS_CLIGetParameter(
+                      commandString,
+                      2, // Get the second parameter (serial interface)
+                      &handle_string_len);
+      SerialHandle_t *handle = serialFindInterface(handle_string, handle_string_len);
+
+      if (handle == NULL) {
+        printf("ERR Invalid interface\n");
+        break;
+      }
+
+      parameter = FreeRTOS_CLIGetParameter(
+                      commandString,
+                      3, // Get the rest of the parameters
+                      &parameterStringLength);
+
+      uint32_t new_baud = atoi(parameter);
+      if (new_baud == 0) {
+        printf("ERR Invalid baud\n");
+        break;
+      }
+      if (strncmp(handle_string, "lpuart", handle_string_len) == 0) {
+        LL_LPUART_SetBaudRate((USART_TypeDef *)handle,
+                        LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE),
+                        LL_LPUART_PRESCALER_DIV64, new_baud);
+      } else if (strncmp(handle_string, "usart1", handle_string_len) == 0) {
+        // TODO - verify prescaler and oversampling
+        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+                        LL_RCC_GetUSARTClockFreq(LL_RCC_USART1_CLKSOURCE),
+                        LL_USART_PRESCALER_DIV1,
+                        LL_USART_OVERSAMPLING_16,
+                        new_baud);
+      } else if (strncmp(handle_string, "usart2", handle_string_len) == 0) {
+        // TODO - verify prescaler and oversampling
+        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+                        LL_RCC_GetUSARTClockFreq(LL_RCC_USART2_CLKSOURCE),
+                        LL_USART_PRESCALER_DIV1,
+                        LL_USART_OVERSAMPLING_16,
+                        new_baud);
+      } else if (strncmp(handle_string, "usart3", handle_string_len) == 0) {
+        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+                        LL_RCC_GetUSARTClockFreq(LL_RCC_USART3_CLKSOURCE),
+                        LL_USART_PRESCALER_DIV1,
+                        LL_USART_OVERSAMPLING_16,
+                        new_baud);
+      } else {
+        printf("ERR Invalid paramters\n");
+        break;
+      }
+
+      printf("OK\n");
     } else {
       printf("ERR Invalid paramters\n");
       break;

--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -18,12 +18,10 @@
 #include "debug.h"
 #include "bsp.h"
 #include "task_priorities.h"
-// #include "log.h"
 
 static void processLineBufferedRxByte(void *serialHandle, uint8_t byte);
 static void printLine(void *serialHandle, uint8_t *line, size_t len);
 
-// Log_t *UARTLog;
 
 #ifdef DEBUG_USE_LPUART1
 #define LPUART1_LINE_BUFF_LEN 64
@@ -496,10 +494,11 @@ static void processLineBufferedRxByte(void *serialHandle, uint8_t byte) {
 
     lineBuffer->idx++;
 
-    // Heavy handed way of dealing with overflow for now
-    // Later we can just purge the buffer
-    // TODO - log error and clear buffer instead
-    configASSERT((lineBuffer->idx + 1) < lineBuffer->len);
+    if (lineBuffer->idx >= lineBuffer->len) {
+      printf("[%s] Line buffer overflowed, clearing!\n", handle->name);
+      memset(lineBuffer->buffer, 0, lineBuffer->len);
+      lineBuffer->idx = 0;
+    }
   }
 }
 
@@ -512,7 +511,6 @@ static void printLine(void *serialHandle, uint8_t *line, size_t len) {
   // Not using len right now
   (void) len;
 
-  // logPrint(UARTLog, LOG_LEVEL_DEBUG, "[%s] %s", handle->name, line);
   printf("[%s] %s", handle->name, line);
 }
 

--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -173,7 +173,7 @@ static const CLI_Command_Definition_t cmdSerial = {
   " * serial list\n"
   " * serial enable <interface>\n"
   " * serial tx <interface> <message>\n"
-  " * serial baud <baudrate>\n"
+  " * serial baud <interface> <baudrate>\n"
   " * serial rxLevel <interface> <high/low>\n"
   " * serial disable <interface>\n",
   // Command function
@@ -307,9 +307,9 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
                       &parameterStringLength);
 
       if (strncmp("high", parameter, parameterStringLength) == 0) {
-        LL_USART_SetRXPinLevel((USART_TypeDef *)handle, LL_USART_RXPIN_LEVEL_STANDARD);
+        LL_USART_SetRXPinLevel((USART_TypeDef *)handle->device, LL_USART_RXPIN_LEVEL_STANDARD);
       } else if (strncmp("low", parameter, parameterStringLength) == 0) {
-        LL_USART_SetRXPinLevel((USART_TypeDef *)handle, LL_USART_RXPIN_LEVEL_INVERTED);
+        LL_USART_SetRXPinLevel((USART_TypeDef *)handle->device, LL_USART_RXPIN_LEVEL_INVERTED);
       } else {
         printf("ERR Invalid paramters\n");
         break;
@@ -339,25 +339,25 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
         break;
       }
       if (strncmp(handle_string, "lpuart", handle_string_len) == 0) {
-        LL_LPUART_SetBaudRate((USART_TypeDef *)handle,
+        LL_LPUART_SetBaudRate((USART_TypeDef *)handle->device,
                         LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE),
                         LL_LPUART_PRESCALER_DIV64, new_baud);
       } else if (strncmp(handle_string, "usart1", handle_string_len) == 0) {
         // TODO - verify prescaler and oversampling
-        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+        LL_USART_SetBaudRate((USART_TypeDef *)handle->device,
                         LL_RCC_GetUSARTClockFreq(LL_RCC_USART1_CLKSOURCE),
                         LL_USART_PRESCALER_DIV1,
                         LL_USART_OVERSAMPLING_16,
                         new_baud);
       } else if (strncmp(handle_string, "usart2", handle_string_len) == 0) {
         // TODO - verify prescaler and oversampling
-        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+        LL_USART_SetBaudRate((USART_TypeDef *)handle->device,
                         LL_RCC_GetUSARTClockFreq(LL_RCC_USART2_CLKSOURCE),
                         LL_USART_PRESCALER_DIV1,
                         LL_USART_OVERSAMPLING_16,
                         new_baud);
       } else if (strncmp(handle_string, "usart3", handle_string_len) == 0) {
-        LL_USART_SetBaudRate((USART_TypeDef *)handle,
+        LL_USART_SetBaudRate((USART_TypeDef *)handle->device,
                         LL_RCC_GetUSARTClockFreq(LL_RCC_USART3_CLKSOURCE),
                         LL_USART_PRESCALER_DIV1,
                         LL_USART_OVERSAMPLING_16,

--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -340,17 +340,19 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
         printf("ERR Invalid baud\n");
         break;
       }
-      if (strncmp(handle_string, "lpuart", handle_string_len) == 0) {
-        LL_LPUART_SetBaudRate((USART_TypeDef *)handle->device,
-                        LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE),
-                        LL_LPUART_PRESCALER_DIV64, new_baud);
-      } else if (strncmp(handle_string, "usart1", handle_string_len) == 0) {
+      if (strncmp(handle_string, "usart1", handle_string_len) == 0)  {
         // TODO - verify prescaler and oversampling
         LL_USART_SetBaudRate((USART_TypeDef *)handle->device,
                         LL_RCC_GetUSARTClockFreq(LL_RCC_USART1_CLKSOURCE),
                         LL_USART_PRESCALER_DIV1,
                         LL_USART_OVERSAMPLING_16,
                         new_baud);
+#ifdef DEBUG_USE_LPUART1
+      } else if (strncmp(handle_string, "lpuart", handle_string_len) == 0){
+        LL_LPUART_SetBaudRate((USART_TypeDef *)handle->device,
+                        LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE),
+                        LL_LPUART_PRESCALER_DIV64, new_baud);
+#endif
       } else if (strncmp(handle_string, "usart2", handle_string_len) == 0) {
         // TODO - verify prescaler and oversampling
         LL_USART_SetBaudRate((USART_TypeDef *)handle->device,

--- a/src/lib/debug/debug_uart.c
+++ b/src/lib/debug/debug_uart.c
@@ -311,6 +311,7 @@ static BaseType_t debugSerialCommand(char *writeBuffer,
       } else if (strncmp("low", parameter, parameterStringLength) == 0) {
         LL_USART_SetRXPinLevel((USART_TypeDef *)handle->device, LL_USART_RXPIN_LEVEL_INVERTED);
       } else {
+        LL_USART_Enable((USART_TypeDef *)handle->device);
         printf("ERR Invalid paramters\n");
         break;
       }


### PR DESCRIPTION
Adding the ability to change the baud of the USARTs/LPUART when using debug_uart.c. This is to allow the testing of SDI-12 with the bringup_mote app. Furthermore, to support this I added the ability to set the rx pin level high/low, as it needs to be low(inverted) for SDI-12. Lastly, I got rid of the configAssert when the RX line buffer overflows. Instead I added a print statement, clear the memory and reset the index to 0. 

### Example back and forth via SDI-12 on two bringup_mote's

Also note the gpio pins that need to be set!
Sender gpios:
 - `gpio clr vbus_5v_en`
 - `gpio clr bf_5v_en`
 
Receiver Gpios:
 - `gpio clr vbus_5v_en`
 - `gpio clr bf_5v_en`
 - `gpio set bf_sdi12_oe`

Serial settings:
- `serial rxLevel lpuart low`
- `serial baud lpuart 1200`
- `serial enable lpuart`
  
<img width="650" alt="Screen Shot 2023-11-28 at 2 51 55 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/bf755b18-eea6-4537-ade0-30e8307278c7">

### Trace from SDI-12 transaction (Also traced the Tx/RX lines of the UART)
![Screen Shot 2023-11-28 at 2 54 10 PM](https://github.com/bristlemouth/bm_protocol/assets/85895527/24b4810c-84b6-4462-a2d9-394df1d88089)
### Showing the settings of the logic analyzer
![Screen Shot 2023-11-28 at 2 54 28 PM](https://github.com/bristlemouth/bm_protocol/assets/85895527/4a69a3d7-46b7-49fa-abce-001fbccc2096)

## Example buffer overflow:
<img width="1071" alt="Screen Shot 2023-11-28 at 3 05 19 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/acd5ab9c-5ae4-46b9-b6fa-3461e47ddf3d">
