### PR TITLE
Fix/dont send reports when no managed sensors

### DIFF
--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -696,8 +696,6 @@ static void report_builder_task(void *parameters) {
             uint32_t temp_num_nodes;
             if (topology_sampler_get_node_list(temp_node_list, temp_node_list_size,
                                                temp_num_nodes, TOPO_TIMEOUT_MS)) {
-              // TODO - we need to use the cbor_map and build a report builder topology map that only
-              // includes aanderaa nodes
               BRIDGE_LOG_PRINT("Got topology in report builder!\n");
               if (temp_num_nodes >= _ctx._report_period_num_nodes) {
                 BRIDGE_LOG_PRINT("Updating CRC and topology in report builder!\n");

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -509,21 +509,21 @@ static void report_builder_task(void *parameters) {
         BRIDGE_LOG_PRINTN(buffer, len);
         if (_ctx._sample_counter >= _ctx._samplesPerReport) {
           if (_ctx._samplesPerReport > 0 && _ctx._transmitAggregations) {
+            // This num_sensors is for the cbor encoder to know how many sensors will be in the report.
+            // We will loop through the sensors type list and only count the number of sensors that are
+            // not UNKNOWN_SENSOR_TYPE.
+            uint32_t num_sensors = 0;
+            for (size_t i = 0; i < _ctx._report_period_num_nodes; i++) {
+              if (_ctx._report_period_sensor_type_list[i] > SENSOR_TYPE_UNKNOWN) {
+                num_sensors++;
+              }
+            }
             // Need to have more than one node to report anything (1 node would be just the bridge)
-            if (_ctx._report_period_num_nodes > 1) {
+            // We also need more than one managed sensor to report anything.
+            if (_ctx._report_period_num_nodes > 1 && num_sensors > 0) {
               app_pub_sub_bm_bridge_sensor_report_data_t *message_buff = NULL;
               uint8_t *cbor_buffer = NULL;
               do {
-                // This num_sensors is for the cbor encoder to know how many sensors will be in the report.
-                // We will loop through the sensors type list and only count the number of sensors that are
-                // not UNKNOWN_SENSOR_TYPE.
-                uint32_t num_sensors = 0;
-                for (size_t i = 0; i < _ctx._report_period_num_nodes; i++) {
-                  if (_ctx._report_period_sensor_type_list[i] > SENSOR_TYPE_UNKNOWN) {
-                    num_sensors++;
-                  }
-                }
-
                 sensor_report_encoder_context_t context;
                 cbor_buffer = static_cast<uint8_t *>(pvPortMalloc(MAX_SENSOR_REPORT_CBOR_LEN));
                 configASSERT(cbor_buffer != NULL);


### PR DESCRIPTION
This is a fix for an edge case. In a system like `devkit | soft` if the SOFT were to go offline, before this fix we would have continued to send BMSensorData1 messages with empty payloads. Now we will only send a report if we have > 1 "managed/known" sensor in out latest topology.


Below we can see after the fix is implemented a line that reads: `Adding sample for 24636777862fb376 to list` this is the sensorController saying I didn't get anything from the soft sensor(node id 24636777862fb376), but here is a NAN report in case during the first sample the sensor was online. This is followed by a line `No nodes to send data for`, and this is the reportBuilder saying during our report window we had no known sensors appear in the topology, so we aren't going to send anything. In this case the node that is lost at the end `193e6faff528b841` is the devkit.
<img width="675" alt="Screenshot 2024-02-05 at 9 55 40 AM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/884b889d-1203-4dc7-ab82-18e1418a7762">
