### PR TITLE
Log Single Ping STD

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -57,13 +57,13 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
             "%.3f,"        // heading_deg_m
             "%.3f,"        // max_tilt_deg
             "%.3f,"        // ping_count
-            "%.3f,"        // standard_ping_std_cm_s
+            "%.3f,"        // single_ping_std_cm_s
             "%.3f,"        // std_tilt_deg
             "%.3f,"        // temperature_deg_c
             "%.3f\n",      // north_cm_s
             node_id, d.header.reading_uptime_millis, d.header.reading_time_utc_s,
             d.header.sensor_reading_time_s, d.abs_speed_cm_s, d.abs_tilt_deg, d.direction_deg_m,
-            d.east_cm_s, d.heading_deg_m, d.max_tilt_deg, d.ping_count, d.standard_ping_std_cm_s,
+            d.east_cm_s, d.heading_deg_m, d.max_tilt_deg, d.ping_count, d.single_ping_std_cm_s,
             d.std_tilt_deg, d.temperature_deg_c, d.north_cm_s);
         if (log_buflen > 0) {
           BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_IND, log_buf, log_buflen);
@@ -131,7 +131,7 @@ void AanderaaSensor::aggregate(void) {
     if(!logRtcGetTimeStr(timeStrbuf, TIME_STR_BUFSIZE,true)){
       printf("Failed to get time string for Aanderaa aggregation\n");
       snprintf(timeStrbuf, TIME_STR_BUFSIZE, "0");
-    }; 
+    };
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                     "%s,"          // timestamp(ticks/UTC)
                     "%" PRIx64 "," // Node Id

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -79,11 +79,11 @@ static void spoof_aanderaa(void);
 
 /// For Turning Text Into Numbers
 #ifdef AANDERAA_BLUE
-#define NUM_PARAMS_TO_AGG                                                                      \
-  13 // Need to manually adjust current_data, valueTypes and keys when changing
+// Need to manually adjust current_data, valueTypes and keys when changing
+#define NUM_PARAMS_TO_AGG 14
 #else
-#define NUM_PARAMS_TO_AGG                                                                      \
-  12 // Need to manually adjust current_data, valueTypes and keys when changing
+// Need to manually adjust current_data, valueTypes and keys when changing
+#define NUM_PARAMS_TO_AGG 13
 #endif
 
 typedef struct {
@@ -113,6 +113,7 @@ static const char lineHeader[] = "MEASUREMENT";
 static ValueType valueTypes[NUM_PARAMS_TO_AGG] = {
     TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,
     TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,
+    TYPE_DOUBLE,
 #ifdef AANDERAA_BLUE
     TYPE_DOUBLE
 #endif
@@ -124,6 +125,7 @@ static const char *keys[] = {"Abs Speed[cm/s]",
                              "Heading[Deg.M]",
                              "Tilt X[Deg]",
                              "Tilt Y[Deg]",
+                             "SP Std[cm/s]",
                              "Ping Count",
                              "Abs Tilt[Deg]",
                              "Max Tilt[Deg]",
@@ -142,6 +144,7 @@ typedef enum AadneraaKeysIdx {
   HEADING,
   TILT_X,
   TILT_Y,
+  SP_STD,
   PING_COUNT,
   ABS_TILT,
   MAX_TILT,
@@ -418,6 +421,7 @@ void loop(void) {
     d.east_cm_s = getDoubleOrNaN(parser.getValue(EAST));
     d.heading_deg_m = getDoubleOrNaN(parser.getValue(HEADING));
     d.north_cm_s = getDoubleOrNaN(parser.getValue(NORTH));
+    d.single_ping_std_cm_s = getDoubleOrNaN(parser.getValue(SP_STD));
     d.ping_count = getDoubleOrNaN(parser.getValue(PING_COUNT));
     d.tilt_x_deg = getDoubleOrNaN(parser.getValue(TILT_X));
     d.tilt_y_deg = getDoubleOrNaN(parser.getValue(TILT_Y));


### PR DESCRIPTION
this PR makes sure the aanderaa motes send the single ping std and that the bridge reads and logs the single ping std.

After testing here is a log where the 12th element (after the 60.000) is  the single ping std. 
```
Node Id,reading_uptime_millis,reading_time_utc_s,sensor_reading_time_s,abs_speed_cm_s,abs_tilt_deg,direction_deg_m,east_cm_s,heading_deg_m,max_tilt_deg,ping_count,standard_ping_std_cm_s,std_tilt_deg,temperature_deg_c,north_cm_s
55771caa48d84607,62699,1701800846,0,1.961,2.186,271.426,-1.960,254.442,2.563,60.000,102.494,0.079,19.180,0.049
55771caa48d84607,122701,1701800906,0,10.119,2.193,270.909,-10.118,252.778,2.261,60.000,93.550,0.040,19.327,0.160
55771caa48d84607,182693,1701800966,0,53.176,2.136,6.453,5.976,250.813,2.171,60.000,90.398,0.020,19.450,52.839
55771caa48d84607,242699,1701801026,0,14.195,2.117,322.184,-8.703,250.764,2.174,60.000,86.525,0.019,19.561,11.214
55771caa48d84607,302691,1701801086,0,20.342,2.107,41.080,13.367,250.576,2.163,60.000,77.303,0.015,19.667,15.334
```