### PR TITLE
Fix/mcuboot reverts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,8 +113,8 @@ set(BOOTLOADER_SIZE 0xC000)
 # (and want to align to 8kB boundaries for flash erase)
 set(APP_SIZE 0xF2000)
 
-# 64kB scratch size
-set(MCUBOOT_SCRATCH_SIZE 0x10000)
+# 16kB scratch size
+set(MCUBOOT_SCRATCH_SIZE 0x4000)
 
 # MCUBOOT can only write flash 16 bytes at a time on the STM32U5
 set(MCUBOOT_BOOT_MAX_ALIGN 16)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ set(BOOTLOADER_SIZE 0xC000)
 
 # 968kB Application size, since we have two slots
 # (and want to align to 8kB boundaries for flash erase)
-set(APP_SIZE 0xF2000)
+set(APP_SIZE 0xE8000)
 
 # 16kB scratch size
 set(MCUBOOT_SCRATCH_SIZE 0x4000)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,10 +111,10 @@ set(BOOTLOADER_SIZE 0xC000)
 
 # 968kB Application size, since we have two slots
 # (and want to align to 8kB boundaries for flash erase)
-set(APP_SIZE 0xE8000)
+set(APP_SIZE 0xF2000)
 
-# 16kB scratch size
-set(MCUBOOT_SCRATCH_SIZE 0x4000)
+# 64kB scratch size
+set(MCUBOOT_SCRATCH_SIZE 0x10000)
 
 # MCUBOOT can only write flash 16 bytes at a time on the STM32U5
 set(MCUBOOT_BOOT_MAX_ALIGN 16)

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -174,7 +174,8 @@ set(MCUBOOT_FILES
 
     ${SRC_DIR}/lib/mcuboot/port_flash.c
     ${SRC_DIR}/lib/mcuboot/port_misc.c
-    ${SRC_DIR}/lib/mcuboot/mcuboot_cli.c
+    # uncomment for the `update sec`, `update clr`, `update confirm` commands
+    # ${SRC_DIR}/lib/mcuboot/mcuboot_cli.c
     )
 set(MCUBOOT_INCLUDES
     ${MCUBOOT_DIR}/boot
@@ -183,7 +184,8 @@ set(MCUBOOT_INCLUDES
 
     # FreeRTOS port
     ${SRC_DIR}/lib/mcuboot/include
-    ${SRC_DIR}/lib/mcuboot/
+    # uncomment for the `update sec`, `update clr`, `update confirm` commands
+    # ${SRC_DIR}/lib/mcuboot/
 
     ${SRC_DIR}/lib/drivers/
     )

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -174,6 +174,7 @@ set(MCUBOOT_FILES
 
     ${SRC_DIR}/lib/mcuboot/port_flash.c
     ${SRC_DIR}/lib/mcuboot/port_misc.c
+    ${SRC_DIR}/lib/mcuboot/mcuboot_cli.c
     )
 set(MCUBOOT_INCLUDES
     ${MCUBOOT_DIR}/boot
@@ -182,6 +183,7 @@ set(MCUBOOT_INCLUDES
 
     # FreeRTOS port
     ${SRC_DIR}/lib/mcuboot/include
+    ${SRC_DIR}/lib/mcuboot/
 
     ${SRC_DIR}/lib/drivers/
     )

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -336,7 +336,8 @@ static void defaultTask( void *parameters ) {
 
     debugSysInit();
     debugMemfaultInit(&usbCLI);
-    mcubootCliInit();
+    // uncomment for the `update sec`, `update clr`, `update confirm` commands
+    // mcubootCliInit();
 
     debugGpioInit(debugGpioPins, sizeof(debugGpioPins)/sizeof(DebugGpio_t));
     debugSpotterInit();

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -30,7 +30,6 @@
 #include "debug_rtc.h"
 #include "debug_sys.h"
 #include "debug_w25.h"
-#include "mcuboot_cli.h"
 #include "external_flash_partitions.h"
 #include "gpdma.h"
 #include "gpioISR.h"
@@ -66,6 +65,9 @@
 #ifdef USE_MICROPYTHON
 #include "micropython_freertos.h"
 #endif
+
+// uncomment for the `update sec`, `update clr`, `update confirm` commands
+//#include "mcuboot_cli.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -30,6 +30,7 @@
 #include "debug_rtc.h"
 #include "debug_sys.h"
 #include "debug_w25.h"
+#include "mcuboot_cli.h"
 #include "external_flash_partitions.h"
 #include "gpdma.h"
 #include "gpioISR.h"
@@ -335,6 +336,7 @@ static void defaultTask( void *parameters ) {
 
     debugSysInit();
     debugMemfaultInit(&usbCLI);
+    mcubootCliInit();
 
     debugGpioInit(debugGpioPins, sizeof(debugGpioPins)/sizeof(DebugGpio_t));
     debugSpotterInit();

--- a/src/lib/mcuboot/include/mcuboot_config/mcuboot_config.h
+++ b/src/lib/mcuboot/include/mcuboot_config/mcuboot_config.h
@@ -95,7 +95,7 @@
 
 /* Default maximum number of flash sectors per image slot; change
  * as desirable. */
-#define MCUBOOT_MAX_IMG_SECTORS 256
+#define MCUBOOT_MAX_IMG_SECTORS 121
 
 /* Default number of separately updateable images; change in case of
  * multiple images. */

--- a/src/lib/mcuboot/port_flash.c
+++ b/src/lib/mcuboot/port_flash.c
@@ -172,7 +172,7 @@ int     flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t l
 /*< Returns this `flash_area`s alignment */
 size_t flash_area_align(const struct flash_area *area) {
   (void)area;
-  return 16;
+  return MCUBOOT_BOOT_MAX_ALIGN;
 }
 
 /*< What is value is read from erased flash bytes. */

--- a/src/lib/mcuboot/port_flash.c
+++ b/src/lib/mcuboot/port_flash.c
@@ -172,7 +172,7 @@ int     flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t l
 /*< Returns this `flash_area`s alignment */
 size_t flash_area_align(const struct flash_area *area) {
   (void)area;
-  return 8;
+  return 16;
 }
 
 /*< What is value is read from erased flash bytes. */


### PR DESCRIPTION
Fixes a flash write alignment bug in the bootloader that makes MCUBoot vulnerable to power downs mid image swap.