### PR TITLE
adding support for sample type in the report encoder

### DIFF
--- a/src/apps/bridge/cbor_sensor_report_encoder.cpp
+++ b/src/apps/bridge/cbor_sensor_report_encoder.cpp
@@ -87,14 +87,25 @@ CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &co
 }
 
 /*!
- * @brief Open a sample array for encoding.
+ * @brief Open a sample array for encoding. The first member in the sampe array is the sample type.
  * @param[in] context The encoding context.
  * @param[in] num_sample_members The number of samples in the sensor.
+ * @param[in] sample_type A string defining type of sample.
  * @return Cbor error code.
  */
 CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
-                                            size_t num_sample_members) {
-  return cbor_encoder_create_array(&context.sensor_array, &context.sample_array, num_sample_members);
+                                            size_t num_sample_members,
+                                            const char *sample_type) {
+  CborError err = CborNoError;
+  do {
+    err = cbor_encoder_create_array(&context.sensor_array, &context.sample_array,
+                                    num_sample_members + 1);
+    if (err != CborNoError) {
+      break;
+    }
+    err = cbor_encode_text_stringz(&context.sample_array, sample_type);
+  } while (0);
+  return err;
 }
 
 /*!
@@ -105,8 +116,8 @@ CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &con
  * @return Cbor error code.
  */
 CborError sensor_report_encoder_add_sample_member(sensor_report_encoder_context_t &context,
-                                            sample_encoder_cb sample_member_encoder_cb,
-                                            void *sensor_data) {
+                                                  sample_encoder_cb sample_member_encoder_cb,
+                                                  void *sensor_data) {
   return sample_member_encoder_cb(context.sample_array, sensor_data);
 }
 

--- a/src/apps/bridge/cbor_sensor_report_encoder.cpp
+++ b/src/apps/bridge/cbor_sensor_report_encoder.cpp
@@ -87,7 +87,7 @@ CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &co
 }
 
 /*!
- * @brief Open a sample array for encoding. The first member in the sampe array is the sample type.
+ * @brief Open a sample array for encoding. The first member in the sample array is the sample type.
  * @param[in] context The encoding context.
  * @param[in] num_sample_members The number of samples in the sensor.
  * @param[in] sample_type A string defining type of sample.

--- a/src/apps/bridge/cbor_sensor_report_encoder.h
+++ b/src/apps/bridge/cbor_sensor_report_encoder.h
@@ -24,11 +24,11 @@ CborError sensor_report_encoder_open_sensor(sensor_report_encoder_context_t &con
 CborError sensor_report_encoder_close_sensor(sensor_report_encoder_context_t &context);
 
 CborError sensor_report_encoder_open_sample(sensor_report_encoder_context_t &context,
-                                            size_t num_sample_members);
+                                            size_t num_sample_members, const char *sample_type);
 
 CborError sensor_report_encoder_add_sample_member(sensor_report_encoder_context_t &context,
-                                           sample_encoder_cb sample_member_encoder_cb,
-                                           void *sensor_data);
+                                                  sample_encoder_cb sample_member_encoder_cb,
+                                                  void *sensor_data);
 
 CborError sensor_report_encoder_close_sample(sensor_report_encoder_context_t &context);
 

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -1,12 +1,5 @@
+#include "reportBuilder.h"
 #include "FreeRTOS.h"
-#include "queue.h"
-#include "semphr.h"
-#include "task.h"
-#include "task_priorities.h"
-#include "timer_callback_handler.h"
-#include "timers.h"
-#include <string.h>
-#include "sensorController.h"
 #include "aanderaaSensor.h"
 #include "app_config.h"
 #include "app_pub_sub.h"
@@ -14,7 +7,14 @@
 #include "bridgeLog.h"
 #include "cbor_sensor_report_encoder.h"
 #include "device_info.h"
-#include "reportBuilder.h"
+#include "queue.h"
+#include "semphr.h"
+#include "sensorController.h"
+#include "task.h"
+#include "task_priorities.h"
+#include "timer_callback_handler.h"
+#include "timers.h"
+#include <string.h>
 
 #define REPORT_BUILDER_QUEUE_SIZE (16)
 #define TOPO_TIMEOUT_MS (1000)
@@ -47,34 +47,39 @@ typedef struct report_builder_element_s {
 } report_builder_element_t;
 
 static aanderaa_aggregations_t NAN_AGG = {.abs_speed_mean_cm_s = NAN,
-                                           .abs_speed_std_cm_s = NAN,
-                                           .direction_circ_mean_rad = NAN,
-                                           .direction_circ_std_rad = NAN,
-                                           .temp_mean_deg_c = NAN,
-                                           .abs_tilt_mean_rad = NAN,
-                                           .std_tilt_mean_rad = NAN,
-                                           .reading_count = 0};
+                                          .abs_speed_std_cm_s = NAN,
+                                          .direction_circ_mean_rad = NAN,
+                                          .direction_circ_std_rad = NAN,
+                                          .temp_mean_deg_c = NAN,
+                                          .abs_tilt_mean_rad = NAN,
+                                          .std_tilt_mean_rad = NAN,
+                                          .reading_count = 0};
 
 class ReportBuilderLinkedList {
-  private:
+private:
+  report_builder_element_t *newElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data,
+                                       uint32_t sensor_data_size, uint32_t samples_per_report,
+                                       uint32_t sample_counter);
+  void freeElement(report_builder_element_s **element_pointer);
+  void append(report_builder_element_t *curr, uint64_t node_id, uint8_t sensor_type,
+              void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report,
+              uint32_t sample_counter);
+  void addSampleToElement(report_builder_element_t *element, uint8_t sensor_type,
+                          void *sensor_data, uint32_t sample_counter);
 
-    report_builder_element_t* newElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter);
-    void freeElement(report_builder_element_s **element_pointer);
-    void append(report_builder_element_t *curr, uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter);
-    void addSampleToElement(report_builder_element_t *element, uint8_t sensor_type, void *sensor_data, uint32_t sample_counter);
+  report_builder_element_t *head;
+  size_t size;
 
-    report_builder_element_t *head;
-    size_t size;
+public:
+  ReportBuilderLinkedList();
+  ~ReportBuilderLinkedList();
 
-  public:
-
-    ReportBuilderLinkedList();
-    ~ReportBuilderLinkedList();
-
-    void removeElement(report_builder_element_t *element);
-    void findElementAndAddSampleToElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter);
-    report_builder_element_t* findElement(uint64_t node_id);
-    void clear();
+  void removeElement(report_builder_element_t *element);
+  void findElementAndAddSampleToElement(uint64_t node_id, uint8_t sensor_type,
+                                        void *sensor_data, uint32_t sensor_data_size,
+                                        uint32_t samples_per_report, uint32_t sample_counter);
+  report_builder_element_t *findElement(uint64_t node_id);
+  void clear();
 };
 
 typedef struct ReportBuilderContext_s {
@@ -97,9 +102,7 @@ ReportBuilderLinkedList::ReportBuilderLinkedList() {
   size = 0;
 }
 
-ReportBuilderLinkedList::~ReportBuilderLinkedList() {
-  clear();
-}
+ReportBuilderLinkedList::~ReportBuilderLinkedList() { clear(); }
 
 /**
  * @brief Creates a new element for the report builder linked list.
@@ -115,13 +118,18 @@ ReportBuilderLinkedList::~ReportBuilderLinkedList() {
  * @return A pointer to the newly created report builder element.
  *
  */
