### PR TITLE
Sc 198151/bridge soft support

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -253,7 +253,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/sm_config_crc_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgePowerController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/aanderaaSensor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/SoftSensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/softSensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensorController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cbor_sensor_report_encoder.cpp

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -72,6 +72,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/aanderaa_data_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/bm_soft_data_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c
@@ -252,6 +253,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/sm_config_crc_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgePowerController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/aanderaaSensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/SoftSensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensorController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cbor_sensor_report_encoder.cpp

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -17,6 +17,7 @@ constexpr const char *ALIGNMENT_INTERVAL_5MIN = "alignmentInterval5Min";
 constexpr const char *TRANSMIT_AGGREGATIONS = "transmitAggregations";
 constexpr const char *SAMPLES_PER_REPORT = "samplesPerReport";
 constexpr const char *CURRENT_READING_PERIOD_MS = "currentReadingPeriodMs";
+constexpr const char *SOFT_READING_PERIOD_MS = "softReadingPeriodMs";
 
 } // namespace AppConfig
 

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -38,6 +38,14 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION     1
 
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC       "bridge/soft_ind"
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_VERSION     1
+
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC       "bridge/soft_agg"
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_VERSION     1
+
 typedef struct app_pub_sub_bm_bridge_sensor_report_data {
     uint32_t bm_config_crc32;
     size_t cbor_buffer_len;

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -30,6 +30,7 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION     1
 
+// TODO - keep as sensor specific logs or switch to the bm_sensor common log
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC       "bridge/aanderaa_ind"
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_VERSION     1
@@ -45,6 +46,7 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC       "bridge/soft_agg"
 #define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_VERSION     1
+// END TODO
 
 typedef struct app_pub_sub_bm_bridge_sensor_report_data {
     uint32_t bm_config_crc32;

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -21,6 +21,14 @@ void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t l
                 printf("[%s] %.*s", "AANDERAA_AGG", len, str);
                 bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION);
                 break;
+            case SOFT_IND:
+                printf("[%s] %.*s", "SOFT_IND", len, str);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_SOFT_IND_VERSION);
+                break;
+            case SOFT_AGG:
+                printf("[%s] %.*s", "SOFT_AGG", len, str);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_VERSION);
+                break;
             default:
                 printf("ERROR: Unknown sensor type in bridgerSensorLogPrintf\n");
                 break;

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -13,6 +13,7 @@ void bridgeLogPrintf(const char *str, size_t len) {
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len) {
     if(len > 0){
         switch(type) {
+            // TODO - keep as sensor specific logs or switch to the bm_sensor common log
             case AANDERAA_IND:
                 printf("[%s] %.*s", "AANDERAA_IND", len, str);
                 bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_VERSION);

--- a/src/apps/bridge/bridgeLog.h
+++ b/src/apps/bridge/bridgeLog.h
@@ -5,7 +5,9 @@ constexpr size_t SENSOR_LOG_BUF_SIZE = 512;
 
 typedef enum {
     AANDERAA_IND,
-    AANDERAA_AGG 
+    AANDERAA_AGG,
+    SOFT_IND,
+    SOFT_AGG
 } bridgeSensorLogType_e;
 
 void bridgeLogPrintf(const char *str, size_t len);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -1,4 +1,3 @@
-#include "reportBuilder.h"
 #include "FreeRTOS.h"
 #include "aanderaaSensor.h"
 #include "app_config.h"
@@ -15,6 +14,8 @@
 #include "task_priorities.h"
 #include "timer_callback_handler.h"
 #include "timers.h"
+#include "topology_sampler.h"
+#include "reportBuilder.h"
 #include <string.h>
 
 #define REPORT_BUILDER_QUEUE_SIZE (16)
@@ -447,7 +448,8 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
   case SOFT_SENSOR_TYPE: {
     soft_aggregations_t soft_sample =
         (static_cast<soft_aggregations_t *>(sensor_data))[sample_index];
-    if (sensor_report_encoder_open_sample(context, SOFT_NUM_SAMPLE_MEMBERS) != CborNoError) {
+    if (sensor_report_encoder_open_sample(context, SOFT_NUM_SAMPLE_MEMBERS,
+                                          "bm_soft_temp_v0") != CborNoError) {
       BRIDGE_LOG_PRINT("Failed to open soft sample in addSamplesToReport\n");
       break;
     }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -457,11 +457,6 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
       break;
     }
-    // if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member,
-    //                                             &soft_sample.reading_count) != CborNoError) {
-    //   BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
-    //   break;
-    // }
     if (sensor_report_encoder_close_sample(context) != CborNoError) {
       BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
       break;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -10,6 +10,7 @@
 #include "queue.h"
 #include "semphr.h"
 #include "sensorController.h"
+#include "softSensor.h"
 #include "task.h"
 #include "task_priorities.h"
 #include "timer_callback_handler.h"
@@ -55,6 +56,8 @@ static aanderaa_aggregations_t NAN_AGG = {.abs_speed_mean_cm_s = NAN,
                                           .std_tilt_mean_rad = NAN,
                                           .reading_count = 0};
 
+static soft_aggregations_t SOFT_NAN_AGG = {.temp_mean_deg_c = NAN, .reading_count = 0};
+
 class ReportBuilderLinkedList {
 private:
   report_builder_element_t *newElement(uint64_t node_id, uint8_t sensor_type, void *sensor_data,
@@ -88,6 +91,8 @@ typedef struct ReportBuilderContext_s {
   uint32_t _transmitAggregations;
   ReportBuilderLinkedList _reportBuilderLinkedList;
   uint64_t _report_period_node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
+  report_builder_sensor_type_e
+      _report_period_sensor_type_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
   uint32_t _report_period_num_nodes;
   uint32_t _report_period_max_network_crc32;
 } ReportBuilderContext_t;
@@ -199,6 +204,29 @@ void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *eleme
       memcpy(&(static_cast<aanderaa_aggregations_t *>(
                  element->sensor_data))[element->sample_counter],
              &NAN_AGG, sizeof(aanderaa_aggregations_t));
+    }
+    element->sample_counter++;
+    break;
+  }
+  case SOFT_SENSOR_TYPE: {
+    if (element->sample_counter < sample_counter) {
+      // Back fill the sensor_data with NANs if we are not on the right sample counter
+      // We use the element->sample_counter to track within each element how many samples
+      // the element has received.
+      for (; element->sample_counter < sample_counter; element->sample_counter++) {
+        memcpy(&(static_cast<soft_aggregations_t *>(
+                   element->sensor_data))[element->sample_counter],
+               &SOFT_NAN_AGG, sizeof(soft_aggregations_t));
+      }
+    }
+    if (sensor_data != NULL) {
+      memcpy(
+          &(static_cast<soft_aggregations_t *>(element->sensor_data))[element->sample_counter],
+          sensor_data, sizeof(soft_aggregations_t));
+    } else {
+      memcpy(
+          &(static_cast<soft_aggregations_t *>(element->sensor_data))[element->sample_counter],
+          &SOFT_NAN_AGG, sizeof(soft_aggregations_t));
     }
     element->sample_counter++;
     break;
@@ -416,6 +444,30 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     rval = true;
     break;
   }
+  case SOFT_SENSOR_TYPE: {
+    soft_aggregations_t soft_sample =
+        (static_cast<soft_aggregations_t *>(sensor_data))[sample_index];
+    if (sensor_report_encoder_open_sample(context, SOFT_NUM_SAMPLE_MEMBERS) != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to open soft sample in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &soft_sample.temp_mean_deg_c) != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member,
+                                                &soft_sample.reading_count) != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
+      break;
+    }
+    if (sensor_report_encoder_close_sample(context) != CborNoError) {
+      BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
+      break;
+    }
+    rval = true;
+    break;
+  }
   default: {
     BRIDGE_LOG_PRINT("Received invalid sensor type in addSamplesToReport\n");
     break;
@@ -466,8 +518,15 @@ static void report_builder_task(void *parameters) {
               app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = NULL;
               uint8_t *cbor_buffer = NULL;
               do {
-                // This num_sensors is for the cbor encoder and we subtract one since the bridge is not included in the report
-                uint32_t num_sensors = _ctx._report_period_num_nodes - 1;
+                // This num_sensors is for the cbor encoder. We will loop through the sensors type list
+                // and only count the number of sensors that are not UNKNOWN_SENSOR_TYPE
+                uint32_t num_sensors = 0;
+                for (size_t i = 0; i < _ctx._report_period_num_nodes; i++) {
+                  if (_ctx._report_period_sensor_type_list[i] > UNKNOWN_SENSOR_TYPE) {
+                    num_sensors++;
+                  }
+                }
+
                 sensor_report_encoder_context_t context;
                 cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
                 configASSERT(cbor_buffer != NULL);
@@ -484,19 +543,40 @@ static void report_builder_task(void *parameters) {
                   if (element == NULL) {
                     constexpr size_t bufsize = 80;
                     static char buffer[bufsize];
-                    int len = snprintf(buffer, bufsize,
-                                       "No data for node %" PRIx64
-                                       " in report period, adding it to the list\n",
-                                       _ctx._report_period_node_list[i]);
-                    BRIDGE_LOG_PRINTN(buffer, len);
-                    // we have a sensor that may have been added at the end of the report period
-                    // so lets add it to the list and this wil backfill all of the data so we can still send it
-                    // in the report. We will need to pass (_ctx._sample_counter - 1) to make sure we don't overflow the sensor_data buffer.
-                    // Also we will pass NULL into the sensor_data since we don't have any data for it yet and we will fill the whole thing with NANs
-                    _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
-                        _ctx._report_period_node_list[i], AANDERAA_SENSOR_TYPE, NULL,
-                        sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport,
-                        (_ctx._sample_counter - 1));
+                    if (_ctx._report_period_sensor_type_list[i] > UNKNOWN_SENSOR_TYPE) {
+                      int len = snprintf(buffer, bufsize,
+                                         "No data for node %" PRIx64
+                                         " in report period, adding it to the list\n",
+                                         _ctx._report_period_node_list[i]);
+                      BRIDGE_LOG_PRINTN(buffer, len);
+                      switch (_ctx._report_period_sensor_type_list[i]) {
+                      case AANDERAA_SENSOR_TYPE: {
+                        _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
+                            _ctx._report_period_node_list[i],
+                            _ctx._report_period_sensor_type_list[i], NULL,
+                            sizeof(aanderaa_aggregations_t), _ctx._samplesPerReport,
+                            (_ctx._sample_counter - 1));
+                        break;
+                      }
+                      case SOFT_SENSOR_TYPE: {
+                        _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
+                            _ctx._report_period_node_list[i],
+                            _ctx._report_period_sensor_type_list[i], NULL,
+                            sizeof(soft_aggregations_t), _ctx._samplesPerReport,
+                            (_ctx._sample_counter - 1));
+                        break;
+                      }
+                      default: {
+                        BRIDGE_LOG_PRINT("Invalid sensor type in report_builder_task\n");
+                        break;
+                      }
+                      }
+                    } else {
+                      BRIDGE_LOG_PRINT("Unknown sensor type in report_builder_task\n");
+                      // This is an unkown sensor type (i.e. hello world or something else) so we won't add it to the report.
+                      // So instead, lets continue the for loop to the next node!
+                      continue;
+                    }
                     element = _ctx._reportBuilderLinkedList.findElement(
                         _ctx._report_period_node_list[i]);
                   } else {
@@ -571,6 +651,8 @@ static void report_builder_task(void *parameters) {
           _ctx._report_period_num_nodes = 0;
           _ctx._report_period_max_network_crc32 = 0;
           memset(_ctx._report_period_node_list, 0, sizeof(_ctx._report_period_node_list));
+          memset(_ctx._report_period_sensor_type_list, 0,
+                 sizeof(_ctx._report_period_sensor_type_list));
         }
         break;
       }
@@ -625,6 +707,17 @@ static void report_builder_task(void *parameters) {
                 _ctx._report_period_num_nodes = temp_num_nodes;
                 memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
                 _ctx._report_period_max_network_crc32 = temp_network_crc32;
+                size_t report_period_sensor_type_list_size =
+                    sizeof(_ctx._report_period_sensor_type_list);
+                if (!topology_sampler_get_sensor_type_list(_ctx._report_period_sensor_type_list,
+                                                           report_period_sensor_type_list_size,
+                                                           _ctx._report_period_num_nodes,
+                                                           TOPO_TIMEOUT_MS)) {
+                  BRIDGE_LOG_PRINT("Failed to get the sensor type list in report builder!\n");
+                } else {
+                  BRIDGE_LOG_PRINT("Got sensor type list in report builder!\n");
+                }
+
               } else {
                 BRIDGE_LOG_PRINT("Not updating CRC and topology in report builder, new "
                                  "topology is smaller than the old one!\n");

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -182,7 +182,7 @@ void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *eleme
                                                  uint8_t sensor_type, void *sensor_data,
                                                  uint32_t sample_counter) {
   switch (sensor_type) {
-  case AANDERAA_SENSOR_TYPE: {
+  case SENSOR_TYPE_AANDERAA: {
     if (element->sample_counter < sample_counter) {
       // Back fill the sensor_data with NANs if we are not on the right sample counter
       // We use the element->sample_counter to track within each element how many samples
@@ -208,7 +208,7 @@ void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *eleme
     element->sample_counter++;
     break;
   }
-  case SOFT_SENSOR_TYPE: {
+  case SENSOR_TYPE_SOFT: {
     if (element->sample_counter < sample_counter) {
       // Back fill the sensor_data with NANs if we are not on the right sample counter
       // We use the element->sample_counter to track within each element how many samples
@@ -381,7 +381,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
                                void *sensor_data, uint32_t sample_index) {
   bool rval = false;
   switch (sensor_type) {
-  case AANDERAA_SENSOR_TYPE: {
+  case SENSOR_TYPE_AANDERAA: {
     aanderaa_aggregations_t aanderaa_sample =
         (static_cast<aanderaa_aggregations_t *>(sensor_data))[sample_index];
     if (sensor_report_encoder_open_sample(context, AANDERAA_NUM_SAMPLE_MEMBERS,
@@ -444,7 +444,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     rval = true;
     break;
   }
-  case SOFT_SENSOR_TYPE: {
+  case SENSOR_TYPE_SOFT: {
     soft_aggregations_t soft_sample =
         (static_cast<soft_aggregations_t *>(sensor_data))[sample_index];
     if (sensor_report_encoder_open_sample(context, SOFT_NUM_SAMPLE_MEMBERS,
@@ -547,7 +547,7 @@ static void report_builder_task(void *parameters) {
                                          _ctx._report_period_node_list[i]);
                       BRIDGE_LOG_PRINTN(buffer, len);
                       switch (_ctx._report_period_sensor_type_list[i]) {
-                      case AANDERAA_SENSOR_TYPE: {
+                      case SENSOR_TYPE_AANDERAA: {
                         _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
                             _ctx._report_period_node_list[i],
                             _ctx._report_period_sensor_type_list[i], NULL,
@@ -555,7 +555,7 @@ static void report_builder_task(void *parameters) {
                             (_ctx._sample_counter - 1));
                         break;
                       }
-                      case SOFT_SENSOR_TYPE: {
+                      case SENSOR_TYPE_SOFT: {
                         _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
                             _ctx._report_period_node_list[i],
                             _ctx._report_period_sensor_type_list[i], NULL,

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -458,11 +458,11 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
       break;
     }
-    if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member,
-                                                &soft_sample.reading_count) != CborNoError) {
-      BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
-      break;
-    }
+    // if (sensor_report_encoder_add_sample_member(context, encode_uint_sample_member,
+    //                                             &soft_sample.reading_count) != CborNoError) {
+    //   BRIDGE_LOG_PRINT("Failed to add soft sample member in addSamplesToReport\n");
+    //   break;
+    // }
     if (sensor_report_encoder_close_sample(context) != CborNoError) {
       BRIDGE_LOG_PRINT("Failed to close sample in addSamplesToReport\n");
       break;

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -12,12 +12,6 @@ typedef enum {
   REPORT_BUILDER_CHECK_CRC,
 } report_builder_message_e;
 
-typedef enum : uint8_t{
-  UNKNOWN_SENSOR_TYPE = 0,
-  AANDERAA_SENSOR_TYPE = 1,
-  SOFT_SENSOR_TYPE = 2,
-} report_builder_sensor_type_e;
-
 typedef struct {
   report_builder_message_e message_type;
   uint64_t node_id;

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -4,6 +4,7 @@
 #include "queue.h"
 #include "configuration.h"
 #include "aanderaaSensor.h"
+#include "softSensor.h"
 
 typedef enum {
   REPORT_BUILDER_INCREMENT_SAMPLE_COUNT,
@@ -11,8 +12,10 @@ typedef enum {
   REPORT_BUILDER_CHECK_CRC,
 } report_builder_message_e;
 
-typedef enum {
-  AANDERAA_SENSOR_TYPE = 0,
+typedef enum : uint8_t{
+  UNKNOWN_SENSOR_TYPE = 0,
+  AANDERAA_SENSOR_TYPE = 1,
+  SOFT_SENSOR_TYPE = 2,
 } report_builder_sensor_type_e;
 
 typedef struct {

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -10,6 +10,7 @@
 #include "task_priorities.h"
 #include "util.h"
 
+// TODO: Once we have bcmp_config request reply, we should read this value from the modules.
 #define DEFAULT_CURRENT_READING_PERIOD_MS 60 * 1000 // default is 1 minute: 60,000 ms
 #define DEFAULT_SOFT_READING_PERIOD_MS 500 // default is 500 ms (2 HZ)
 

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -106,6 +106,9 @@ static void runController(void *param) {
           if(curr->type == SENSOR_TYPE_AANDERAA){
             Aanderaa_t* aanderaa = static_cast<Aanderaa_t*>(curr);
             aanderaa->aggregate();
+          } else if (curr->type == SENSOR_TYPE_SOFT) {
+            Soft_t *soft = static_cast<Soft_t *>(curr);
+            soft->aggregate();
           }
           curr = curr->next;
         }

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -177,7 +177,7 @@ void AanderaaSensor::aggregate(void) {
     } else {
       printf("ERROR: Failed to print Aanderaa data\n");
     }
-    reportBuilderAddToQueue(node_id, AANDERAA_SENSOR_TYPE, static_cast<void *>(&agg), sizeof(aanderaa_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
+    reportBuilderAddToQueue(node_id, SENSOR_TYPE_AANDERAA, static_cast<void *>(&agg), sizeof(aanderaa_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
     memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
     // Clear the buffers
     abs_speed_cm_s.clear();

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -146,7 +146,7 @@ void AanderaaSensor::aggregate(void) {
     if(!logRtcGetTimeStr(timeStrbuf, TIME_STR_BUFSIZE,true)){
       printf("Failed to get time string for Aanderaa aggregation\n");
       snprintf(timeStrbuf, TIME_STR_BUFSIZE, "0");
-    };
+    }
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                     "%s,"          // timestamp(ticks/UTC)
                     "%" PRIx64 "," // Node Id
@@ -176,8 +176,6 @@ void AanderaaSensor::aggregate(void) {
       printf("ERROR: Failed to print Aanderaa data\n");
     }
     reportBuilderAddToQueue(node_id, AANDERAA_SENSOR_TYPE, static_cast<void *>(&agg), sizeof(aanderaa_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
-    // TODO - send aggregated data to a "report builder" task that will
-    // combine all the data from all the sensors and send it to the spotter
     memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
     // Clear the buffers
     abs_speed_cm_s.clear();

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -73,7 +73,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
                      "%.3f,"          // north_cm_s
                      "%.3f,"          // tilt_x_deg
                      "%.3f,"          // tilt_y_deg
-                     "%.3f\n",         // transducer_strength_db
+                     "%.3f\n",        // transducer_strength_db
                      node_id, d.header.reading_uptime_millis, reading_time_sec,
                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
                      d.abs_speed_cm_s, d.abs_tilt_deg, d.direction_deg_m, d.east_cm_s,

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -81,6 +81,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
                      d.std_tilt_deg, d.temperature_deg_c, d.north_cm_s, d.tilt_x_deg,
                      d.tilt_y_deg, d.transducer_strength_db);
         if (log_buflen > 0) {
+          // TODO - keep as individual log or switch to the bm_sensor common log
           BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print Aanderaa data\n");
@@ -171,6 +172,7 @@ void AanderaaSensor::aggregate(void) {
                     agg.std_tilt_mean_rad,
                     agg.reading_count);
     if (log_buflen > 0) {
+      // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print Aanderaa data\n");

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.h
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.h
@@ -8,6 +8,11 @@
 
 #define AANDERAA_NUM_SAMPLE_MEMBERS 8
 
+// Clang doesn't have M_TWOPI defined in math.h so for CI tests we define it here.
+#ifdef CI_TEST
+#define M_TWOPI 2*M_PI
+#endif
+
 typedef struct aanderaa_aggregations_s {
   double abs_speed_mean_cm_s;
   double abs_speed_std_cm_s;

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -3,7 +3,7 @@
 #include "semphr.h"
 #include <stdint.h>
 
-typedef enum abstractSensorType {
+typedef enum abstractSensorType : uint8_t {
     SENSOR_TYPE_UNKNOWN = 0,
     SENSOR_TYPE_AANDERAA = 1,
     SENSOR_TYPE_SOFT = 2,

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -6,6 +6,7 @@
 typedef enum abstractSensorType {
     SENSOR_TYPE_UNKNOWN = 0,
     SENSOR_TYPE_AANDERAA = 1,
+    SENSOR_TYPE_SOFT = 2,
 } abstractSensorType_e;
 
 struct AbstractSensor {

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -1,15 +1,15 @@
 #include "softSensor.h"
-#include "bm_soft_data_msg.h"
 #include "app_config.h"
 #include "avgSampler.h"
 #include "bm_network.h"
 #include "bm_pubsub.h"
+#include "bm_soft_data_msg.h"
 #include "bridgeLog.h"
 #include "device_info.h"
 #include "reportBuilder.h"
 #include "semphr.h"
-#include "util.h"
 #include "stm32_rtc.h"
+#include "util.h"
 #include <new>
 
 bool SoftSensor::subscribe() {
@@ -58,8 +58,8 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                      "%03" PRIu32 "," // sensor_reading_time_ms millis part
                      "%.3f\n",        // temp_deg_c
                      node_id, soft_data.header.reading_uptime_millis, reading_time_sec,
-                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
-                      soft_data.temperature_deg_c);
+                     reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
+                     soft_data.temperature_deg_c);
         if (log_buflen > 0) {
           // TODO - keep as individual log or switch to the bm_sensor common log
           BRIDGE_SENSOR_LOG_PRINTN(SOFT_IND, log_buf, log_buflen);
@@ -86,7 +86,8 @@ void SoftSensor::aggregate(void) {
     if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       soft_aggs.temp_mean_deg_c = temp_deg_c.getMean();
       soft_aggs.reading_count = reading_count;
-      if (soft_aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||soft_aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
+      if (soft_aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||
+          soft_aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
         soft_aggs.temp_mean_deg_c = NAN;
       }
     }
@@ -96,19 +97,21 @@ void SoftSensor::aggregate(void) {
       printf("Failed to get RTC time string for Soft aggregation\n");
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
-    log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
-                          "%s,"          // timstamp(ticks/UTC)
-                          "%" PRIx64 "," // Node Id
-                          "%" PRIu32 "," // reading_count
-                          "%.3f\n",      // temp_mean_deg_c
-                          time_str, node_id, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
+    log_buflen =
+        snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                 "%s,"          // timstamp(ticks/UTC)
+                 "%" PRIx64 "," // Node Id
+                 "%" PRIu32 "," // reading_count
+                 "%.3f\n",      // temp_mean_deg_c
+                 time_str, node_id, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
       // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(SOFT_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print soft aggregate log\n");
     }
-    reportBuilderAddToQueue(node_id, SENSOR_TYPE_SOFT, static_cast<void *>(&soft_aggs), sizeof(soft_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
+    reportBuilderAddToQueue(node_id, SENSOR_TYPE_SOFT, static_cast<void *>(&soft_aggs),
+                            sizeof(soft_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
     memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
     // Clear the buffers
     temp_deg_c.clear();
@@ -120,7 +123,8 @@ void SoftSensor::aggregate(void) {
   vPortFree(log_buf);
 }
 
-Soft_t* createSoftSub(uint64_t node_id, uint32_t current_agg_period_ms, uint32_t averager_max_samples) {
+Soft_t *createSoftSub(uint64_t node_id, uint32_t current_agg_period_ms,
+                      uint32_t averager_max_samples) {
   Soft_t *new_sub = static_cast<Soft_t *>(pvPortMalloc(sizeof(Soft_t)));
   new_sub = new (new_sub) Soft_t();
   configASSERT(new_sub);

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -1,0 +1,136 @@
+#include "softSensor.h"
+#include "bm_soft_data_msg.h"
+#include "app_config.h"
+#include "avgSampler.h"
+#include "bm_network.h"
+#include "bm_pubsub.h"
+#include "bridgeLog.h"
+#include "device_info.h"
+#include "reportBuilder.h"
+#include "semphr.h"
+#include "util.h"
+#include "stm32_rtc.h"
+#include <new>
+
+bool SoftSensor::subscribe() {
+  bool rval = false;
+  char *sub = static_cast<char *>(pvPortMalloc(BM_TOPIC_MAX_LEN));
+  configASSERT(sub);
+  int topic_strlen = snprintf(sub, BM_TOPIC_MAX_LEN, "%" PRIx64 "%s", node_id, subtag);
+  if (topic_strlen > 0) {
+    rval = bm_sub_wl(sub, topic_strlen, softSubCallback);
+  }
+  vPortFree(sub);
+  return rval;
+}
+
+void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                 const uint8_t *data, uint16_t data_len, uint8_t type,
+                                 uint8_t version) {
+  (void)type;
+  (void)version;
+  printf("SOFT data received from node %" PRIx64 " On topic: %.*s\n", node_id, topic_len,
+         topic);
+  Soft_t *soft = static_cast<Soft_t *>(sensorControllerFindSensorById(node_id));
+  if (soft && soft->type == SENSOR_TYPE_SOFT) {
+    if (xSemaphoreTake(soft->_mutex, portMAX_DELAY)) {
+      static BmSoftDataMsg::Data soft_data;
+      if (BmSoftDataMsg::decode(soft_data, data, data_len) == CborNoError) {
+        char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
+        configASSERT(log_buf);
+        soft->temp_deg_c.addSample(soft_data.temperature_deg_c);
+        soft->reading_count++;
+
+        // Large floats get formatted in scientific notation,
+        // so we print integer seconds and millis separately.
+        uint64_t reading_time_sec = soft_data.header.reading_time_utc_ms / 1000U;
+        uint32_t reading_time_millis = soft_data.header.reading_time_utc_ms % 1000U;
+        uint64_t sensor_reading_time_sec = soft_data.header.sensor_reading_time_ms / 1000U;
+        uint32_t sensor_reading_time_millis = soft_data.header.sensor_reading_time_ms % 1000U;
+
+        size_t log_buflen =
+            snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                     "%" PRIx64 ","   // Node Id
+                     "%" PRIu64 ","   // reading_uptime_millis
+                     "%" PRIu64 "."   // reading_time_utc_ms seconds part
+                     "%03" PRIu32 "," // reading_time_utc_ms millis part
+                     "%" PRIu64 "."   // sensor_reading_time_ms seconds part
+                     "%03" PRIu32 "," // sensor_reading_time_ms millis part
+                     "%.3f\n",          // temp_deg_c
+                     node_id, soft_data.header.reading_uptime_millis, reading_time_sec,
+                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
+                      soft_data.temperature_deg_c);
+        if (log_buflen > 0) {
+          BRIDGE_SENSOR_LOG_PRINTN(SOFT_IND, log_buf, log_buflen);
+        } else {
+          printf("ERROR: Failed to print soft individual log\n");
+        }
+        vPortFree(log_buf);
+      }
+      xSemaphoreGive(soft->_mutex);
+    } else {
+      printf("Failed to get the subbed Soft mutex after getting a new reading\n");
+    }
+  }
+}
+
+void SoftSensor::aggregate(void) {
+  char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
+  configASSERT(log_buf);
+  if (xSemaphoreTake(_mutex, portMAX_DELAY)) {
+    size_t log_buflen = 0;
+    soft_aggregations_t soft_aggs = {.temp_mean_deg_c = NAN, .reading_count = 0};
+    // Check to make sure we have enough sensor readings for a valid aggregation.
+    // If not send NaNs for all the values.
+    if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
+      soft_aggs.temp_mean_deg_c = temp_deg_c.getMean();
+      soft_aggs.reading_count = reading_count;
+      if (soft_aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||soft_aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
+        soft_aggs.temp_mean_deg_c = NAN;
+      }
+    }
+    static constexpr uint8_t TIME_STR_BUFSIZE = 50;
+    char time_str[TIME_STR_BUFSIZE];
+    if (!logRtcGetTimeStr(time_str, TIME_STR_BUFSIZE, true)) {
+      printf("Failed to get RTC time string for Soft aggregation\n");
+      snprintf(time_str, TIME_STR_BUFSIZE, "0");
+    }
+    log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                          "%s,"          // timstamp(ticks/UTC)
+                          "%" PRIx64 "," // Node Id
+                          "%" PRIu32 "," // reading_count
+                          "%.3f\n",      // temp_mean_deg_c
+                          time_str, node_id, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
+    if (log_buflen > 0) {
+      BRIDGE_SENSOR_LOG_PRINTN(SOFT_AGG, log_buf, log_buflen);
+    } else {
+      printf("ERROR: Failed to print soft aggregate log\n");
+    }
+    reportBuilderAddToQueue(node_id, SENSOR_TYPE_SOFT, static_cast<void *>(&soft_aggs), sizeof(soft_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
+    memset(log_buf, 0, SENSOR_LOG_BUF_SIZE);
+    // Clear the buffers
+    temp_deg_c.clear();
+    reading_count = 0;
+    xSemaphoreGive(_mutex);
+  } else {
+    printf("Failed to get the subbed Soft mutex while trying to aggregate\n");
+  }
+  vPortFree(log_buf);
+}
+
+Soft_t* createSoftSub(uint64_t node_id, uint32_t current_agg_period_ms, uint32_t averager_max_samples) {
+  Soft_t *new_sub = static_cast<Soft_t *>(pvPortMalloc(sizeof(Soft_t)));
+  new_sub = new (new_sub) Soft_t();
+  configASSERT(new_sub);
+
+  new_sub->_mutex = xSemaphoreCreateMutex();
+  configASSERT(new_sub->_mutex);
+
+  new_sub->node_id = node_id;
+  new_sub->type = SENSOR_TYPE_SOFT;
+  new_sub->next = NULL;
+  new_sub->current_agg_period_ms = current_agg_period_ms;
+  new_sub->temp_deg_c.initBuffer(averager_max_samples);
+  new_sub->reading_count = 0;
+  return new_sub;
+}

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -61,6 +61,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                       reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
                       soft_data.temperature_deg_c);
         if (log_buflen > 0) {
+          // TODO - keep as individual log or switch to the bm_sensor common log
           BRIDGE_SENSOR_LOG_PRINTN(SOFT_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print soft individual log\n");
@@ -102,6 +103,7 @@ void SoftSensor::aggregate(void) {
                           "%.3f\n",      // temp_mean_deg_c
                           time_str, node_id, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
+      // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(SOFT_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print soft aggregate log\n");

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -56,7 +56,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                      "%03" PRIu32 "," // reading_time_utc_ms millis part
                      "%" PRIu64 "."   // sensor_reading_time_ms seconds part
                      "%03" PRIu32 "," // sensor_reading_time_ms millis part
-                     "%.3f\n",          // temp_deg_c
+                     "%.3f\n",        // temp_deg_c
                      node_id, soft_data.header.reading_uptime_millis, reading_time_sec,
                       reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
                       soft_data.temperature_deg_c);

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -35,7 +35,7 @@ private:
                              uint8_t version);
 
 private:
-  static constexpr char subtag[] = "/soft";
+  static constexpr char subtag[] = "/bm_soft_temp";
 } Soft_t;
 
 Soft_t* createSoftSub(uint64_t node_id, uint32_t current_agg_period_ms, uint32_t averager_max_samples);

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define SOFT_NUM_SAMPLE_MEMBERS 2
+#define SOFT_NUM_SAMPLE_MEMBERS 1
 
 typedef struct soft_aggregations_s {
   double temp_mean_deg_c;

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -22,8 +22,8 @@ typedef struct SoftSensor : public AbstractSensor {
   // Extra sample padding to account for timing slop.
   static constexpr uint32_t N_SAMPLES_PAD = 10;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5.0;
-  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40.0;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -200.0;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 200.0;
 
 public:
   bool subscribe() override;

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "FreeRTOS.h"
+#include "abstractSensor.h"
+#include "avgSampler.h"
+#include "sensorController.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define SOFT_NUM_SAMPLE_MEMBERS 2
+
+typedef struct soft_aggregations_s {
+  double temp_mean_deg_c;
+  uint32_t reading_count;
+} soft_aggregations_t;
+
+typedef struct SoftSensor : public AbstractSensor {
+  uint32_t current_agg_period_ms;
+  AveragingSampler temp_deg_c;
+  uint32_t reading_count;
+
+  // Extra sample padding to account for timing slop.
+  static constexpr uint32_t N_SAMPLES_PAD = 10;
+  static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5.0;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40.0;
+
+public:
+  bool subscribe() override;
+  void aggregate(void);
+
+private:
+  static void softSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                             const uint8_t *data, uint16_t data_len, uint8_t type,
+                             uint8_t version);
+
+private:
+  static constexpr char subtag[] = "/soft";
+} Soft_t;
+
+Soft_t* createSoftSub(uint64_t node_id, uint32_t current_agg_period_ms, uint32_t averager_max_samples);

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -768,6 +768,9 @@ void bm_topology_last_network_info_cb(void){
  * the node list. By default the sensor type list is initialized to SENSOR_TYPE_UNKNOWN,
  * aka zero's.
  *
+ * Note: This function can only be called in a location that has taken the
+ * _node_list.node_list_mutex.
+ *
  * @param node_id The ID of the node to update.
  * @param app_name The name of the application associated with the node.
  * @param app_name_len The length of the application name.

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -757,7 +757,21 @@ void bm_topology_last_network_info_cb(void){
   }
 }
 
-
+/**
+ * @brief Updates the sensor type list with the given node ID and application name.
+ *
+ * This function iterates over the node list. If a node with the given ID is found,
+ * the function checks the application name. If the application name is "aanderaa",
+ * the sensor type for that node is set to SENSOR_TYPE_AANDERAA. If the application
+ * name is "bm_soft_module", the sensor type for that node is set to SENSOR_TYPE_SOFT.
+ * This function makes sure that the sensor type list is updated in the same order as
+ * the node list. By default the sensor type list is initialized to SENSOR_TYPE_UNKNOWN,
+ * aka zero's.
+ *
+ * @param node_id The ID of the node to update.
+ * @param app_name The name of the application associated with the node.
+ * @param app_name_len The length of the application name.
+ */
 void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len) {
   (void) app_name_len;
   for (uint8_t i = 0; i < TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE; i++) {

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -22,7 +22,6 @@
 #include "config_cbor_map_srv_request_msg.h"
 #include "crc.h"
 #include "device_info.h"
-#include "reportBuilder.h"
 #include "sm_config_crc_list.h"
 #include "sys_info_service.h"
 #include "sys_info_svc_reply_msg.h"
@@ -53,6 +52,7 @@ typedef struct network_configuration_info {
 
 typedef struct node_list {
   uint64_t nodes[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
+  report_builder_sensor_type_e sensor_type[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
   uint16_t num_nodes;
   SemaphoreHandle_t node_list_mutex;
   network_configuration_info_s last_network_configuration_info;
@@ -81,6 +81,8 @@ static bool encode_cbor_configuration(CborEncoder &array_encoder,
                                       ConfigCborMapSrvReplyMsg::Data &cbor_map_reply);
 static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bufsize);
 
+static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len);
+
 static void topology_sample_cb(networkTopology_t *networkTopology) {
   uint8_t *cbor_buffer = NULL;
   bm_common_network_info_t *network_info = NULL;
@@ -104,6 +106,7 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
     configASSERT(sizeof(_node_list.nodes) >= _node_list.num_nodes * sizeof(uint64_t));
 
     memset(_node_list.nodes, 0, sizeof(_node_list.nodes));
+    memset(_node_list.sensor_type, 0, sizeof(_node_list.sensor_type));
 
     neighborTableEntry_t *cursor = NULL;
     uint16_t counter;
@@ -391,6 +394,14 @@ static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bu
       // Update the network crc with all of the node crcs
       if (xQueueReceive(_sys_info_queue, &info_reply,
                         pdMS_TO_TICKS(NODE_NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS))) {
+
+        // Call function here that will update the sensor_type list and match a node id to a sensor type
+        // This function will use the app name to determine the sensor type and update the _node_list.sensor_type array
+        // so that the reportBuilder can pull the sensor type from the node id. The sensor type array will match the
+        // order of the node id array. This function call is placed here since it is run from the context of the topology
+        // sampler callback, which will have the _node_list mutex taken.
+        _update_sensor_type_list(info_reply.node_id, info_reply.app_name, info_reply.app_name_strlen);
+
         // If we have a sys info reply coming back, request the cbor map
         if (!config_cbor_map_service_request(info_reply.node_id, CONFIG_CBOR_MAP_PARTITION_ID_SYS,
                                            cbor_config_map_reply_cb,
@@ -662,6 +673,36 @@ bool topology_sampler_get_node_list(uint64_t *node_list, size_t &node_list_size,
 }
 
 /*!
+  * @brief Get the sensor type list from the topology sampler
+  * @param[out] sensor_type_list The sensor type list to populate
+  * @param[in,out] sensor_type_list_size The size of the sensor type list in bytes. Will be updated with the size of the sensor type list in bytes.
+  * @param[out] num_nodes The number of nodes in the node list.
+  * @param[in] timeout_ms The timeout in milliseconds.
+ */
+bool topology_sampler_get_sensor_type_list(report_builder_sensor_type_e *sensor_type_list,
+                                           size_t &sensor_type_list_size, uint32_t &num_nodes,
+                                           uint32_t timeout_ms) {
+  configASSERT(sensor_type_list);
+  bool rval = false;
+  if (xSemaphoreTake(_node_list.node_list_mutex, pdMS_TO_TICKS(timeout_ms))) {
+    do {
+      if (!_node_list.num_nodes) {
+        break;
+      }
+      if (sensor_type_list_size < _node_list.num_nodes * sizeof(report_builder_sensor_type_e)) {
+        break;
+      }
+      num_nodes = _node_list.num_nodes;
+      sensor_type_list_size = _node_list.num_nodes * sizeof(report_builder_sensor_type_e);
+      memcpy(sensor_type_list, _node_list.sensor_type, sensor_type_list_size);
+      rval = true;
+    } while (0);
+    xSemaphoreGive(_node_list.node_list_mutex);
+  }
+  return rval;
+}
+
+/*!
  * @brief Get the last network configuration from the topology sampler
  * @note This function will allocate memory for the cbor config map, the caller is responsible for freeing it.
  * @param[out] network_crc32 The network crc32
@@ -714,5 +755,23 @@ void bm_topology_last_network_info_cb(void){
                                   _node_list.last_network_configuration_info.cbor_config_map);
     } while (0);
     xSemaphoreGive(_node_list.node_list_mutex);
+  }
+}
+
+
+void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len) {
+  (void) app_name_len;
+  for (uint8_t i = 0; i < TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE; i++) {
+    if (_node_list.nodes[i] == node_id) {
+      if (strncmp(app_name, "aanderaa", strlen("aanderaa")) == 0) {
+        _node_list.sensor_type[i] = AANDERAA_SENSOR_TYPE;
+        printf("Found aanderaa sensor node %" PRIx64 " in the topology sampler!\n", node_id);
+        break;
+      } else if (strncmp(app_name, "bm_soft_module", strlen("bm_soft_module")) == 0) {
+        _node_list.sensor_type[i] = SOFT_SENSOR_TYPE;
+        printf("Found soft sensor node %" PRIx64 " in the topology sampler!\n", node_id);
+        break;
+      }
+    }
   }
 }

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -775,7 +775,7 @@ void bm_topology_last_network_info_cb(void){
  * @param app_name The name of the application associated with the node.
  * @param app_name_len The length of the application name.
  */
-void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len) {
+static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len) {
   (void) app_name_len;
   for (uint8_t i = 0; i < TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE; i++) {
     if (_node_list.nodes[i] == node_id) {

--- a/src/lib/common/topology_sampler.h
+++ b/src/lib/common/topology_sampler.h
@@ -4,6 +4,7 @@
 #include "task.h"
 #include "configuration.h"
 #include "bridgePowerController.h"
+#include "reportBuilder.h"
 
 #include <stdint.h>
 
@@ -11,5 +12,6 @@
 
 void topology_sampler_init(BridgePowerController *power_controller, cfg::Configuration* hw_cfg, cfg::Configuration* sys_cfg);
 bool topology_sampler_get_node_list(uint64_t *node_list, size_t &node_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
+bool topology_sampler_get_sensor_type_list(report_builder_sensor_type_e *sensor_type_list, size_t &sensor_type_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
 uint8_t* topology_sampler_alloc_last_network_config(uint32_t &network_crc32, uint32_t &cbor_config_size);
 void bm_topology_last_network_info_cb(void);

--- a/src/lib/common/topology_sampler.h
+++ b/src/lib/common/topology_sampler.h
@@ -12,6 +12,6 @@
 
 void topology_sampler_init(BridgePowerController *power_controller, cfg::Configuration* hw_cfg, cfg::Configuration* sys_cfg);
 bool topology_sampler_get_node_list(uint64_t *node_list, size_t &node_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
-bool topology_sampler_get_sensor_type_list(report_builder_sensor_type_e *sensor_type_list, size_t &sensor_type_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
+bool topology_sampler_get_sensor_type_list(abstractSensorType_e *sensor_type_list, size_t &sensor_type_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
 uint8_t* topology_sampler_alloc_last_network_config(uint32_t &network_crc32, uint32_t &cbor_config_size);
 void bm_topology_last_network_info_cb(void);


### PR DESCRIPTION
Adding support for SOFT on the bridge. The bridge will by default assume a 2 HZ sampling frequency(there is a config to change this expected frequency if needed) for the Soft modules and upon subscribing to the Soft node it will create buffers large enough to take in that many samples. It will then aggregate those buffers at the end of a sample duration and send the aggregated sample to the reportBuilder. After receiving enough aggregations the reportBuilder will cbor encode the SOFT aggregations and send them to Spotter.

Right not I implemented logging of individual and aggregate readings in the same way the Aanderaa logs are done, however, there has been a decision to merge these into shared logs. There are still some details that need to be spec'd out, but those changes will come in a separate PR.