### PR TITLE
Add all aanderaa data to IND log

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -70,12 +70,16 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
                      "%.3f,"          // single_ping_std_cm_s
                      "%.3f,"          // std_tilt_deg
                      "%.3f,"          // temperature_deg_c
-                     "%.3f\n",        // north_cm_s
+                     "%.3f,"          // north_cm_s
+                     "%.3f,"          // tilt_x_deg
+                     "%.3f,"          // tilt_y_deg
+                     "%.3f\n",         // transducer_strength_db
                      node_id, d.header.reading_uptime_millis, reading_time_sec,
                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
                      d.abs_speed_cm_s, d.abs_tilt_deg, d.direction_deg_m, d.east_cm_s,
                      d.heading_deg_m, d.max_tilt_deg, d.ping_count, d.single_ping_std_cm_s,
-                     d.std_tilt_deg, d.temperature_deg_c, d.north_cm_s);
+                     d.std_tilt_deg, d.temperature_deg_c, d.north_cm_s, d.tilt_x_deg,
+                     d.tilt_y_deg, d.transducer_strength_db);
         if (log_buflen > 0) {
           BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_IND, log_buf, log_buflen);
         } else {


### PR DESCRIPTION
add the three additional fields that are in an aanderaa data message but not yet logged.

EX:

```
Node Id,reading_uptime_millis,reading_time_utc_s,sensor_reading_time_s,abs_speed_cm_s,abs_tilt_deg,direction_deg_m,east_cm_s,heading_deg_m,max_tilt_deg,ping_count,single_ping_std_cm_s,std_tilt_deg,temperature_deg_c,north_cm_s,tilt_x_deg,tilt_y_deg,transducer_strength_db
193e6faff528b841,122150,1704489751.070,0.000,50.000,8.000,152.000,32.000,165.000,20.000,101.000,0.000,7.000,20.000,45.000,7.000,16.000,0.000
193e6faff528b841,182152,1704489811.085,0.000,51.000,9.000,151.000,33.000,171.000,9.000,119.000,0.000,19.000,20.000,50.000,8.000,4.000,0.000
193e6faff528b841,242158,1704489871.105,0.000,55.000,8.000,154.000,32.000,157.000,15.000,100.000,0.000,13.000,21.000,45.000,21.000,15.000,0.000
```