-report_builder_element_t* ReportBuilderLinkedList::newElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter) {
-  report_builder_element_t *element = static_cast<report_builder_element_t *>(pvPortMalloc(sizeof(report_builder_element_t)));
+report_builder_element_t *
+ReportBuilderLinkedList::newElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data,
+                                    uint32_t sensor_data_size, uint32_t samples_per_report,
+                                    uint32_t sample_counter) {
+  report_builder_element_t *element =
+      static_cast<report_builder_element_t *>(pvPortMalloc(sizeof(report_builder_element_t)));
   configASSERT(element != NULL);
   element->node_id = node_id;
   element->sensor_type = sensor_type;
   element->sample_counter = 0;
-  element->sensor_data = static_cast<void *>(pvPortMalloc(samples_per_report * sensor_data_size));
+  element->sensor_data =
+      static_cast<void *>(pvPortMalloc(samples_per_report * sensor_data_size));
   configASSERT(element->sensor_data != NULL);
   memset(element->sensor_data, 0, samples_per_report * sensor_data_size);
 
@@ -165,34 +173,42 @@ void ReportBuilderLinkedList::removeElement(report_builder_element_t *element) {
  * @param sensor_data Pointer to the sensor data for the report.
  * @param sample_counter The current sample counter, indicating the position at which to add the sensor data.
  */
-void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *element, uint8_t sensor_type, void *sensor_data, uint32_t sample_counter) {
-    switch (sensor_type) {
-      case AANDERAA_SENSOR_TYPE: {
-        if (element->sample_counter < sample_counter) {
-          // Back fill the sensor_data with NANs if we are not on the right sample counter
-          // We use the element->sample_counter to track within each element how many samples
-          // the element has received.
-          for (; element->sample_counter < sample_counter; element->sample_counter++) {
-            memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[element->sample_counter], &NAN_AGG, sizeof(aanderaa_aggregations_t));
-          }
-        }
-
-        // Copy the sensor data into the elements array in the correct location within the buffer
-        // If it is NULL then just fill it with NAN again
-        if (sensor_data != NULL) {
-          memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[element->sample_counter], sensor_data, sizeof(aanderaa_aggregations_t));
-        } else {
-          memcpy(&(static_cast<aanderaa_aggregations_t *>(element->sensor_data))[element->sample_counter], &NAN_AGG, sizeof(aanderaa_aggregations_t));
-        }
-        element->sample_counter++;
-        break;
-      }
-      default: {
-        BRIDGE_LOG_PRINT("Unknown sensor type in addSampleToElement\n");
-        configASSERT(0);
-        break;
+void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *element,
+                                                 uint8_t sensor_type, void *sensor_data,
+                                                 uint32_t sample_counter) {
+  switch (sensor_type) {
+  case AANDERAA_SENSOR_TYPE: {
+    if (element->sample_counter < sample_counter) {
+      // Back fill the sensor_data with NANs if we are not on the right sample counter
+      // We use the element->sample_counter to track within each element how many samples
+      // the element has received.
+      for (; element->sample_counter < sample_counter; element->sample_counter++) {
+        memcpy(&(static_cast<aanderaa_aggregations_t *>(
+                   element->sensor_data))[element->sample_counter],
+               &NAN_AGG, sizeof(aanderaa_aggregations_t));
       }
     }
+
+    // Copy the sensor data into the elements array in the correct location within the buffer
+    // If it is NULL then just fill it with NAN again
+    if (sensor_data != NULL) {
+      memcpy(&(static_cast<aanderaa_aggregations_t *>(
+                 element->sensor_data))[element->sample_counter],
+             sensor_data, sizeof(aanderaa_aggregations_t));
+    } else {
+      memcpy(&(static_cast<aanderaa_aggregations_t *>(
+                 element->sensor_data))[element->sample_counter],
+             &NAN_AGG, sizeof(aanderaa_aggregations_t));
+    }
+    element->sample_counter++;
+    break;
+  }
+  default: {
+    BRIDGE_LOG_PRINT("Unknown sensor type in addSampleToElement\n");
+    configASSERT(0);
+    break;
+  }
+  }
 }
 
 /**
@@ -208,25 +224,33 @@ void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *eleme
  * @param sample_counter The current sample counter.
  * @return A boolean value indicating whether the operation was successful. Returns true if the sample was added successfully, false otherwise.
  */
-void ReportBuilderLinkedList::findElementAndAddSampleToElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter) {
+void ReportBuilderLinkedList::findElementAndAddSampleToElement(
+    uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size,
+    uint32_t samples_per_report, uint32_t sample_counter) {
   report_builder_element_t *element = findElement(node_id);
   if (element != NULL) {
     addSampleToElement(element, sensor_type, sensor_data, sample_counter);
   } else {
     if (head == NULL && size == 0) {
-      append(NULL, node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report, sample_counter);
+      append(NULL, node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report,
+             sample_counter);
     } else {
       report_builder_element_t *element = head;
       while (element->next != NULL) {
         element = element->next;
       }
-      append(element, node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report, sample_counter);
+      append(element, node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report,
+             sample_counter);
     }
   }
 }
 
-void ReportBuilderLinkedList::append(report_builder_element_t *curr, uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, uint32_t samples_per_report, uint32_t sample_counter) {
-   report_builder_element_s *element = newElement(node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report, sample_counter);
+void ReportBuilderLinkedList::append(report_builder_element_t *curr, uint64_t node_id,
+                                     uint8_t sensor_type, void *sensor_data,
+                                     uint32_t sensor_data_size, uint32_t samples_per_report,
+                                     uint32_t sample_counter) {
+  report_builder_element_s *element = newElement(
+      node_id, sensor_type, sensor_data, sensor_data_size, samples_per_report, sample_counter);
   if (curr != NULL) {
     element->next = curr->next;
     element->prev = curr;
@@ -240,7 +264,7 @@ void ReportBuilderLinkedList::append(report_builder_element_t *curr, uint64_t no
   }
 }
 
-report_builder_element_t* ReportBuilderLinkedList::findElement(uint64_t node_id) {
+report_builder_element_t *ReportBuilderLinkedList::findElement(uint64_t node_id) {
   report_builder_element_t *element = head;
   while (element != NULL) {
     if (element->node_id == node_id) {
@@ -262,15 +286,15 @@ void ReportBuilderLinkedList::clear() {
   size = 0;
 }
 
-CborError encode_double_sample_member(CborEncoder &sample_array, void* sample_member){
-  double local_sample_member = *(double*)sample_member;
+CborError encode_double_sample_member(CborEncoder &sample_array, void *sample_member) {
+  double local_sample_member = *(double *)sample_member;
   CborError err = CborNoError;
   err = cbor_encode_double(&sample_array, local_sample_member);
   return err;
 }
 
-CborError encode_uint_sample_member(CborEncoder &sample_array, void* sample_member){
-  uint32_t local_sample_member = *(uint32_t*)sample_member;
+CborError encode_uint_sample_member(CborEncoder &sample_array, void *sample_member) {
+  uint32_t local_sample_member = *(uint32_t *)sample_member;
   CborError err = CborNoError;
   err = cbor_encode_uint(&sample_array, local_sample_member);
   return err;
@@ -291,7 +315,8 @@ CborError encode_uint_sample_member(CborEncoder &sample_array, void* sample_memb
  * If the message type is REPORT_BUILDER_INCREMENT_SAMPLE_COUNT or REPORT_BUILDER_CHECK_CRC, these parameters are ignored and default values are used instead
  * since they are not needed for these message types.
  */
-void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, report_builder_message_e msg_type) {
+void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor_data,
+                             uint32_t sensor_data_size, report_builder_message_e msg_type) {
   report_builder_queue_item_t item;
   item.message_type = msg_type;
   if (msg_type == REPORT_BUILDER_SAMPLE_MESSAGE) {
@@ -302,7 +327,8 @@ void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor
     configASSERT(item.sensor_data != NULL);
     memcpy(item.sensor_data, sensor_data, sensor_data_size);
     item.sensor_data_size = sensor_data_size;
-  } else if (msg_type == REPORT_BUILDER_INCREMENT_SAMPLE_COUNT || msg_type == REPORT_BUILDER_CHECK_CRC) {
+  } else if (msg_type == REPORT_BUILDER_INCREMENT_SAMPLE_COUNT ||
+             msg_type == REPORT_BUILDER_CHECK_CRC) {
     item.node_id = 0;
     item.sensor_type = 0;
     item.sensor_data = NULL;
@@ -323,70 +349,90 @@ void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor
  * @param sensor_data Pointer to the sensor data for the report.
  * @param sample_index The index of the sensor data to be copied into the sensor report.
  */
-static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t sensor_type, void *sensor_data, uint32_t sample_index) {
+static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t sensor_type,
+                               void *sensor_data, uint32_t sample_index) {
   bool rval = false;
-  switch (sensor_type){
-    case AANDERAA_SENSOR_TYPE: {
-      aanderaa_aggregations_t aanderaa_sample = (static_cast<aanderaa_aggregations_t *>(sensor_data))[sample_index];
-      if (sensor_report_encoder_open_sample(context, AANDERAA_NUM_SAMPLE_MEMBERS) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to open sample in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_speed_mean_cm_s) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_speed_std_cm_s) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.direction_circ_mean_rad) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.direction_circ_std_rad) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.temp_mean_deg_c) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.abs_tilt_mean_rad) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &aanderaa_sample.std_tilt_mean_rad) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member, &aanderaa_sample.reading_count) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
-        break;
-      }
-      if (sensor_report_encoder_close_sample(context) != CborNoError) {
-        BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
-        break;
-      }
-      rval = true;
+  switch (sensor_type) {
+  case AANDERAA_SENSOR_TYPE: {
+    aanderaa_aggregations_t aanderaa_sample =
+        (static_cast<aanderaa_aggregations_t *>(sensor_data))[sample_index];
+    if (sensor_report_encoder_open_sample(context, AANDERAA_NUM_SAMPLE_MEMBERS,
+                                          "aandera_current_v0") != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to open sample in addSamplesToReport\n");
       break;
     }
-    default: {
-      BRIDGE_LOG_PRINT("Received invalid sensor type in addSamplesToReport\n");
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.abs_speed_mean_cm_s) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
       break;
     }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.abs_speed_std_cm_s) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.direction_circ_mean_rad) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.direction_circ_std_rad) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.temp_mean_deg_c) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.abs_tilt_mean_rad) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &aanderaa_sample.std_tilt_mean_rad) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member,
+                                                &aanderaa_sample.reading_count) !=
+        CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_close_sample(context) != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
+      break;
+    }
+    rval = true;
+    break;
+  }
+  default: {
+    BRIDGE_LOG_PRINT("Received invalid sensor type in addSamplesToReport\n");
+    break;
+  }
   }
   return rval;
