### PR TITLE
[CI] Rename output files

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -53,9 +53,9 @@ class AutoBuilder:
         self.sign = False
         self.encrypt = False
         self.version = None
-        self.ed25519_priv_key = None
+        self.ed25519_priv_key: str | None = None
         self.ed25519_priv_key_file = None
-        self.x25519_priv_key = None
+        self.x25519_priv_key: str | None = None
         self.x25519_priv_key_file = None
 
     # Get all the configs from the .yml file
@@ -184,6 +184,8 @@ class AutoBuilder:
 
         if self.version and len(self.version):
             cmd += [f"--version={self.version}"]
+
+        cmd += ["--output-name", config["name"]]
 
         result = self.run_command(cmd)
 

--- a/tools/scripts/release/readme_template.txt
+++ b/tools/scripts/release/readme_template.txt
@@ -41,7 +41,7 @@ You'll need to have [dfu-util](http://dfu-util.sourceforge.net/) installed.
 On MacOS just `brew install dfu-util`, on Ubuntu just `apt-get install dfu-util`
 
 Connect a USB cable from your computer to the Bristlemouth node and open a
-serial terminal using pyserial-miniterm or similar. If the device already has
+serial terminal using pyserial-miniterm or similar. If the device has
 already been flashed, you can enter the ROM bootloader by typing the
 `bootloader` command over the USB console. Otherwise, you need to hold the BOOT
 button while pressing and releasing the reset button to enter the bootloader.

--- a/tools/scripts/release/release.py
+++ b/tools/scripts/release/release.py
@@ -126,11 +126,13 @@ if source_version["is_eng"]:
 # First name in sorted list is imagename.elf
 base_name = os.path.splitext(os.path.basename(files[0]))[0]
 
+new_base_name = base_name
 if args.output_name:
-    base_name = args.output_name
+    new_base_name = args.output_name
 
 # Add version to basename
-new_base_name = f"{base_name}-{source_version['version_str']}"
+new_base_name += f"-{source_version['version_str']}"
+
 new_exec_name = args.executable.replace(base_name, new_base_name)
 
 # Variables to replace in readme_template.txt

--- a/tools/scripts/release/release.py
+++ b/tools/scripts/release/release.py
@@ -21,6 +21,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument("executable", help="Executable name")
 parser.add_argument("binpath", help="Binary path")
 parser.add_argument(
+    "-o", "--output-name", help="Base name for output files without any extension"
+)
+parser.add_argument(
     "--template",
     default=os.path.join(
         get_project_root(), "tools/scripts/release/readme_template.txt"
@@ -37,7 +40,6 @@ args = parser.parse_args()
 
 # Get git version string from version.c, which is what's included in the image
 def get_source_version(version_filename):
-
     version = {
         "version_str": None,
         "git_sha": None,
@@ -123,6 +125,9 @@ if source_version["is_eng"]:
 
 # First name in sorted list is imagename.elf
 base_name = os.path.splitext(os.path.basename(files[0]))[0]
+
+if args.output_name:
+    base_name = args.output_name
 
 # Add version to basename
 new_base_name = f"{base_name}-{source_version['version_str']}"


### PR DESCRIPTION
When running:

    python tools/scripts/release/release.py \
      bridge_v1_0-bridge-dbg.elf \
      cmake-build/bridge/src \
      --eng_build \
      -o bridge_debug

I get output including the following:

```
GIT_SHA: 0DCF1942
Source version: v0.9.1-5-g0dcf1942
Contents of README.txt:

# Firmware update instructions (ENG-v0.9.1-5-g0dcf1942)
```
...
```
In the output, you need to find the Node ID of the node you want to update.
Once you have it, place a copy of the `bridge_debug-ENG-v0.9.1-5-g0dcf1942.elf.dfu.bin` file on the SD card,
and rename it to `update_<NODE_ID>.bin`, for example `update_2b64cf4c62a575a0.bin`.
```
...
```
To flash the image, run this command in the directory that has the firmware image:
`dfu-util -d 0483:df11 -c 1 -i 0 -a 0 -s 0x8000000:leave -D bridge_debug-ENG-v0.9.1-5-g0dcf1942.elf.unified.bin`

**DO NOT INTERRUPT THE DFU PROCESS!**

Release archived in cmake-build/bridge/src/release/bridge_debug-ENG-v0.9.1-5-g0dcf1942.zip
```
showing that the readme content is being replaced with the intended renaming. Additionally the zip file, the extracted folder, and the binary files inside that folder are all renamed as well.

And the auto_build.py script runs to completion for all the given configs, creating the renamed zip files:
```
(bristlemouth) zac@532nm bm_protocol % python tools/scripts/release/auto_build.py tools/scripts/release/configs/default.yml                                 
Loading configs from tools/scripts/release/configs/default.yml
Building: bootloader_signing_required
Building: bootloader_development
Building: bridge_debug
Building: bridge_release
Building: aanderaa_debug
Building: aanderaa_release
Building: hello_world_debug
```