### PR TITLE
adding new fields

### DIFF
--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -275,8 +275,10 @@ static void runController(void *param) {
                               "%.3f,"        // abs_speed_std_cm_s
                               "%.3f,"        // direction_circ_mean_rad
                               "%.3f,"        // direction_circ_std_rad
+                              "%.3f,"        // temp_mean_deg_c
                               "%.3f,"        // abs_tilt_mean_rad
-                              "%.3f\n",      // temp_mean_deg_c
+                              "%.3f,"        // std_tilt_mean_rad
+                              "%" PRIu32 "\n", // reading_count
                               timeStrbuf,
                               curr->node_id,
                               curr->abs_speed_cm_s.getNumSamples(),
@@ -284,8 +286,10 @@ static void runController(void *param) {
                               agg.abs_speed_std_cm_s,
                               agg.direction_circ_mean_rad,
                               agg.direction_circ_std_rad,
+                              agg.temp_mean_deg_c,
                               agg.abs_tilt_mean_rad,
-                              agg.temp_mean_deg_c);
+                              agg.std_tilt_mean_rad,
+                              agg.reading_count);
             if (log_buflen > 0) {
               BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_AGG, log_buf, log_buflen);
             } else {
@@ -339,7 +343,8 @@ static void createAanderaaSub(uint64_t node_id) {
   new_sub->direction_rad.initBuffer(AVERAGER_MAX_SAMPLES);
   new_sub->temp_deg_c.initBuffer(AVERAGER_MAX_SAMPLES);
   new_sub->abs_tilt_rad.initBuffer(AVERAGER_MAX_SAMPLES);
-
+  new_sub->std_tilt_rad.initBuffer(AVERAGER_MAX_SAMPLES);
+  new_sub->reading_count = 0;
   if (_ctx._subbed_aanderaas == NULL) {
     _ctx._subbed_aanderaas = new_sub;
   } else {

--- a/src/apps/bridge/aanderaaController.cpp
+++ b/src/apps/bridge/aanderaaController.cpp
@@ -69,6 +69,8 @@ static constexpr uint32_t TOPO_TIMEOUT_MS = 10 * 1000;
 static constexpr uint32_t NODE_INFO_TIMEOUT_MS = 1000;
 static constexpr double DIRECTION_SAMPLE_MEMBER_MIN = 0.0;
 static constexpr double DIRECTION_SAMPLE_MEMBER_MAX = M_TWOPI;
+static constexpr double TILT_SAMPLE_MEMBER_MIN = 0.0;
+static constexpr double TILT_SAMPLE_MEMBER_MAX = M_PI_2;
 static constexpr double ABS_SPEED_SAMPLE_MEMBER_MIN = 0.0;
 static constexpr double ABS_SPEED_SAMPLE_MEMBER_MAX = 300.0;
 static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5.0;
@@ -254,10 +256,10 @@ static void runController(void *param) {
               if (agg.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN || agg.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
                 agg.temp_mean_deg_c = NAN;
               }
-              if (agg.abs_tilt_mean_rad < DIRECTION_SAMPLE_MEMBER_MIN || agg.abs_tilt_mean_rad > DIRECTION_SAMPLE_MEMBER_MAX) {
+              if (agg.abs_tilt_mean_rad < TILT_SAMPLE_MEMBER_MIN || agg.abs_tilt_mean_rad > TILT_SAMPLE_MEMBER_MAX) {
                 agg.abs_tilt_mean_rad = NAN;
               }
-              if (agg.std_tilt_mean_rad < DIRECTION_SAMPLE_MEMBER_MIN || agg.std_tilt_mean_rad > DIRECTION_SAMPLE_MEMBER_MAX) {
+              if (agg.std_tilt_mean_rad < TILT_SAMPLE_MEMBER_MIN || agg.std_tilt_mean_rad > TILT_SAMPLE_MEMBER_MAX) {
                 agg.std_tilt_mean_rad = NAN;
               }
             }

--- a/src/apps/bridge/aanderaaController.h
+++ b/src/apps/bridge/aanderaaController.h
@@ -16,6 +16,9 @@ typedef struct aanderaa_aggregations_s {
   double direction_circ_mean_rad;
   double direction_circ_std_rad;
   double temp_mean_deg_c;
+  double abs_tilt_mean_rad;
+  double std_tilt_mean_rad;
+  uint32_t reading_count;
 } aanderaa_aggregations_t;
 
 typedef enum {
@@ -25,7 +28,7 @@ typedef enum {
 
 extern TaskHandle_t aanderaa_controller_task_handle;
 
-#define AANDERAA_NUM_SAMPLE_MEMBERS 5
+#define AANDERAA_NUM_SAMPLE_MEMBERS 8
 
 void aanderaControllerInit(BridgePowerController *power_controller,
                            cfg::Configuration *sys_cfg);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -36,7 +36,10 @@ static aanderaa_aggregations_t NAN_AGG = {.abs_speed_mean_cm_s = NAN,
                                            .abs_speed_std_cm_s = NAN,
                                            .direction_circ_mean_rad = NAN,
                                            .direction_circ_std_rad = NAN,
-                                           .temp_mean_deg_c = NAN};
+                                           .temp_mean_deg_c = NAN,
+                                           .abs_tilt_mean_rad = NAN,
+                                           .std_tilt_mean_rad = NAN,
+                                           .reading_count = 0};
 
 class ReportBuilderLinkedList {
   private:
@@ -252,6 +255,13 @@ CborError encode_double_sample_member(CborEncoder &sample_array, void* sample_me
   return err;
 }
 
+CborError encode_uint_sample_member(CborEncoder &sample_array, void* sample_member){
+  uint32_t local_sample_member = *(uint32_t*)sample_member;
+  CborError err = CborNoError;
+  err = cbor_encode_uint(&sample_array, local_sample_member);
+  return err;
+}
+
 /**
  * @brief Adds a new item to the report builder queue.
  *
@@ -325,6 +335,18 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
         break;
       }
       if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.temp_mean_deg_c) != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
+      }
+      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_tilt_mean_rad) != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
+      }
+      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.std_tilt_mean_rad) != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+        break;
+      }
+      if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member, &aanderaa_sample.reading_count) != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
         break;
       }


### PR DESCRIPTION
Testing:

Tested with: https://github.com/wavespotter/fleet-spotter-fw/pull/804#pullrequestreview-1757973664

```
2023-11-30T00:05:57.800Z [BRIDGE_SYS] [INFO] Found data for node c893b2eb471c5c0d adding it to the the report
Current bit offset: 166
Rounded bit offset: 168
New bit offset: 264
2023-11-30T00:05:57.812Z [MS] [INFO] Added message(id: 2 len: 33) to queue MS_Q_LEGACY: (3)!
Message: E6 65 67 D1 E5 CF FF A0 12 01 A6 D8 00 06 D4 00 02 82 37 01 34 29 8A 51 85 54 C0 31 54 E8 69 48 0C
```


```
Aggregation period done!
[AANDERAA_AGG] 1701302757.050,c893b2eb471c5c0d,6,53.167,52.174,2.726,0.049,22.167,0.134,0.413,6
```