-
 }
 
 // Task init
-void reportBuilderInit(cfg::Configuration* sys_cfg) {
+void reportBuilderInit(cfg::Configuration *sys_cfg) {
   configASSERT(sys_cfg);
   _ctx._samplesPerReport = DEFAULT_SAMPLES_PER_REPORT;
-  sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT), _ctx._samplesPerReport);
+  sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT),
+                     _ctx._samplesPerReport);
   _ctx._transmitAggregations = DEFAULT_TRANSMIT_AGGREGATIONS;
-  sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS, strlen(AppConfig::TRANSMIT_AGGREGATIONS), _ctx._transmitAggregations);
+  sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS, strlen(AppConfig::TRANSMIT_AGGREGATIONS),
+                     _ctx._transmitAggregations);
   _ctx._sample_counter = 0;
   _report_builder_queue =
       xQueueCreate(REPORT_BUILDER_QUEUE_SIZE, sizeof(report_builder_queue_item_t));
@@ -399,187 +445,207 @@ void reportBuilderInit(cfg::Configuration* sys_cfg) {
 
 // Task
 static void report_builder_task(void *parameters) {
-  (void) parameters;
+  (void)parameters;
 
   report_builder_queue_item_t item;
 
   while (1) {
-    if (xQueueReceive(_report_builder_queue, &item,
-                      portMAX_DELAY) == pdPASS) {
+    if (xQueueReceive(_report_builder_queue, &item, portMAX_DELAY) == pdPASS) {
       switch (item.message_type) {
-        case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT: {
-          _ctx._sample_counter++;
-          constexpr size_t bufsize = 50;
-          static char buffer[bufsize];
-          int len =
-              snprintf(buffer, bufsize, "Incrementing sample counter to %d\n", _ctx._sample_counter);
-          BRIDGE_LOG_PRINTN(buffer, len);
-          if (_ctx._sample_counter >= _ctx._samplesPerReport) {
-            if (_ctx._samplesPerReport > 0 && _ctx._transmitAggregations) {
-              // Need to have more than one node to report anything (1 node would be just the bridge)
-              if (_ctx._report_period_num_nodes > 1) {
-                app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = NULL;
-                uint8_t *cbor_buffer = NULL;
-                do {
-                  // This num_sensors is for the cbor encoder and we subtract one since the bridge is not included in the report
-                  uint32_t num_sensors = _ctx._report_period_num_nodes - 1;
-                  sensor_report_encoder_context_t context;
-                  cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
-                  configASSERT(cbor_buffer != NULL);
-                  if (sensor_report_encoder_open_report(cbor_buffer, MAX_SENSOR_REPORT_CBOR_LEN, num_sensors, context) != CborNoError) {
-                    BRIDGE_LOG_PRINT("Failed to open report in report_builder_task\n");
+      case REPORT_BUILDER_INCREMENT_SAMPLE_COUNT: {
+        _ctx._sample_counter++;
+        constexpr size_t bufsize = 50;
+        static char buffer[bufsize];
+        int len = snprintf(buffer, bufsize, "Incrementing sample counter to %d\n",
+                           _ctx._sample_counter);
+        BRIDGE_LOG_PRINTN(buffer, len);
+        if (_ctx._sample_counter >= _ctx._samplesPerReport) {
+          if (_ctx._samplesPerReport > 0 && _ctx._transmitAggregations) {
+            // Need to have more than one node to report anything (1 node would be just the bridge)
+            if (_ctx._report_period_num_nodes > 1) {
+              app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = NULL;
+              uint8_t *cbor_buffer = NULL;
+              do {
+                // This num_sensors is for the cbor encoder and we subtract one since the bridge is not included in the report
+                uint32_t num_sensors = _ctx._report_period_num_nodes - 1;
+                sensor_report_encoder_context_t context;
+                cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
+                configASSERT(cbor_buffer != NULL);
+                if (sensor_report_encoder_open_report(cbor_buffer, MAX_SENSOR_REPORT_CBOR_LEN,
+                                                      num_sensors, context) != CborNoError) {
+                  BRIDGE_LOG_PRINT("Failed to open report in report_builder_task\n");
+                  break;
+                }
+                bool abort_cbor_encoding = false;
+                // Start at index 1 to skip the bridge
+                for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
+                  report_builder_element_t *element = _ctx._reportBuilderLinkedList.findElement(
+                      _ctx._report_period_node_list[i]);
+                  if (element == NULL) {
+                    constexpr size_t bufsize = 80;
+                    static char buffer[bufsize];
+                    int len = snprintf(buffer, bufsize,
+                                       "No data for node %" PRIx64
+                                       " in report period, adding it to the list\n",
+                                       _ctx._report_period_node_list[i]);
+                    BRIDGE_LOG_PRINTN(buffer, len);
+                    // we have a sensor that may have been added at the end of the report period
+                    // so lets add it to the list and this wil backfill all of the data so we can still send it
+                    // in the report. We will need to pass (_ctx._sample_counter - 1) to make sure we don't overflow the sensor_data buffer.
+                    // Also we will pass NULL into the sensor_data since we don't have any data for it yet and we will fill the whole thing with NANs
+                    _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
+                        _ctx._report_period_node_list[i], AANDERAA_SENSOR_TYPE, NULL,
+                        sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport,
+                        (_ctx._sample_counter - 1));
+                    element = _ctx._reportBuilderLinkedList.findElement(
+                        _ctx._report_period_node_list[i]);
+                  } else {
+                    constexpr size_t bufsize = 70;
+                    static char buffer[bufsize];
+                    int len = snprintf(buffer, bufsize,
+                                       "Found data for node %" PRIx64
+                                       " adding it to the the report\n",
+                                       _ctx._report_period_node_list[i]);
+                    BRIDGE_LOG_PRINTN(buffer, len);
+                  }
+                  if (sensor_report_encoder_open_sensor(context, _ctx._samplesPerReport) !=
+                      CborNoError) {
+                    BRIDGE_LOG_PRINT("Failed to open sensor in report_builder_task\n");
+                    abort_cbor_encoding = true;
                     break;
                   }
-                  bool abort_cbor_encoding = false;
-                  // Start at index 1 to skip the bridge
-                  for (size_t i = 1; i < _ctx._report_period_num_nodes; i++) {
-                    report_builder_element_t *element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
-                    if (element == NULL) {
-                      constexpr size_t bufsize = 80;
-                      static char buffer[bufsize];
-                      int len =
-                          snprintf(buffer, bufsize, "No data for node %" PRIx64 " in report period, adding it to the list\n", _ctx._report_period_node_list[i]);
-                      BRIDGE_LOG_PRINTN(buffer, len);
-                      // we have a sensor that may have been added at the end of the report period
-                      // so lets add it to the list and this wil backfill all of the data so we can still send it
-                      // in the report. We will need to pass (_ctx._sample_counter - 1) to make sure we don't overflow the sensor_data buffer.
-                      // Also we will pass NULL into the sensor_data since we don't have any data for it yet and we will fill the whole thing with NANs
-                      _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(_ctx._report_period_node_list[i], AANDERAA_SENSOR_TYPE, NULL, sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport, (_ctx._sample_counter - 1));
-                      element = _ctx._reportBuilderLinkedList.findElement(_ctx._report_period_node_list[i]);
-                    } else {
-                      constexpr size_t bufsize = 70;
-                      static char buffer[bufsize];
-                      int len =
-                          snprintf(buffer, bufsize, "Found data for node %" PRIx64 " adding it to the the report\n", _ctx._report_period_node_list[i]);
-                      BRIDGE_LOG_PRINTN(buffer, len);
-                    }
-                    if (sensor_report_encoder_open_sensor(context, _ctx._samplesPerReport) != CborNoError) {
-                      BRIDGE_LOG_PRINT("Failed to open sensor in report_builder_task\n");
+                  for (uint32_t j = 0; j < _ctx._samplesPerReport; j++) {
+                    if (!addSamplesToReport(context, element->sensor_type, element->sensor_data,
+                                            j)) {
+                      BRIDGE_LOG_PRINT(
+                          "Failed to add samples to report in report_builder_task\n");
                       abort_cbor_encoding = true;
                       break;
                     }
-                    for (uint32_t j = 0; j < _ctx._samplesPerReport; j++) {
-                      if (!addSamplesToReport(context, element->sensor_type, element->sensor_data, j)) {
-                        BRIDGE_LOG_PRINT("Failed to add samples to report in report_builder_task\n");
-                        abort_cbor_encoding = true;
-                        break;
-                      }
-                    }
-                    if (sensor_report_encoder_close_sensor(context) != CborNoError || abort_cbor_encoding) {
-                      BRIDGE_LOG_PRINT("Failed to close sensor in report_builder_task\n");
-                      abort_cbor_encoding = true;
-                      break;
-                    }
                   }
-                  if (abort_cbor_encoding) {
+                  if (sensor_report_encoder_close_sensor(context) != CborNoError ||
+                      abort_cbor_encoding) {
+                    BRIDGE_LOG_PRINT("Failed to close sensor in report_builder_task\n");
+                    abort_cbor_encoding = true;
                     break;
                   }
-                  if (sensor_report_encoder_close_report(context) != CborNoError) {
-                    BRIDGE_LOG_PRINT("Failed to close report in report_builder_task\n");
-                    break;
-                  }
-                  size_t cbor_buffer_len = sensor_report_encoder_get_report_size_bytes(context);
-                  message_buff = static_cast<app_pub_sub_bm_bridge_sensor_report_data_t *>(pvPortMalloc(sizeof(app_pub_sub_bm_bridge_sensor_report_data_t) + cbor_buffer_len));
-                  configASSERT(message_buff != NULL);
-                  message_buff->bm_config_crc32 = _ctx._report_period_max_network_crc32;
-                  message_buff->cbor_buffer_len = cbor_buffer_len;
-                  memcpy(&message_buff->cbor_buffer, cbor_buffer, cbor_buffer_len);
-                  // Send cbor_buffer to the other side.
-                  bm_serial_pub(getNodeId(),APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC,
-                      sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC),
-                      reinterpret_cast<uint8_t *>(message_buff),
-                      sizeof(uint32_t) + sizeof(size_t) + cbor_buffer_len,
-                      APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE,
-                      APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION);
-                } while (0);
-                if (message_buff != NULL) {
-                  vPortFree(message_buff);
                 }
-                if (cbor_buffer != NULL) {
-                  vPortFree(cbor_buffer);
+                if (abort_cbor_encoding) {
+                  break;
                 }
-              } else {
-                BRIDGE_LOG_PRINT("No nodes to send data for\n");
+                if (sensor_report_encoder_close_report(context) != CborNoError) {
+                  BRIDGE_LOG_PRINT("Failed to close report in report_builder_task\n");
+                  break;
+                }
+                size_t cbor_buffer_len = sensor_report_encoder_get_report_size_bytes(context);
+                message_buff =
+                    static_cast<app_pub_sub_bm_bridge_sensor_report_data_t *>(pvPortMalloc(
+                        sizeof(app_pub_sub_bm_bridge_sensor_report_data_t) + cbor_buffer_len));
+                configASSERT(message_buff != NULL);
+                message_buff->bm_config_crc32 = _ctx._report_period_max_network_crc32;
+                message_buff->cbor_buffer_len = cbor_buffer_len;
+                memcpy(&message_buff->cbor_buffer, cbor_buffer, cbor_buffer_len);
+                // Send cbor_buffer to the other side.
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC,
+                              sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC),
+                              reinterpret_cast<uint8_t *>(message_buff),
+                              sizeof(uint32_t) + sizeof(size_t) + cbor_buffer_len,
+                              APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE,
+                              APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION);
+              } while (0);
+              if (message_buff != NULL) {
+                vPortFree(message_buff);
               }
-              BRIDGE_LOG_PRINT("Clearing the list\n");
-              _ctx._reportBuilderLinkedList.clear();
-            }
-            BRIDGE_LOG_PRINT("Clearing the sample counter\n");
-            _ctx._sample_counter = 0;
-            // Clear the report periods network associated data to rebuild it for the next report period
-            _ctx._report_period_num_nodes = 0;
-            _ctx._report_period_max_network_crc32 = 0;
-            memset(_ctx._report_period_node_list, 0, sizeof(_ctx._report_period_node_list));
-          }
-          break;
-        }
-
-        case REPORT_BUILDER_SAMPLE_MESSAGE: {
-          if (_ctx._samplesPerReport > 0) {
-            constexpr size_t bufsize = 55;
-            static char buffer[bufsize];
-            int len =
-                snprintf(buffer, bufsize, "Adding sample for %" PRIx64 " to list\n", item.node_id);
-            BRIDGE_LOG_PRINTN(buffer, len);
-            _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(item.node_id, item.sensor_type, item.sensor_data, item.sensor_data_size, _ctx._samplesPerReport, _ctx._sample_counter);
-          } else {
-            BRIDGE_LOG_PRINT("samplesPerReport is 0, not adding sample to list\n");
-          }
-          break;
-        }
-
-        case REPORT_BUILDER_CHECK_CRC: {
-
-          // IMPORTANT: If the bus is constantly on, the currentAggPeriodMin(or sample period eventually) must be longer than the topology sampler period (1 min)
-          // otherwise the CRC for the report builder may not update before a message needs to be sent
-
-          BRIDGE_LOG_PRINT("Checking CRC in report builder!\n");
-          // Get the latest crc - if it doens't match our saved one, pull the latest topology and compare the topology
-          // to our current topology - if it doesn't match our current one (and mainly if it is bigger or the same size) then
-          // update the crc and the topology list
-          uint32_t temp_network_crc32 = 0;
-          uint32_t temp_cbor_config_size = 0;
-          uint8_t *last_network_config = topology_sampler_alloc_last_network_config(temp_network_crc32, temp_cbor_config_size);
-          if (last_network_config != NULL) {
-            constexpr size_t bufsize = 50;
-            static char buffer[bufsize];
-            int len =
-                snprintf(buffer, bufsize, "Got CRC %" PRIx32 " OLD CRC %" PRIx32 "\n", temp_network_crc32, _ctx._report_period_max_network_crc32);
-            BRIDGE_LOG_PRINTN(buffer, len);
-            if (temp_network_crc32 != _ctx._report_period_max_network_crc32) {
-              BRIDGE_LOG_PRINT("Getting topology in report builder!\n");
-              uint64_t temp_node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
-              size_t temp_node_list_size = sizeof(temp_node_list);
-              uint32_t temp_num_nodes;
-              if (topology_sampler_get_node_list(temp_node_list, temp_node_list_size, temp_num_nodes, TOPO_TIMEOUT_MS)) {
-                // TODO - we need to use the cbor_map and build a report builder topology map that only
-                // includes aanderaa nodes
-                BRIDGE_LOG_PRINT("Got topology in report builder!\n");
-                if (temp_num_nodes >= _ctx._report_period_num_nodes) {
-                  BRIDGE_LOG_PRINT("Updating CRC and topology in report builder!\n");
-                  _ctx._report_period_num_nodes = temp_num_nodes;
-                  memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
-                  _ctx._report_period_max_network_crc32 = temp_network_crc32;
-                } else {
-                  BRIDGE_LOG_PRINT("Not updating CRC and topology in report builder, new topology is smaller than the old one!\n");
-                }
-              } else {
-                BRIDGE_LOG_PRINT("Failed to get the node list in report builder!\n");
+              if (cbor_buffer != NULL) {
+                vPortFree(cbor_buffer);
               }
             } else {
-              BRIDGE_LOG_PRINT("CRCs match, not updating\n");
+              BRIDGE_LOG_PRINT("No nodes to send data for\n");
             }
-            // The last network config is not used here, but in the future it can be used to determine if varying sensor types have been
-            // connected/disconnected to the network.
-            vPortFree(last_network_config);
+            BRIDGE_LOG_PRINT("Clearing the list\n");
+            _ctx._reportBuilderLinkedList.clear();
           }
-          break;
+          BRIDGE_LOG_PRINT("Clearing the sample counter\n");
+          _ctx._sample_counter = 0;
+          // Clear the report periods network associated data to rebuild it for the next report period
+          _ctx._report_period_num_nodes = 0;
+          _ctx._report_period_max_network_crc32 = 0;
+          memset(_ctx._report_period_node_list, 0, sizeof(_ctx._report_period_node_list));
         }
+        break;
+      }
 
-        default: {
-          BRIDGE_LOG_PRINT("Uknown message type received in report_builder_task\n");
-          break;
+      case REPORT_BUILDER_SAMPLE_MESSAGE: {
+        if (_ctx._samplesPerReport > 0) {
+          constexpr size_t bufsize = 55;
+          static char buffer[bufsize];
+          int len = snprintf(buffer, bufsize, "Adding sample for %" PRIx64 " to list\n",
+                             item.node_id);
+          BRIDGE_LOG_PRINTN(buffer, len);
+          _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
+              item.node_id, item.sensor_type, item.sensor_data, item.sensor_data_size,
+              _ctx._samplesPerReport, _ctx._sample_counter);
+        } else {
+          BRIDGE_LOG_PRINT("samplesPerReport is 0, not adding sample to list\n");
         }
+        break;
+      }
+
+      case REPORT_BUILDER_CHECK_CRC: {
+
+        // IMPORTANT: If the bus is constantly on, the currentAggPeriodMin(or sample period eventually) must be longer than the topology sampler period (1 min)
+        // otherwise the CRC for the report builder may not update before a message needs to be sent
+
+        BRIDGE_LOG_PRINT("Checking CRC in report builder!\n");
+        // Get the latest crc - if it doens't match our saved one, pull the latest topology and compare the topology
+        // to our current topology - if it doesn't match our current one (and mainly if it is bigger or the same size) then
+        // update the crc and the topology list
+        uint32_t temp_network_crc32 = 0;
+        uint32_t temp_cbor_config_size = 0;
+        uint8_t *last_network_config = topology_sampler_alloc_last_network_config(
+            temp_network_crc32, temp_cbor_config_size);
+        if (last_network_config != NULL) {
+          constexpr size_t bufsize = 50;
+          static char buffer[bufsize];
+          int len = snprintf(buffer, bufsize, "Got CRC %" PRIx32 " OLD CRC %" PRIx32 "\n",
+                             temp_network_crc32, _ctx._report_period_max_network_crc32);
+          BRIDGE_LOG_PRINTN(buffer, len);
+          if (temp_network_crc32 != _ctx._report_period_max_network_crc32) {
+            BRIDGE_LOG_PRINT("Getting topology in report builder!\n");
+            uint64_t temp_node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
+            size_t temp_node_list_size = sizeof(temp_node_list);
+            uint32_t temp_num_nodes;
+            if (topology_sampler_get_node_list(temp_node_list, temp_node_list_size,
+                                               temp_num_nodes, TOPO_TIMEOUT_MS)) {
+              // TODO - we need to use the cbor_map and build a report builder topology map that only
+              // includes aanderaa nodes
+              BRIDGE_LOG_PRINT("Got topology in report builder!\n");
+              if (temp_num_nodes >= _ctx._report_period_num_nodes) {
+                BRIDGE_LOG_PRINT("Updating CRC and topology in report builder!\n");
+                _ctx._report_period_num_nodes = temp_num_nodes;
+                memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
+                _ctx._report_period_max_network_crc32 = temp_network_crc32;
+              } else {
+                BRIDGE_LOG_PRINT("Not updating CRC and topology in report builder, new "
+                                 "topology is smaller than the old one!\n");
+              }
+            } else {
+              BRIDGE_LOG_PRINT("Failed to get the node list in report builder!\n");
+            }
+          } else {
+            BRIDGE_LOG_PRINT("CRCs match, not updating\n");
+          }
+          // The last network config is not used here, but in the future it can be used to determine if varying sensor types have been
+          // connected/disconnected to the network.
+          vPortFree(last_network_config);
+        }
+        break;
+      }
+
+      default: {
+        BRIDGE_LOG_PRINT("Uknown message type received in report_builder_task\n");
+        break;
+      }
       }
       // Free the sensor data if it is not NULL, it is allocated in reportBuilderAddToQueue
       if (item.sensor_data != NULL) {

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -357,7 +357,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     aanderaa_aggregations_t aanderaa_sample =
         (static_cast<aanderaa_aggregations_t *>(sensor_data))[sample_index];
     if (sensor_report_encoder_open_sample(context, AANDERAA_NUM_SAMPLE_MEMBERS,
-                                          "aandera_current_v0") != CborNoError) {
+                                          "aanderaa_current_v0") != CborNoError) {
       BRIDGE_LOG_PRINT("Failed to open sample in addSamplesToReport\n");
       break;
     }


### PR DESCRIPTION
To support additional sensors (i.e. BM soft) when we need to know what type of sample to decode/bitpack on the Spotter. 
Therefore, I added a string at the top of each sample array to define what kind of samples are contained in the array. 

On the Spotter side - I'll generalize a report builder decode library and account for this extra string member in the sample array. 
