### PR TITLE
Sc 198772/common bm logs

### DIFF
--- a/src/apps/bm_soft_module/user_code/user_code.cpp
+++ b/src/apps/bm_soft_module/user_code/user_code.cpp
@@ -107,7 +107,7 @@ void loop(void) {
                rtcTimeBuffer, temperature);
     bm_printf(0, "soft | tick: %llu, rtc: %s, temp: %f", uptimeGetMs(), rtcTimeBuffer,
               temperature);
-    BmSoftDataMsg::Data d;
+    static BmSoftDataMsg::Data d;
     d.header.version = 1;
     if (rtcValid) {
       d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) * 1e-3;

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -30,23 +30,13 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION     1
 
-// TODO - keep as sensor specific logs or switch to the bm_sensor common log
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC       "bridge/aanderaa_ind"
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC       "bridge/bm_common_ind"
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_VERSION     1
 
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TOPIC       "bridge/aanderaa_agg"
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION     1
-
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC       "bridge/soft_ind"
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_IND_VERSION     1
-
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC       "bridge/soft_agg"
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_VERSION     1
-// END TODO
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC       "bridge/bm_common_agg"
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_VERSION     1
 
 typedef struct app_pub_sub_bm_bridge_sensor_report_data {
     uint32_t bm_config_crc32;

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -30,13 +30,13 @@ extern "C" {
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE        1
 #define APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION     1
 
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC       "bridge/bm_common_ind"
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC       "bridge/sensor_ind_log"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION     1
 
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC       "bridge/bm_common_agg"
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC       "bridge/sensor_agg_log"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE        1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION     1
 
 typedef struct app_pub_sub_bm_bridge_sensor_report_data {
     uint32_t bm_config_crc32;

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -14,24 +14,16 @@ void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t l
     if(len > 0){
         switch(type) {
             // TODO - keep as sensor specific logs or switch to the bm_sensor common log
-            case AANDERAA_IND:
-                printf("[%s] %.*s", "AANDERAA_IND", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_AANDERAA_IND_VERSION);
+            case BM_COMMON_IND:
+                printf("[%s] %.*s", "BM_COMMON_IND", len, str);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_VERSION);
                 break;
-            case AANDERAA_AGG:
-                printf("[%s] %.*s", "AANDERAA_AGG", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_AANDERAA_AGG_VERSION);
-                break;
-            case SOFT_IND:
-                printf("[%s] %.*s", "SOFT_IND", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SOFT_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_SOFT_IND_VERSION);
-                break;
-            case SOFT_AGG:
-                printf("[%s] %.*s", "SOFT_AGG", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_SOFT_AGG_VERSION);
+            case BM_COMMON_AGG:
+                printf("[%s] %.*s", "BM_COMMON_AGG", len, str);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_VERSION);
                 break;
             default:
-                printf("ERROR: Unknown sensor type in bridgerSensorLogPrintf\n");
+                printf("ERROR: Unknown log type in bridgerSensorLogPrintf\n");
                 break;
         }
     }

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -16,11 +16,11 @@ void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t l
             // TODO - keep as sensor specific logs or switch to the bm_sensor common log
             case BM_COMMON_IND:
                 printf("[%s] %.*s", "BM_COMMON_IND", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_IND_VERSION);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);
                 break;
             case BM_COMMON_AGG:
                 printf("[%s] %.*s", "BM_COMMON_AGG", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_BM_COMMON_AGG_VERSION);
+                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION);
                 break;
             default:
                 printf("ERROR: Unknown log type in bridgerSensorLogPrintf\n");

