### PR TITLE
fix: reuse abs speed mean for std calculation

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -97,7 +97,7 @@ void AanderaaSensor::aggregate(void) {
     // TODO - verify that we can assume if one sampler is below the min then all of them are.
     if(abs_speed_cm_s.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       agg.abs_speed_mean_cm_s = abs_speed_cm_s.getMean(true);
-      agg.abs_speed_std_cm_s = abs_speed_cm_s.getStd(true);
+      agg.abs_speed_std_cm_s = abs_speed_cm_s.getStd(agg.abs_speed_mean_cm_s, 0.0, true);
       agg.direction_circ_mean_rad = direction_rad.getCircularMean();
       agg.direction_circ_std_rad = direction_rad.getCircularStd();
       agg.temp_mean_deg_c = temp_deg_c.getMean(true);


### PR DESCRIPTION
The single argument `true` is being converted to the double value `1.0` for the first argument "mean", rather than the third `bool` arg `useKahan` as we intended. The output data is consistent with a mean of 1.0. The C++ compiler cares more about argument position than it cares about type (bool vs double).