### PR TITLE
Feature/log bridges pclr

### DIFF
--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -5,10 +5,10 @@
 #include "device_info.h"
 #include "bm_serial.h"
 
-void bridgeLogPrintf(const char *str, size_t len) {  
+void bridgeLogPrintf(const char *str, size_t len) {
     printf("%.*s", len, str);
     bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE, APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION);
-}   
+}
 
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len) {
     if(len > 0){

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -21,6 +21,7 @@
 #include "ncp_dfu.h"
 #include "ncp_config.h"
 #include "reset_reason.h"
+#include "memfault_platform_core.h"
 #include "memfault/core/reboot_tracking.h"
 #include "gpio.h"
 
@@ -346,7 +347,7 @@ void ncpInit(SerialHandle_t *ncpUartHandle, NvmPartition *dfu_partition, BridgeP
 
   serialEnable(ncpSerialHandle);
   ncp_dfu_check_for_update();
-  bm_serial_send_reboot_info(getNodeId(), checkResetReason(), getGitSHA(), memfault_reboot_tracking_get_crash_count());
+  bm_serial_send_reboot_info(getNodeId(), checkResetReason(), getGitSHA(), memfault_reboot_tracking_get_crash_count(), memfault_get_pc(), memfault_get_lr());
 }
 
 void ncpRXTask( void *parameters) {

--- a/src/lib/memfault/memfault_platform_core.h
+++ b/src/lib/memfault/memfault_platform_core.h
@@ -3,7 +3,6 @@
 //
 
 #pragma once
-
 #include "memfault/core/platform/debug_log.h"
 #include "memfault/core/platform/device_info.h"
 #include "memfault/core/data_packetizer.h"
@@ -27,6 +26,8 @@ int memfault_platform_start(void);
 void memfault_enable_mpu();
 bool memfault_threadsafe_packetizer_get_chunk_from_source(void* chunk_buff, size_t* chunk_len, uint32_t src_mask);
 bool memfault_threadsafe_packetizer_is_data_available_from_source(uint32_t src_mask);
+uint32_t memfault_get_pc(void);
+uint32_t memfault_get_lr(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/third_party/memfault.cmake
+++ b/src/third_party/memfault.cmake
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.18)
 
 # Add sdk files as suggest here:
 # https://github.com/memfault/memfault-firmware-sdk#add-sources-to-build-system
-set(MEMFAULT_DIR ${CMAKE_SOURCE_DIR}/src)
+set(MEMFAULT_DIR ${CMAKE_SOURCE_DIR}/src/third_party/memfault-firmware-sdk)
+message(STATUS "MEMFAULT_DIR: ${MEMFAULT_DIR}")
 set(MEMFAULT_SDK_ROOT ${CMAKE_SOURCE_DIR}/src/third_party/memfault-firmware-sdk)
 list(APPEND MEMFAULT_COMPONENTS "core" "util" "panics" "metrics" "http")
 include(${MEMFAULT_SDK_ROOT}/cmake/Memfault.cmake)
 memfault_library(${MEMFAULT_SDK_ROOT} MEMFAULT_COMPONENTS
  MEMFAULT_COMPONENTS_SRCS MEMFAULT_COMPONENTS_INC_FOLDERS)
+message(STATUS "MEMFAULT_COMPONENTS_INC_FOLDERS: ${MEMFAULT_COMPONENTS_INC_FOLDERS}")
 
 set(MEMFAULT_PORT_ROOT ${MEMFAULT_SDK_ROOT}/ports)
 set(MEMFAULT_FREERTOS_PORT_ROOT ${MEMFAULT_PORT_ROOT}/freertos)
@@ -34,6 +36,7 @@ set(MEMFAULT_SOURCES
 set(MEMFAULT_INCLUDES
     ${MEMFAULT_COMPONENTS_INC_FOLDERS}
     ${MEMFAULT_DIR}/
+    ${MEMFAULT_DIR}/components/core/src
     ${MEMFAULT_FREERTOS_PORT_ROOT}/include
     ${MEMFAULT_PORT_ROOT}/include
     )

--- a/src/third_party/memfault.cmake
+++ b/src/third_party/memfault.cmake
@@ -2,14 +2,12 @@ cmake_minimum_required(VERSION 3.18)
 
 # Add sdk files as suggest here:
 # https://github.com/memfault/memfault-firmware-sdk#add-sources-to-build-system
-set(MEMFAULT_DIR ${CMAKE_SOURCE_DIR}/src/third_party/memfault-firmware-sdk)
-message(STATUS "MEMFAULT_DIR: ${MEMFAULT_DIR}")
+set(MEMFAULT_DIR ${CMAKE_SOURCE_DIR}/src)
 set(MEMFAULT_SDK_ROOT ${CMAKE_SOURCE_DIR}/src/third_party/memfault-firmware-sdk)
 list(APPEND MEMFAULT_COMPONENTS "core" "util" "panics" "metrics" "http")
 include(${MEMFAULT_SDK_ROOT}/cmake/Memfault.cmake)
 memfault_library(${MEMFAULT_SDK_ROOT} MEMFAULT_COMPONENTS
  MEMFAULT_COMPONENTS_SRCS MEMFAULT_COMPONENTS_INC_FOLDERS)
-message(STATUS "MEMFAULT_COMPONENTS_INC_FOLDERS: ${MEMFAULT_COMPONENTS_INC_FOLDERS}")
 
 set(MEMFAULT_PORT_ROOT ${MEMFAULT_SDK_ROOT}/ports)
 set(MEMFAULT_FREERTOS_PORT_ROOT ${MEMFAULT_PORT_ROOT}/freertos)
@@ -36,7 +34,7 @@ set(MEMFAULT_SOURCES
 set(MEMFAULT_INCLUDES
     ${MEMFAULT_COMPONENTS_INC_FOLDERS}
     ${MEMFAULT_DIR}/
-    ${MEMFAULT_DIR}/components/core/src
+    ${MEMFAULT_SDK_ROOT}/components/core/src/
     ${MEMFAULT_FREERTOS_PORT_ROOT}/include
     ${MEMFAULT_PORT_ROOT}/include
     )


### PR DESCRIPTION
On boot let's get the PC/LR from the Memfault SDK so we can send it and log it.

Example of the the PC/LR coming from the bridge log:
```
First power on after flash:
Reboot cnt: 0 PC: 0x0 LR: 0x0

Debug crash
Reboot cnt: 1 PC: 0x801f39c LR: 0x8026665

(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0x801f39c
debugCommand(char*, unsigned int, char const*) at ./src/./lib/debug/debug_sys.cpp:313
(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0x8026665
FreeRTOS_CLIProcessCommand at ./src/./third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c:213


Debug hard fault:
Reboot cnt: 2 PC: 0x801f384 LR: 0x801f37b

(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0x801f384
debugCommand(char*, unsigned int, char const*) at ./src/./lib/debug/debug_sys.cpp:316
(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0x801f37b
debugCommand(char*, unsigned int, char const*) at ./src/./lib/debug/debug_sys.cpp:314

Debug hang:
Reboot cnt: 3 PC: 0x801cb58 LR: 0xffffffbc

(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0x801cb58
IWDG_IRQHandler at ./src/./lib/common/watchdog.c:60
(bristlemouth) ➜  src git:(feature/log_bridges_pclr) ✗ arm-none-eabi-addr2line -pCf -e bridge_v1_0-bridge-dbg.elf 0xffffffbc
?? ??:0
```
And the crash locations:
![Screen Shot 2023-12-06 at 11 43 50 AM](https://github.com/bristlemouth/bm_protocol/assets/85895527/2c03227a-eb33-4611-b62e-07ef4218a45b)

![Screen Shot 2023-12-06 at 11 44 20 AM](https://github.com/bristlemouth/bm_protocol/assets/85895527/bb233b3d-ce00-4436-8da5-9fa254ca88d7)