--- a/src/apps/bridge/bridgeLog.h
+++ b/src/apps/bridge/bridgeLog.h
@@ -4,10 +4,8 @@
 constexpr size_t SENSOR_LOG_BUF_SIZE = 512;
 
 typedef enum {
-    AANDERAA_IND,
-    AANDERAA_AGG,
-    SOFT_IND,
-    SOFT_AGG
+    BM_COMMON_IND,
+    BM_COMMON_AGG,
 } bridgeSensorLogType_e;
 
 void bridgeLogPrintf(const char *str, size_t len);

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -159,7 +159,7 @@ void AanderaaSensor::aggregate(void) {
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                     "%" PRIx64 "," // Node Id
                     "%" PRIu8 ","  // node_position
-                    "aanderaa,"    // nade_app_name
+                    "aanderaa,"    // node_app_name
                     "%s,"          // timestamp(ticks/UTC)
                     "%" PRIu32 "," // reading_count
                     "%.3f,"        // abs_speed_mean_cm_s
@@ -168,20 +168,18 @@ void AanderaaSensor::aggregate(void) {
                     "%.3f,"        // direction_circ_std_rad
                     "%.3f,"        // temp_mean_deg_c
                     "%.3f,"        // abs_tilt_mean_rad
-                    "%.3f,"        // std_tilt_mean_rad
-                    "%" PRIu32 "\n", // reading_count
+                    "%.3f",        // std_tilt_mean_rad
                     node_id,
                     node_position,
                     timeStrbuf,
-                    abs_speed_cm_s.getNumSamples(),
+                    agg.reading_count,
                     agg.abs_speed_mean_cm_s,
                     agg.abs_speed_std_cm_s,
                     agg.direction_circ_mean_rad,
                     agg.direction_circ_std_rad,
                     agg.temp_mean_deg_c,
                     agg.abs_tilt_mean_rad,
-                    agg.std_tilt_mean_rad,
-                    agg.reading_count);
+                    agg.std_tilt_mean_rad);
     if (log_buflen > 0) {
       // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -168,7 +168,7 @@ void AanderaaSensor::aggregate(void) {
                     "%.3f,"        // direction_circ_std_rad
                     "%.3f,"        // temp_mean_deg_c
                     "%.3f,"        // abs_tilt_mean_rad
-                    "%.3f",        // std_tilt_mean_rad
+                    "%.3f\n",      // std_tilt_mean_rad
                     node_id,
                     node_position,
                     timeStrbuf,

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -82,7 +82,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
                      d.tilt_y_deg, d.transducer_strength_db);
         if (log_buflen > 0) {
           // TODO - keep as individual log or switch to the bm_sensor common log
-          BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_IND, log_buf, log_buflen);
+          BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print Aanderaa data\n");
         }
@@ -173,7 +173,7 @@ void AanderaaSensor::aggregate(void) {
                     agg.reading_count);
     if (log_buflen > 0) {
       // TODO - keep as individual log or switch to the bm_sensor common log
-      BRIDGE_SENSOR_LOG_PRINTN(AANDERAA_AGG, log_buf, log_buflen);
+      BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print Aanderaa data\n");
     }

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -58,7 +58,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                      "%" PRIx64 ","   // Node Id
-                     "%" PRIu8 ","    // node_position
+                     "%" PRIi8 ","    // node_position
                      "aanderaa,"      // node_app_name
                      "%" PRIu64 ","   // reading_uptime_millis
                      "%" PRIu64 "."   // reading_time_utc_ms seconds part
@@ -158,7 +158,7 @@ void AanderaaSensor::aggregate(void) {
 
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                     "%" PRIx64 "," // Node Id
-                    "%" PRIu8 ","  // node_position
+                    "%" PRIi8 ","  // node_position
                     "aanderaa,"    // node_app_name
                     "%s,"          // timestamp(ticks/UTC)
                     "%" PRIu32 "," // reading_count

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -113,7 +113,7 @@ void SoftSensor::aggregate(void) {
                  "%s,"          // timstamp(ticks/UTC)
                  "%" PRIu32 "," // reading_count
                  "%.3f\n",      // temp_mean_deg_c
-                 node_id, node_position, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
+                 node_id, node_position, time_str, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
       // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -62,7 +62,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                      soft_data.temperature_deg_c);
         if (log_buflen > 0) {
           // TODO - keep as individual log or switch to the bm_sensor common log
-          BRIDGE_SENSOR_LOG_PRINTN(SOFT_IND, log_buf, log_buflen);
+          BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print soft individual log\n");
         }
@@ -106,7 +106,7 @@ void SoftSensor::aggregate(void) {
                  time_str, node_id, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
       // TODO - keep as individual log or switch to the bm_sensor common log
-      BRIDGE_SENSOR_LOG_PRINTN(SOFT_AGG, log_buf, log_buflen);
+      BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print soft aggregate log\n");
     }

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -54,7 +54,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                      "%" PRIx64 ","   // Node Id
-                     "%" PRIi8, ","   // node_position
+                     "%" PRIi8 ","   // node_position
                      "soft,"          // node_app_name
                      "%" PRIu64 ","   // reading_uptime_millis
                      "%" PRIu64 "."   // reading_time_utc_ms seconds part

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -54,7 +54,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                      "%" PRIx64 ","   // Node Id
-                     "%" PRIi8 ","   // node_position
+                     "%" PRIi8 ","    // node_position
                      "soft,"          // node_app_name
                      "%" PRIu64 ","   // reading_uptime_millis
                      "%" PRIu64 "."   // reading_time_utc_ms seconds part

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -19,8 +19,9 @@ typedef struct SoftSensor : public AbstractSensor {
   AveragingSampler temp_deg_c;
   uint32_t reading_count;
 
-  // Extra sample padding to account for timing slop.
-  static constexpr uint32_t N_SAMPLES_PAD = 10;
+  // Extra sample padding to account for timing slop. Calculated as the sample frequency + 2 minutes bridge on period + some extra slop.
+  // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.
+  static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
   static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
   static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40;

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -22,8 +22,8 @@ typedef struct SoftSensor : public AbstractSensor {
   // Extra sample padding to account for timing slop.
   static constexpr uint32_t N_SAMPLES_PAD = 10;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -200.0;
-  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 200.0;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40;
 
 public:
   bool subscribe() override;

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -702,6 +702,28 @@ bool topology_sampler_get_sensor_type_list(abstractSensorType_e *sensor_type_lis
 }
 
 /*!
+ * @brief Get the node position in the node list from the topology sampler
+ * @param[in] node_id The node id to search for.
+ * @param[in] timeout_ms The timeout in milliseconds.
+ * @return The position of the node in the node list or -1 if not found.
+ */
+int8_t topology_sampler_get_node_position(uint64_t node_id, uint32_t timeout_ms) {
+  int requested_nodes_position = -1;
+  if (xSemaphoreTake(_node_list.node_list_mutex, pdMS_TO_TICKS(timeout_ms))) {
+    do {
+      for (uint8_t i = 0; i < TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE; i++) {
+        if (_node_list.nodes[i] == node_id) {
+          requested_nodes_position = i;
+          break;
+        }
+      }
+    } while (0);
+    xSemaphoreGive(_node_list.node_list_mutex);
+  }
+  return requested_nodes_position;
+}
+
+/*!
  * @brief Get the last network configuration from the topology sampler
  * @note This function will allocate memory for the cbor config map, the caller is responsible for freeing it.
  * @param[out] network_crc32 The network crc32

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -708,7 +708,7 @@ bool topology_sampler_get_sensor_type_list(abstractSensorType_e *sensor_type_lis
  * @return The position of the node in the node list or -1 if not found.
  */
 int8_t topology_sampler_get_node_position(uint64_t node_id, uint32_t timeout_ms) {
-  int requested_nodes_position = -1;
+  int8_t requested_nodes_position = -1;
   if (xSemaphoreTake(_node_list.node_list_mutex, pdMS_TO_TICKS(timeout_ms))) {
     do {
       for (uint8_t i = 0; i < TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE; i++) {

--- a/src/lib/common/topology_sampler.h
+++ b/src/lib/common/topology_sampler.h
@@ -13,5 +13,6 @@
 void topology_sampler_init(BridgePowerController *power_controller, cfg::Configuration* hw_cfg, cfg::Configuration* sys_cfg);
 bool topology_sampler_get_node_list(uint64_t *node_list, size_t &node_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
 bool topology_sampler_get_sensor_type_list(abstractSensorType_e *sensor_type_list, size_t &sensor_type_list_size, uint32_t &num_nodes, uint32_t timeout_ms);
+int8_t topology_sampler_get_node_position(uint64_t node_id, uint32_t timeout_ms);
 uint8_t* topology_sampler_alloc_last_network_config(uint32_t &network_crc32, uint32_t &cbor_config_size);
 void bm_topology_last_network_info_cb(void);


### PR DESCRIPTION
This PR makes all the sensor aggregators on the bridge direct their logs to the shared SENS_AGG and SENS_IND logs for the aggregations and individual readings it collects from the sensors on the bristlemouth bus.

EX AGG log:
```
cat 0001_SENS_AGG.csv
bm_node_id,node_position,node_app_name,timestamp(ticks/UTC),reading_count
910030066a2926a7,1,soft,1707244095.957,542,23.033
24636777862fb376,2,aanderaa,1707244095.957,4,54.750,2.861,2.688,0.039,21.750,0.144,0.415
910030066a2926a7,1,soft,1707244396.019,368,23.418
24636777862fb376,2,aanderaa,1707244396.019,3,56.333,3.091,2.699,0.058,22.667,0.151,0.256
910030066a2926a7,1,soft,1707244695.082,368,23.564
24636777862fb376,2,aanderaa,1707244695.082,3,52.667,3.091,2.705,0.051,22.667,0.134,0.198
910030066a2926a7,1,soft,1707244995.144,370,23.426
24636777862fb376,2,aanderaa,1707244995.148,3,54.667,2.494,2.659,0.036,22.333,0.134,0.361
910030066a2926a7,1,soft,1707245295.210,368,23.359
24636777862fb376,2,aanderaa,1707245295.210,3,54.667,2.357,2.659,0.022,23.667,0.151,0.204
```
EX IND log:
```
bm_node_id,node_position,node_app_name,reading_uptime_millis,reading_time_utc_s,sensor_reading_time_s
910030066a2926a7,1,soft,3279,0.000,0.000,22.749
910030066a2926a7,1,soft,3799,0.000,0.000,22.749
910030066a2926a7,1,soft,4319,0.000,0.000,22.758
910030066a2926a7,1,soft,4839,0.000,0.000,22.749
910030066a2926a7,1,soft,5359,0.000,0.000,22.749
910030066a2926a7,1,soft,5879,0.000,0.000,22.758
910030066a2926a7,1,soft,6399,1707243307.003,0.000,22.758
910030066a2926a7,1,soft,6919,1707243307.523,0.000,22.749
910030066a2926a7,1,soft,7439,1707243308.042,0.000,22.749
910030066a2926a7,1,soft,7959,1707243308.566,0.000,22.749
910030066a2926a7,1,soft,8479,1707243309.085,0.000,22.749
910030066a2926a7,1,soft,8999,1707243309.605,0.000,22.749
910030066a2926a7,1,soft,9519,1707243310.125,0.000,22.749
910030066a2926a7,1,soft,10039,1707243310.644,0.000,22.749
910030066a2926a7,1,soft,10559,1707243311.164,0.000,22.749
910030066a2926a7,1,soft,11079,1707243311.683,0.000,22.758
910030066a2926a7,1,soft,11599,1707243312.203,0.000,22.749
910030066a2926a7,1,soft,12119,1707243312.726,0.000,22.749
910030066a2926a7,1,soft,12639,1707243313.246,0.000,22.749
910030066a2926a7,1,soft,13159,1707243313.765,0.000,22.749
910030066a2926a7,1,soft,13679,1707243314.285,0.000,22.749
910030066a2926a7,1,soft,14199,1707243314.804,0.000,22.749
910030066a2926a7,1,soft,14719,1707243315.324,0.000,22.749
.
.
.
910030066a2926a7,1,soft,61519,1707243362.132,0.000,22.775
910030066a2926a7,1,soft,62039,1707243362.652,0.000,22.775
24636777862fb376,2,aanderaa,62143,1707243363.152,0.000,56.000,9.000,155.000,32.000,167.000,20.000,103.000,0.000,25.000,20.000,47.000,15.000,2.000,0.000
910030066a2926a7,1,soft,62559,1707243363.175,0.000,22.775
910030066a2926a7,1,soft,63079,1707243363.695,0.000,22.775
```