### PR TITLE
Sc 198619/bridge support for rbr

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -253,6 +253,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/sm_config_crc_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgePowerController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/aanderaaSensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/rbrCodaSensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers/softSensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensorController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/aanderaa_data_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/bm_common_messages/bm_soft_data_msg.cpp
+    ${SRC_DIR}/lib/bm_common_messages/bm_rbr_data_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
     ${SRC_DIR}/lib/debug/debug.c

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -18,6 +18,7 @@ constexpr const char *TRANSMIT_AGGREGATIONS = "transmitAggregations";
 constexpr const char *SAMPLES_PER_REPORT = "samplesPerReport";
 constexpr const char *CURRENT_READING_PERIOD_MS = "currentReadingPeriodMs";
 constexpr const char *SOFT_READING_PERIOD_MS = "softReadingPeriodMs";
+constexpr const char *RBR_CODA_READING_PERIOD_MS = "rbrCodaReadingPeriodMs";
 
 } // namespace AppConfig
 

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -61,8 +61,8 @@ static aanderaa_aggregations_t NAN_AGG = {.abs_speed_mean_cm_s = NAN,
 static soft_aggregations_t SOFT_NAN_AGG = {.temp_mean_deg_c = NAN, .reading_count = 0};
 
 static rbr_coda_aggregations_t RBR_CODA_NAN_AGG = {.temp_mean_deg_c = NAN,
-                                                   .pressure_mean_ubar = NAN,
-                                                   .pressure_stdev_ubar = NAN,
+                                                   .pressure_mean_deci_bar = NAN,
+                                                   .pressure_stdev_deci_bar = NAN,
                                                    .reading_count = 0,
                                                    .sensor_type =
                                                        BmRbrDataMsg::SensorType::UNKNOWN};
@@ -547,13 +547,13 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       break;
     }
     if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
-                                                &rbr_coda_sample.pressure_mean_ubar) !=
+                                                &rbr_coda_sample.pressure_mean_deci_bar) !=
         CborNoError) {
       BRIDGE_LOG_PRINT("Failed to add rbr_coda sample member in addSamplesToReport\n");
       break;
     }
     if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
-                                                &rbr_coda_sample.pressure_stdev_ubar) !=
+                                                &rbr_coda_sample.pressure_stdev_deci_bar) !=
         CborNoError) {
       BRIDGE_LOG_PRINT("Failed to add rbr_coda sample member in addSamplesToReport\n");
       break;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -64,7 +64,8 @@ static rbr_coda_aggregations_t RBR_CODA_NAN_AGG = {.temp_mean_deg_c = NAN,
                                                    .pressure_mean_ubar = NAN,
                                                    .pressure_stdev_ubar = NAN,
                                                    .reading_count = 0,
-                                                   .sensor_type = BmRbrDataMsg::SensorType::UNKNOWN};
+                                                   .sensor_type =
+                                                       BmRbrDataMsg::SensorType::UNKNOWN};
 
 class ReportBuilderLinkedList {
 private:
@@ -243,14 +244,20 @@ void ReportBuilderLinkedList::addSampleToElement(report_builder_element_t *eleme
       // Back fill the sensor_data with NANs if we are not on the right sample counter
       // We use the element->sample_counter to track within each element how many samples
       // the element has received.
-      for(; element->sample_counter < sample_counter; element->sample_counter++) {
-        memcpy(&(static_cast<rbr_coda_aggregations_t *>(element->sensor_data))[element->sample_counter], &RBR_CODA_NAN_AGG, sizeof(rbr_coda_aggregations_t));
+      for (; element->sample_counter < sample_counter; element->sample_counter++) {
+        memcpy(&(static_cast<rbr_coda_aggregations_t *>(
+                   element->sensor_data))[element->sample_counter],
+               &RBR_CODA_NAN_AGG, sizeof(rbr_coda_aggregations_t));
       }
     }
     if (sensor_data != NULL) {
-      memcpy(&(static_cast<rbr_coda_aggregations_t *>(element->sensor_data))[element->sample_counter], sensor_data, sizeof(rbr_coda_aggregations_t));
+      memcpy(&(static_cast<rbr_coda_aggregations_t *>(
+                 element->sensor_data))[element->sample_counter],
+             sensor_data, sizeof(rbr_coda_aggregations_t));
     } else {
-      memcpy(&(static_cast<rbr_coda_aggregations_t *>(element->sensor_data))[element->sample_counter], &RBR_CODA_NAN_AGG, sizeof(rbr_coda_aggregations_t));
+      memcpy(&(static_cast<rbr_coda_aggregations_t *>(
+                 element->sensor_data))[element->sample_counter],
+             &RBR_CODA_NAN_AGG, sizeof(rbr_coda_aggregations_t));
     }
     element->sample_counter++;
     break;
@@ -489,54 +496,65 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     break;
   }
   case SENSOR_TYPE_RBR_CODA: {
-    rbr_coda_aggregations_t rbr_coda_sample = (static_cast<rbr_coda_aggregations_t *>(sensor_data))[sample_index];
+    rbr_coda_aggregations_t rbr_coda_sample =
+        (static_cast<rbr_coda_aggregations_t *>(sensor_data))[sample_index];
     bool rbr_coda_sample_valid = false;
-    switch(rbr_coda_sample.sensor_type) {
-      case BmRbrDataMsg::SensorType::TEMPERATURE: {
-        if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_t_v0") != CborNoError) {
-          BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
-        }
-        rbr_coda_sample_valid = true;
-        break;
+    switch (rbr_coda_sample.sensor_type) {
+    case BmRbrDataMsg::SensorType::TEMPERATURE: {
+      if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
+                                            "bm_rbr_t_v0") != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
       }
-      case BmRbrDataMsg::SensorType::PRESSURE: {
-        if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_d_v0") != CborNoError) {
-          BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
-        }
-        rbr_coda_sample_valid = true;
-        break;
+      rbr_coda_sample_valid = true;
+      break;
+    }
+    case BmRbrDataMsg::SensorType::PRESSURE: {
+      if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
+                                            "bm_rbr_d_v0") != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
       }
-      case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
-        if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_td_v0") != CborNoError) {
-          BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
-        }
-        rbr_coda_sample_valid = true;
-        break;
+      rbr_coda_sample_valid = true;
+      break;
+    }
+    case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
+      if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
+                                            "bm_rbr_td_v0") != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
       }
-      case BmRbrDataMsg::SensorType::UNKNOWN: {
-        if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_unknown") != CborNoError) {
-          BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
-        }
-        rbr_coda_sample_valid = true;
-        break;
+      rbr_coda_sample_valid = true;
+      break;
+    }
+    case BmRbrDataMsg::SensorType::UNKNOWN: {
+      if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
+                                            "bm_rbr_unknown") != CborNoError) {
+        BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
       }
-      default: {
-        BRIDGE_LOG_PRINT("Received invalid rbr type in addSamplesToReport\n");
-        break;
-      }
+      rbr_coda_sample_valid = true;
+      break;
+    }
+    default: {
+      BRIDGE_LOG_PRINT("Received invalid rbr type in addSamplesToReport\n");
+      break;
+    }
     }
     if (!rbr_coda_sample_valid) {
       break;
     }
-    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &rbr_coda_sample.temp_mean_deg_c) != CborNoError) {
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &rbr_coda_sample.temp_mean_deg_c) !=
+        CborNoError) {
       BRIDGE_LOG_PRINT("Failed to add rbr_coda sample member in addSamplesToReport\n");
       break;
     }
-    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &rbr_coda_sample.pressure_mean_ubar) != CborNoError) {
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &rbr_coda_sample.pressure_mean_ubar) !=
+        CborNoError) {
       BRIDGE_LOG_PRINT("Failed to add rbr_coda sample member in addSamplesToReport\n");
       break;
     }
-    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member, &rbr_coda_sample.pressure_stdev_ubar) != CborNoError) {
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &rbr_coda_sample.pressure_stdev_ubar) !=
+        CborNoError) {
       BRIDGE_LOG_PRINT("Failed to add rbr_coda sample member in addSamplesToReport\n");
       break;
     }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -517,8 +517,8 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
         if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_unknown") != CborNoError) {
           BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
         }
-        break;
         rbr_coda_sample_valid = true;
+        break;
       }
       default: {
         BRIDGE_LOG_PRINT("Received invalid rbr type in addSamplesToReport\n");

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -646,6 +646,14 @@ static void report_builder_task(void *parameters) {
                             (_ctx._sample_counter - 1));
                         break;
                       }
+                      case SENSOR_TYPE_RBR: {
+                        _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
+                            _ctx._report_period_node_list[i],
+                            _ctx._report_period_sensor_type_list[i], NULL,
+                            sizeof(rbr_coda_aggregations_t), _ctx._samplesPerReport,
+                            (_ctx._sample_counter - 1));
+                        break;
+                      }
                       default: {
                         BRIDGE_LOG_PRINT("Invalid sensor type in report_builder_task\n");
                         break;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -646,7 +646,7 @@ static void report_builder_task(void *parameters) {
                             (_ctx._sample_counter - 1));
                         break;
                       }
-                      case SENSOR_TYPE_RBR: {
+                      case SENSOR_TYPE_RBR_CODA: {
                         _ctx._reportBuilderLinkedList.findElementAndAddSampleToElement(
                             _ctx._report_period_node_list[i],
                             _ctx._report_period_sensor_type_list[i], NULL,

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -513,6 +513,13 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
         rbr_coda_sample_valid = true;
         break;
       }
+      case BmRbrDataMsg::SensorType::UNKNOWN: {
+        if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS, "bm_rbr_unknown") != CborNoError) {
+          BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
+        }
+        break;
+        rbr_coda_sample_valid = true;
+      }
       default: {
         BRIDGE_LOG_PRINT("Received invalid rbr type in addSamplesToReport\n");
         break;

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -3,6 +3,7 @@
 #include "app_config.h"
 #include "bridgePowerController.h"
 #include "device_info.h"
+#include "rbrCodaSensor.h"
 #include "reportBuilder.h"
 #include "softSensor.h"
 #include "sys_info_service.h"
@@ -13,6 +14,7 @@
 // TODO: Once we have bcmp_config request reply, we should read this value from the modules.
 #define DEFAULT_CURRENT_READING_PERIOD_MS 60 * 1000 // default is 1 minute: 60,000 ms
 #define DEFAULT_SOFT_READING_PERIOD_MS 500 // default is 500 ms (2 HZ)
+#define DEFAULT_RBR_CODA_READING_PERIOD_MS 500 // default is 500 ms (2 HZ)
 
 TaskHandle_t sensor_controller_task_handle = NULL;
 
@@ -27,6 +29,7 @@ typedef struct sensorControllerCtx {
   cfg::Configuration *_sys_cfg;
   uint32_t current_reading_period_ms;
   uint32_t soft_reading_period_ms;
+  uint32_t rbr_coda_agg_period_ms;
 } sensorsControllerCtx_t;
 
 static sensorsControllerCtx_t _ctx;
@@ -57,6 +60,9 @@ void sensorControllerInit(BridgePowerController *power_controller,
 
   _ctx.soft_reading_period_ms = DEFAULT_SOFT_READING_PERIOD_MS;
   _ctx._sys_cfg->getConfig(AppConfig::SOFT_READING_PERIOD_MS, strlen(AppConfig::SOFT_READING_PERIOD_MS), _ctx.soft_reading_period_ms);
+
+  _ctx.rbr_coda_agg_period_ms = DEFAULT_RBR_CODA_READING_PERIOD_MS;
+  _ctx._sys_cfg->getConfig(AppConfig::RBR_CODA_READING_PERIOD_MS, strlen(AppConfig::RBR_CODA_READING_PERIOD_MS), _ctx.rbr_coda_agg_period_ms);
 
   BaseType_t rval = xTaskCreate(runController, "Sensor Controller", 128 * 4, NULL,
                                 SENSOR_CONTROLLER_TASK_PRIORITY, &_ctx._task_handle);
@@ -195,7 +201,22 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
                 abstractSensorAddSensorSub(soft_sub);
             }
         }
+        // TODO - remove this print statement
         printf("Soft sensor node found %" PRIx64 "\n", reply.node_id);
+      } else if (strncmp(reply.app_name, "bm_rbr_data", MIN(reply.app_name_strlen, strlen("bm_rbr_data"))) == 0) {
+        // if (!sensorControllerFindSensorById(reply.node_id)) {
+          // uint32_t rbr_coda_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
+          // _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+          //                               rbr_coda_agg_period_ms);
+          // uint32_t AVERAGER_MAX_SAMPLES =
+          //     (rbr_coda_agg_period_ms / _ctx.rbr_coda_agg_period_ms) + RbrCoda_t::N_SAMPLES_PAD;
+          // RbrCoda_t * rbr_coda_sub = createRbrCodaSub(reply.node_id, rbr_coda_agg_period_ms, AVERAGER_MAX_SAMPLES);
+          // if(rbr_coda_sub){
+          //     abstractSensorAddSensorSub(rbr_coda_sub);
+          // }
+        // }
+        // TODO - remove this print statement after done testing
+        printf("RBR CODA sensor node found %" PRIx64 "\n", reply.node_id);
       }
     } else {
       printf("NACK\n");

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -13,8 +13,8 @@
 
 // TODO: Once we have bcmp_config request reply, we should read this value from the modules.
 #define DEFAULT_CURRENT_READING_PERIOD_MS 60 * 1000 // default is 1 minute: 60,000 ms
-#define DEFAULT_SOFT_READING_PERIOD_MS 500 // default is 500 ms (2 HZ)
-#define DEFAULT_RBR_CODA_READING_PERIOD_MS 500 // default is 500 ms (2 HZ)
+#define DEFAULT_SOFT_READING_PERIOD_MS 500          // default is 500 ms (2 HZ)
+#define DEFAULT_RBR_CODA_READING_PERIOD_MS 500      // default is 500 ms (2 HZ)
 
 TaskHandle_t sensor_controller_task_handle = NULL;
 
@@ -49,20 +49,26 @@ static void abstractSensorAddSensorSub(AbstractSensor *sensor);
  * It will also aggregate the data from the Aanderaa nodes and transmit it over the spotter_tx service.
  */
 void sensorControllerInit(BridgePowerController *power_controller,
-                           cfg::Configuration *sys_cfg) {
+                          cfg::Configuration *sys_cfg) {
   configASSERT(power_controller);
   configASSERT(sys_cfg);
   _ctx._bridge_power_controller = power_controller;
   _ctx._sys_cfg = sys_cfg;
 
   _ctx.current_reading_period_ms = DEFAULT_CURRENT_READING_PERIOD_MS;
-  _ctx._sys_cfg->getConfig(AppConfig::CURRENT_READING_PERIOD_MS, strlen(AppConfig::CURRENT_READING_PERIOD_MS), _ctx.current_reading_period_ms);
+  _ctx._sys_cfg->getConfig(AppConfig::CURRENT_READING_PERIOD_MS,
+                           strlen(AppConfig::CURRENT_READING_PERIOD_MS),
+                           _ctx.current_reading_period_ms);
 
   _ctx.soft_reading_period_ms = DEFAULT_SOFT_READING_PERIOD_MS;
-  _ctx._sys_cfg->getConfig(AppConfig::SOFT_READING_PERIOD_MS, strlen(AppConfig::SOFT_READING_PERIOD_MS), _ctx.soft_reading_period_ms);
+  _ctx._sys_cfg->getConfig(AppConfig::SOFT_READING_PERIOD_MS,
+                           strlen(AppConfig::SOFT_READING_PERIOD_MS),
+                           _ctx.soft_reading_period_ms);
 
   _ctx.rbr_coda_agg_period_ms = DEFAULT_RBR_CODA_READING_PERIOD_MS;
-  _ctx._sys_cfg->getConfig(AppConfig::RBR_CODA_READING_PERIOD_MS, strlen(AppConfig::RBR_CODA_READING_PERIOD_MS), _ctx.rbr_coda_agg_period_ms);
+  _ctx._sys_cfg->getConfig(AppConfig::RBR_CODA_READING_PERIOD_MS,
+                           strlen(AppConfig::RBR_CODA_READING_PERIOD_MS),
+                           _ctx.rbr_coda_agg_period_ms);
 
   BaseType_t rval = xTaskCreate(runController, "Sensor Controller", 128 * 4, NULL,
                                 SENSOR_CONTROLLER_TASK_PRIORITY, &_ctx._task_handle);
@@ -97,13 +103,13 @@ static void runController(void *param) {
         printf("Sampling for sensor nodes\n");
         uint32_t num_nodes = 0;
         if (topology_sampler_get_node_list(_ctx._node_list, size_list, num_nodes,
-                                          TOPO_TIMEOUT_MS)) {
+                                           TOPO_TIMEOUT_MS)) {
           for (size_t i = 0; i < num_nodes; i++) {
             if (_ctx._node_list[i] != getNodeId()) {
               if (!sys_info_service_request(_ctx._node_list[i], node_info_reply_cb,
                                             NODE_INFO_TIMEOUT_MS)) {
                 printf("Failed to send sys_info request to node %" PRIx64 "\n",
-                      _ctx._node_list[i]);
+                       _ctx._node_list[i]);
               }
             }
           }
@@ -115,8 +121,8 @@ static void runController(void *param) {
       if (_ctx._subbed_sensors != NULL) {
         AbstractSensor *curr = _ctx._subbed_sensors;
         while (curr != NULL) {
-          if(curr->type == SENSOR_TYPE_AANDERAA){
-            Aanderaa_t* aanderaa = static_cast<Aanderaa_t*>(curr);
+          if (curr->type == SENSOR_TYPE_AANDERAA) {
+            Aanderaa_t *aanderaa = static_cast<Aanderaa_t *>(curr);
             aanderaa->aggregate();
           } else if (curr->type == SENSOR_TYPE_SOFT) {
             Soft_t *soft = static_cast<Soft_t *>(curr);
@@ -182,44 +188,51 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
       if (strncmp(reply.app_name, "aanderaa", MIN(reply.app_name_strlen, strlen("aanderaa"))) ==
           0) {
         if (!sensorControllerFindSensorById(reply.node_id)) {
-            uint32_t current_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
-            _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
-                                        current_agg_period_ms);
-            uint32_t AVERAGER_MAX_SAMPLES =
-                (current_agg_period_ms / _ctx.current_reading_period_ms) + Aanderaa_t::N_SAMPLES_PAD;
-            Aanderaa_t * aanderaa_sub = createAanderaaSub(reply.node_id, current_agg_period_ms, AVERAGER_MAX_SAMPLES);
-            if(aanderaa_sub){
-                abstractSensorAddSensorSub(aanderaa_sub);
-            }
-        }
-      } else if (strncmp(reply.app_name, "bm_soft_module", MIN(reply.app_name_strlen, strlen("bm_soft_module"))) == 0) {
-        if (!sensorControllerFindSensorById(reply.node_id)) {
-          uint32_t soft_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
-          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
-                                        soft_agg_period_ms);
-            uint32_t AVERAGER_MAX_SAMPLES =
-                (soft_agg_period_ms / _ctx.soft_reading_period_ms) + Soft_t::N_SAMPLES_PAD;
-            Soft_t * soft_sub = createSoftSub(reply.node_id, soft_agg_period_ms, AVERAGER_MAX_SAMPLES);
-            if(soft_sub){
-                abstractSensorAddSensorSub(soft_sub);
-            }
-        }
-        // TODO - remove this print statement
-        printf("Soft sensor node found %" PRIx64 "\n", reply.node_id);
-      } else if (strncmp(reply.app_name, "bm_rbr", MIN(reply.app_name_strlen, strlen("bm_rbr"))) == 0) {
-        if (!sensorControllerFindSensorById(reply.node_id)) {
-          uint32_t rbr_coda_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
-          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
-                                        rbr_coda_agg_period_ms);
+          uint32_t current_agg_period_ms =
+              (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
+          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS,
+                                   strlen(AppConfig::SAMPLE_DURATION_MS),
+                                   current_agg_period_ms);
           uint32_t AVERAGER_MAX_SAMPLES =
-              (rbr_coda_agg_period_ms / _ctx.rbr_coda_agg_period_ms) + RbrCoda_t::N_SAMPLES_PAD;
-          RbrCoda_t * rbr_coda_sub = createRbrCodaSub(reply.node_id, rbr_coda_agg_period_ms, AVERAGER_MAX_SAMPLES);
-          if(rbr_coda_sub){
-              abstractSensorAddSensorSub(rbr_coda_sub);
+              (current_agg_period_ms / _ctx.current_reading_period_ms) +
+              Aanderaa_t::N_SAMPLES_PAD;
+          Aanderaa_t *aanderaa_sub =
+              createAanderaaSub(reply.node_id, current_agg_period_ms, AVERAGER_MAX_SAMPLES);
+          if (aanderaa_sub) {
+            abstractSensorAddSensorSub(aanderaa_sub);
           }
         }
-        // TODO - remove this print statement after done testing
-        printf("RBR CODA sensor node found %" PRIx64 "\n", reply.node_id);
+      } else if (strncmp(reply.app_name, "bm_soft_module",
+                         MIN(reply.app_name_strlen, strlen("bm_soft_module"))) == 0) {
+        if (!sensorControllerFindSensorById(reply.node_id)) {
+          uint32_t soft_agg_period_ms =
+              (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
+          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS,
+                                   strlen(AppConfig::SAMPLE_DURATION_MS), soft_agg_period_ms);
+          uint32_t AVERAGER_MAX_SAMPLES =
+              (soft_agg_period_ms / _ctx.soft_reading_period_ms) + Soft_t::N_SAMPLES_PAD;
+          Soft_t *soft_sub =
+              createSoftSub(reply.node_id, soft_agg_period_ms, AVERAGER_MAX_SAMPLES);
+          if (soft_sub) {
+            abstractSensorAddSensorSub(soft_sub);
+          }
+        }
+      } else if (strncmp(reply.app_name, "bm_rbr",
+                         MIN(reply.app_name_strlen, strlen("bm_rbr"))) == 0) {
+        if (!sensorControllerFindSensorById(reply.node_id)) {
+          uint32_t rbr_coda_agg_period_ms =
+              (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
+          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS,
+                                   strlen(AppConfig::SAMPLE_DURATION_MS),
+                                   rbr_coda_agg_period_ms);
+          uint32_t AVERAGER_MAX_SAMPLES =
+              (rbr_coda_agg_period_ms / _ctx.rbr_coda_agg_period_ms) + RbrCoda_t::N_SAMPLES_PAD;
+          RbrCoda_t *rbr_coda_sub =
+              createRbrCodaSub(reply.node_id, rbr_coda_agg_period_ms, AVERAGER_MAX_SAMPLES);
+          if (rbr_coda_sub) {
+            abstractSensorAddSensorSub(rbr_coda_sub);
+          }
+        }
       }
     } else {
       printf("NACK\n");

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -121,6 +121,9 @@ static void runController(void *param) {
           } else if (curr->type == SENSOR_TYPE_SOFT) {
             Soft_t *soft = static_cast<Soft_t *>(curr);
             soft->aggregate();
+          } else if (curr->type == SENSOR_TYPE_RBR_CODA) {
+            RbrCoda_t *rbr_coda = static_cast<RbrCoda_t *>(curr);
+            rbr_coda->aggregate();
           }
           curr = curr->next;
         }

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -203,18 +203,18 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
         }
         // TODO - remove this print statement
         printf("Soft sensor node found %" PRIx64 "\n", reply.node_id);
-      } else if (strncmp(reply.app_name, "bm_rbr_data", MIN(reply.app_name_strlen, strlen("bm_rbr_data"))) == 0) {
-        // if (!sensorControllerFindSensorById(reply.node_id)) {
-          // uint32_t rbr_coda_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
-          // _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
-          //                               rbr_coda_agg_period_ms);
-          // uint32_t AVERAGER_MAX_SAMPLES =
-          //     (rbr_coda_agg_period_ms / _ctx.rbr_coda_agg_period_ms) + RbrCoda_t::N_SAMPLES_PAD;
-          // RbrCoda_t * rbr_coda_sub = createRbrCodaSub(reply.node_id, rbr_coda_agg_period_ms, AVERAGER_MAX_SAMPLES);
-          // if(rbr_coda_sub){
-          //     abstractSensorAddSensorSub(rbr_coda_sub);
-          // }
-        // }
+      } else if (strncmp(reply.app_name, "bm_rbr", MIN(reply.app_name_strlen, strlen("bm_rbr"))) == 0) {
+        if (!sensorControllerFindSensorById(reply.node_id)) {
+          uint32_t rbr_coda_agg_period_ms = (BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000);
+          _ctx._sys_cfg->getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+                                        rbr_coda_agg_period_ms);
+          uint32_t AVERAGER_MAX_SAMPLES =
+              (rbr_coda_agg_period_ms / _ctx.rbr_coda_agg_period_ms) + RbrCoda_t::N_SAMPLES_PAD;
+          RbrCoda_t * rbr_coda_sub = createRbrCodaSub(reply.node_id, rbr_coda_agg_period_ms, AVERAGER_MAX_SAMPLES);
+          if(rbr_coda_sub){
+              abstractSensorAddSensorSub(rbr_coda_sub);
+          }
+        }
         // TODO - remove this print statement after done testing
         printf("RBR CODA sensor node found %" PRIx64 "\n", reply.node_id);
       }

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -86,7 +86,6 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
                      d.std_tilt_deg, d.temperature_deg_c, d.north_cm_s, d.tilt_x_deg,
                      d.tilt_y_deg, d.transducer_strength_db);
         if (log_buflen > 0) {
-          // TODO - keep as individual log or switch to the bm_sensor common log
           BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print Aanderaa data\n");
@@ -181,7 +180,6 @@ void AanderaaSensor::aggregate(void) {
                     agg.abs_tilt_mean_rad,
                     agg.std_tilt_mean_rad);
     if (log_buflen > 0) {
-      // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print Aanderaa data\n");

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -7,10 +7,7 @@ typedef enum abstractSensorType : uint8_t {
     SENSOR_TYPE_UNKNOWN = 0,
     SENSOR_TYPE_AANDERAA = 1,
     SENSOR_TYPE_SOFT = 2,
-    SENSOR_TYPE_RBR_T = 3,
-    SENSOR_TYPE_RBR_D = 4,
-    SENSOR_TYPE_RBR_DT = 5,
-    SENSOR_TYPE_RBR = 6,
+    SENSOR_TYPE_RBR_CODA = 3,
 } abstractSensorType_e;
 
 struct AbstractSensor {

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -10,6 +10,7 @@ typedef enum abstractSensorType : uint8_t {
     SENSOR_TYPE_RBR_T = 3,
     SENSOR_TYPE_RBR_D = 4,
     SENSOR_TYPE_RBR_DT = 5,
+    SENSOR_TYPE_RBR = 6,
 } abstractSensorType_e;
 
 struct AbstractSensor {

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -7,6 +7,9 @@ typedef enum abstractSensorType : uint8_t {
     SENSOR_TYPE_UNKNOWN = 0,
     SENSOR_TYPE_AANDERAA = 1,
     SENSOR_TYPE_SOFT = 2,
+    SENSOR_TYPE_RBR_T = 3,
+    SENSOR_TYPE_RBR_D = 4,
+    SENSOR_TYPE_RBR_DT = 5,
 } abstractSensorType_e;
 
 struct AbstractSensor {

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -157,7 +157,7 @@ void RbrCodaSensor::aggregate(void) {
                  node_id, node_position, sensor_type_str, time_str, aggs.reading_count,
                  aggs.temp_mean_deg_c, aggs.pressure_mean_ubar, aggs.pressure_stdev_ubar);
     if (log_buflen > 0) {
-      BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
+      BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print rbr_coda aggregation log\n");
     }

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -77,11 +77,10 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
                      "%" PRIu64 ","   // sensor_reading_time_ms seconds part
                      "%03" PRIu32 "," // sensor_reading_time_ms millis part
                      "%.3f,"          // temperature_deg_c
-                     "%.3f,"          // pressure_ubar
-                     "%" PRIu32 "\n", // reading_count
+                     "%.3f\n",          // pressure_ubar
                      node_id, node_position, sensor_type_str, rbr_data.header.reading_uptime_millis, reading_time_sec,
                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
-                     rbr_data.temperature_deg_c, rbr_data.pressure_deci_bar, rbr_coda->reading_count);
+                     rbr_data.temperature_deg_c, rbr_data.pressure_deci_bar);
         if (log_buflen > 0) {
           BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -177,7 +177,7 @@ void RbrCodaSensor::aggregate(void) {
 RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
                             uint32_t averager_max_samples) {
   RbrCoda_t *new_sub = static_cast<RbrCoda_t *>(pvPortMalloc(sizeof(RbrCoda_t)));
-  new_sub = new (std::nothrow) RbrCoda_t;
+  new_sub = new (new_sub) RbrCoda_t();
   configASSERT(new_sub);
 
   new_sub->_mutex = xSemaphoreCreateMutex();

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -1,0 +1,166 @@
+#include "rbrCodaSensor.h"
+#include "app_config.h"
+#include "avgSampler.h"
+#include "bm_network.h"
+#include "bm_pubsub.h"
+#include "bm_rbr_data_msg.h"
+#include "bridgeLog.h"
+#include "device_info.h"
+#include "reportBuilder.h"
+#include "semphr.h"
+#include "stm32_rtc.h"
+#include "topology_sampler.h"
+#include "util.h"
+#include <new>
+
+bool RbrCodaSensor::subscribe() {
+  bool rval = false;
+  char *sub = static_cast<char *>(pvPortMalloc(BM_TOPIC_MAX_LEN));
+  configASSERT(sub);
+  int topic_strlen = snprintf(sub, BM_TOPIC_MAX_LEN, "%" PRIx64 "%s", node_id, subtag);
+  if (topic_strlen > 0) {
+    rval = bm_sub_wl(sub, topic_strlen, rbrCodaSubCallback);
+  }
+  vPortFree(sub);
+  return
+}
+
+void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                       const uint8_t *data, uint16_t data_len, uint8_t type,
+                                       uint8_t version) {
+  (void)type;
+  (void)version;
+  printf("RBR CODA data received from node %" PRIx64 " On topic: %.*s\n", node_id, topic_len,
+        topic);
+  RbrCoda_t *rbr_coda = static_cast<RbrCoda_t *>(sensorControllerFindSensorById(node_id));
+  if (rbr_coda && rbr_coda->type == SENSOR_TYPE_RBR) {
+    if (xSemaphoreTake(rbr_coda->_mutex, portMAX_DELAY)) {
+      static BmRbrDataMsg::Data rbr_data;
+      if (BmRbrDataMsg::decode(rbr_data, data, data_len) == CborNoError) {
+        char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
+        configAssert(log_buf);
+        rbr_coda->temp_deg_c.addSample(rbr_data.temperature_deg_c);
+        rbr_coda->pressure_ubar.addSample(rbr_data.pressure_ubar);
+        rbr_coda->reading_count++;
+
+        // Large floats get formatted in scientific notation,
+        // so we print integer seconds and millis separately.
+        uint64_t reading_time_sec = rbr_data.header.reading_time_utc_ms / 1000U;
+        uint32_t reading_time_millis = rbr_data.header.reading_time_utc_ms % 1000U;
+        uint64_t sensor_reading_time_sec = rbr_data.header.sensor_reading_time_ms / 1000U;
+        uint32_t sensor_reading_time_millis = rbr_data.header.sensor_reading_time_ms % 1000U;
+
+        int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+
+        size_t log_buflen =
+            snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                     "%" PRIx64 ","   // Node Id
+                     "%" PRIi8 ","    // node_position
+                     "rbr_coda,"      // node_app_name
+                     "%" PRIu64 ","   // reading_uptime_millis
+                     "%" PRIu64 "."   // reading_time_utc_ms seconds part
+                     "%03" PRIu32 "," // reading_time_utc_ms millis part
+                     "%" PRIu64 ","   // sensor_reading_time_ms seconds part
+                     "%03" PRIu32 "," // sensor_reading_time_ms millis part
+                     "%.2f,"          // temperature_deg_c
+                     "%.2f,"          // pressure_ubar
+                     "%" PRIu32 "\n", // reading_count
+                     node_id, node_position, rbr_data.header.reading_uptime_ms, reading_time_sec,
+                     reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
+                     rbr_data.temperature_deg_c, rbr_data.pressure_ubar, rbr_coda->reading_count);
+        if (log_buflen > 0) {
+          BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
+        } else {
+          printf("ERROR: Failed to print rbr_coda individual log\n");
+        }
+        vPortFree(log_buf);
+      }
+      xSemaphoreGive(rbr_coda->_mutex);
+    } else {
+      printf("Failed to get the subbed RBR CODA mutex after getting a new reading\n");
+    }
+  }
+}
+
+void RbrCodaSensor::aggregate(void) {
+  char *log_buf = static_cast<char *>(pvPortMalloc(SENSOR_LOG_BUF_SIZE));
+  configAssert(log_buf);
+  if (xSemaphoreTake(_mutex, portMAX_DELAY)) {
+    size_t log_buflen = 0;
+    rbr_coda_aggregations_t aggs = {.temp_mean_deg_c = NAN,
+                                    .pressure_mean_ubar = NAN,
+                                    .pressure_stdev_ubar = NAN,
+                                    .reading_count = 0};
+    if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
+      aggs.temp_mean_deg_c = temp_deg_c.getMean();
+      aggs.pressure_mean_ubar = pressure_ubar.getMean();
+      aggs.pressure_stdev_ubar = pressure_ubar.getStd(aggs.pressure_mean_ubar);
+      aggs.reading_count = reading_count;
+
+      if (aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||
+          aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
+        aggs.temp_mean_deg_c = NAN;
+      }
+      if (aggs.pressure_mean_ubar < PRESSURE_SAMPLE_MEMBER_MIN ||
+          aggs.pressure_mean_ubar > PRESSURE_SAMPLE_MEMBER_MAX) {
+        aggs.pressure_mean_ubar = NAN;
+        aggs.pressure_stdev_ubar = NAN;
+      }
+    }
+    static constexpr uint8_t TIME_STR_BUFSIZE = 50;
+    char time_str[TIME_STR_BUFSIZE];
+    if (!logRtcGetTimeStr(time_str, TIME_STR_BUFSIZE, true)) {
+      printf("Failed to get RTC time string for RBR CODA aggregation\n");
+      snprintf(time_str, TIME_STR_BUFSIZE, "0");
+    }
+
+    int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+
+    log_buflen =
+        snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                 "%" PRIx64 "," // Node Id
+                 "%" PRIi8 ","  // node_position
+                 "rbr_coda,"    // node_app_name
+                 "%" PRIu64 "," // reading_uptime_millis
+                 "%s,"          // time_str
+                 "%.2f,"         // temp_mean_deg_c
+                 "%.2f,"         // pressure_mean_ubar
+                 "%.2f,"         // pressure_stdev_ubar
+                 "%" PRIu32 "\n", // reading_count
+                 node_id, node_position, aggs.reading_uptime_millis, time_str, aggs.temp_mean_deg_c,
+                 aggs.pressure_mean_ubar, aggs.pressure_stdev_ubar, aggs.reading_count);
+    if (log_buflen > 0) {
+      BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
+    } else {
+      printf("ERROR: Failed to print rbr_coda aggregation log\n");
+    }
+    reportBuilderAddToQueue(node_id, SENSOR_TYPE_RBR, static_cast<void *>(&aggs),
+                            sizeof(rbr_coda_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
+    temp_deg_c.clear();
+    pressure_ubar.clear();
+    reading_count = 0;
+    xSemaphoreGive(_mutex);
+  } else {
+    printf("Failed to get the RBR CODA mutex after getting a new reading\n");
+  }
+  vPortFree(log_buf);
+}
+
+RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
+                            uint32_t averager_max_samples) {
+  RbrCoda_t *new_sub = static_cast<RbrCoda_t *>(pvPortMalloc(sizeof(RbrCoda_t)));
+  new_sub = new (std::nothrow) RbrCoda_t;
+  configAssert(new_sub);
+
+  new_sub->_mutex = xSemaphoreCreateMutex();
+  configAssert(new_sub->_mutex);
+
+  new_sub->node_id = node_id;
+  new_sub->type = SENSOR_TYPE_RBR;
+  new_sub->next = NULL;
+  new_sub->rbr_coda_agg_period_ms = rbr_coda_agg_period_ms;
+  new_sub->temp_deg_c.init(averager_max_samples);
+  new_sub->pressure_ubar.init(averager_max_samples);
+  new_sub->reading_count = 0;
+  return new_sub;
+}

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -31,7 +31,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
   (void)type;
   (void)version;
   printf("RBR CODA data received from node %" PRIx64 " On topic: %.*s\n", node_id, topic_len,
-        topic);
+         topic);
   RbrCoda_t *rbr_coda = static_cast<RbrCoda_t *>(sensorControllerFindSensorById(node_id));
   if (rbr_coda && rbr_coda->type == SENSOR_TYPE_RBR_CODA) {
     if (xSemaphoreTake(rbr_coda->_mutex, portMAX_DELAY)) {
@@ -60,27 +60,28 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
           sensor_type_str = "RBR.T";
         } else if (rbr_coda->latest_sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
           sensor_type_str = "RBR.D";
-        } else if (rbr_coda->latest_sensor_type == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+        } else if (rbr_coda->latest_sensor_type ==
+                   BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
           sensor_type_str = "RBR.DT";
         } else {
           sensor_type_str = "RBR.UNKNOWN";
         }
 
-        size_t log_buflen =
-            snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
-                     "%" PRIx64 ","   // Node Id
-                     "%" PRIi8 ","    // node_position
-                     "%s,"            // node_app_name
-                     "%" PRIu64 ","   // reading_uptime_millis
-                     "%" PRIu64 "."   // reading_time_utc_ms seconds part
-                     "%03" PRIu32 "," // reading_time_utc_ms millis part
-                     "%" PRIu64 ","   // sensor_reading_time_ms seconds part
-                     "%03" PRIu32 "," // sensor_reading_time_ms millis part
-                     "%.3f,"          // temperature_deg_c
-                     "%.3f\n",          // pressure_ubar
-                     node_id, node_position, sensor_type_str, rbr_data.header.reading_uptime_millis, reading_time_sec,
-                     reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
-                     rbr_data.temperature_deg_c, rbr_data.pressure_deci_bar);
+        size_t log_buflen = snprintf(
+            log_buf, SENSOR_LOG_BUF_SIZE,
+            "%" PRIx64 ","   // Node Id
+            "%" PRIi8 ","    // node_position
+            "%s,"            // node_app_name
+            "%" PRIu64 ","   // reading_uptime_millis
+            "%" PRIu64 "."   // reading_time_utc_ms seconds part
+            "%03" PRIu32 "," // reading_time_utc_ms millis part
+            "%" PRIu64 ","   // sensor_reading_time_ms seconds part
+            "%03" PRIu32 "," // sensor_reading_time_ms millis part
+            "%.3f,"          // temperature_deg_c
+            "%.3f\n",        // pressure_ubar
+            node_id, node_position, sensor_type_str, rbr_data.header.reading_uptime_millis,
+            reading_time_sec, reading_time_millis, sensor_reading_time_sec,
+            sensor_reading_time_millis, rbr_data.temperature_deg_c, rbr_data.pressure_deci_bar);
         if (log_buflen > 0) {
           BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
@@ -150,10 +151,10 @@ void RbrCodaSensor::aggregate(void) {
                  "%" PRIi8 ","  // node_position
                  "%s,"          // node_app_name
                  "%s,"          // timeStamp(ticks/UTC)
-                 "%" PRIu32","  // reading_count
+                 "%" PRIu32 "," // reading_count
                  "%.3f,"        // temp_mean_deg_c
                  "%.3f,"        // pressure_mean_ubar
-                 "%.3f\n",        // pressure_stdev_ubar
+                 "%.3f\n",      // pressure_stdev_ubar
                  node_id, node_position, sensor_type_str, time_str, aggs.reading_count,
                  aggs.temp_mean_deg_c, aggs.pressure_mean_ubar, aggs.pressure_stdev_ubar);
     if (log_buflen > 0) {
@@ -173,7 +174,7 @@ void RbrCodaSensor::aggregate(void) {
   vPortFree(log_buf);
 }
 
-RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
+RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
                             uint32_t averager_max_samples) {
   RbrCoda_t *new_sub = static_cast<RbrCoda_t *>(pvPortMalloc(sizeof(RbrCoda_t)));
   new_sub = new (new_sub) RbrCoda_t();

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -120,6 +120,9 @@ void RbrCodaSensor::aggregate(void) {
       if (aggs.pressure_mean_ubar < PRESSURE_SAMPLE_MEMBER_MIN ||
           aggs.pressure_mean_ubar > PRESSURE_SAMPLE_MEMBER_MAX) {
         aggs.pressure_mean_ubar = NAN;
+      }
+      if (aggs.pressure_stdev_ubar < PRESSURE_STDEV_SAMPLE_MEMBER_MIN ||
+          aggs.pressure_stdev_ubar > PRESSURE_STDEV_SAMPLE_MEMBER_MAX) {
         aggs.pressure_stdev_ubar = NAN;
       }
     }
@@ -133,7 +136,6 @@ void RbrCodaSensor::aggregate(void) {
     int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
 
     // Use the latest sensor type to determine the sensor type string
-    // TODO - this is duplicated from the callback function. Should we make this a function?
     const char *sensor_type_str;
     if (latest_sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {
       sensor_type_str = "RBR.T";

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -102,28 +102,28 @@ void RbrCodaSensor::aggregate(void) {
   if (xSemaphoreTake(_mutex, portMAX_DELAY)) {
     size_t log_buflen = 0;
     rbr_coda_aggregations_t aggs = {.temp_mean_deg_c = NAN,
-                                    .pressure_mean_ubar = NAN,
-                                    .pressure_stdev_ubar = NAN,
+                                    .pressure_mean_deci_bar = NAN,
+                                    .pressure_stdev_deci_bar = NAN,
                                     .reading_count = 0,
                                     .sensor_type = BmRbrDataMsg::SensorType::UNKNOWN};
     aggs.sensor_type = latest_sensor_type;
     if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       aggs.temp_mean_deg_c = temp_deg_c.getMean();
-      aggs.pressure_mean_ubar = pressure_ubar.getMean();
-      aggs.pressure_stdev_ubar = pressure_ubar.getStd(aggs.pressure_mean_ubar);
+      aggs.pressure_mean_deci_bar = pressure_ubar.getMean();
+      aggs.pressure_stdev_deci_bar = pressure_ubar.getStd(aggs.pressure_mean_deci_bar);
       aggs.reading_count = reading_count;
 
       if (aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||
           aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
         aggs.temp_mean_deg_c = NAN;
       }
-      if (aggs.pressure_mean_ubar < PRESSURE_SAMPLE_MEMBER_MIN ||
-          aggs.pressure_mean_ubar > PRESSURE_SAMPLE_MEMBER_MAX) {
-        aggs.pressure_mean_ubar = NAN;
+      if (aggs.pressure_mean_deci_bar < PRESSURE_SAMPLE_MEMBER_MIN ||
+          aggs.pressure_mean_deci_bar > PRESSURE_SAMPLE_MEMBER_MAX) {
+        aggs.pressure_mean_deci_bar = NAN;
       }
-      if (aggs.pressure_stdev_ubar < PRESSURE_STDEV_SAMPLE_MEMBER_MIN ||
-          aggs.pressure_stdev_ubar > PRESSURE_STDEV_SAMPLE_MEMBER_MAX) {
-        aggs.pressure_stdev_ubar = NAN;
+      if (aggs.pressure_stdev_deci_bar < PRESSURE_STDEV_SAMPLE_MEMBER_MIN ||
+          aggs.pressure_stdev_deci_bar > PRESSURE_STDEV_SAMPLE_MEMBER_MAX) {
+        aggs.pressure_stdev_deci_bar = NAN;
       }
     }
     static constexpr uint8_t TIME_STR_BUFSIZE = 50;
@@ -155,10 +155,10 @@ void RbrCodaSensor::aggregate(void) {
                  "%s,"          // timeStamp(ticks/UTC)
                  "%" PRIu32 "," // reading_count
                  "%.3f,"        // temp_mean_deg_c
-                 "%.3f,"        // pressure_mean_ubar
-                 "%.3f\n",      // pressure_stdev_ubar
+                 "%.3f,"        // pressure_mean_deci_bar
+                 "%.3f\n",      // pressure_stdev_deci_bar
                  node_id, node_position, sensor_type_str, time_str, aggs.reading_count,
-                 aggs.temp_mean_deg_c, aggs.pressure_mean_ubar, aggs.pressure_stdev_ubar);
+                 aggs.temp_mean_deg_c, aggs.pressure_mean_deci_bar, aggs.pressure_stdev_deci_bar);
     if (log_buflen > 0) {
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -28,10 +28,12 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   // TODO - double check these values
   static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -20;
   static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40;
   static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 0;
-  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 10000;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 20970000;
+  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MIN = 0;
+  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 327000;
 
 public:
   bool subscribe() override;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -2,18 +2,21 @@
 #include "FreeRTOS.h"
 #include "abstractSensor.h"
 #include "avgSampler.h"
+#include "bm_rbr_data_msg.h"
 #include "sensorController.h"
 
 #include <stdint.h>
 #include <stdlib.h>
 
-#define RBR_CODA_MAX_NUM_SAMPLE_MEMBERS 3
+#define RBR_CODA_NUM_SAMPLE_MEMBERS 3
+
 
 typedef struct rbr_coda_aggregations_s {
   double temp_mean_deg_c;
   double pressure_mean_ubar;
   double pressure_stdev_ubar;
   uint32_t reading_count;
+  BmRbrDataMsg::SensorType_t sensor_type;
 } rbr_coda_aggregations_t;
 
 typedef struct RbrCodaSensor : public AbstractSensor {
@@ -21,6 +24,7 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   AveragingSampler temp_deg_c;
   AveragingSampler pressure_ubar;
   uint32_t reading_count;
+  BmRbrDataMsg::SensorType_t latest_sensor_type;
 
   // TODO - double check these values
   static constexpr uint32_t N_SAMPLES_PAD = 270;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -25,7 +25,8 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   uint32_t reading_count;
   BmRbrDataMsg::SensorType_t latest_sensor_type;
 
-  // TODO - double check these values
+  // Extra sample padding to account for timing slop. Calculated as the sample frequency + 2 minutes bridge on period + some extra slop.
+  // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.
   static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
   static constexpr double TEMP_SAMPLE_MEMBER_MIN = -20;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -44,7 +44,7 @@ private:
                                  uint8_t version);
 
 private:
-  static constexpr char subtag[] = "/rbr_coda";
+  static constexpr char subtag[] = "/bm_rbr_data";
 } RbrCoda_t;
 
 RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms, uint32_t averager_max_samples);

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -10,7 +10,6 @@
 
 #define RBR_CODA_NUM_SAMPLE_MEMBERS 3
 
-
 typedef struct rbr_coda_aggregations_s {
   double temp_mean_deg_c;
   double pressure_mean_ubar;
@@ -47,4 +46,5 @@ private:
   static constexpr char subtag[] = "/bm_rbr_data";
 } RbrCoda_t;
 
-RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms, uint32_t averager_max_samples);
+RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
+                            uint32_t averager_max_samples);

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -12,8 +12,8 @@
 
 typedef struct rbr_coda_aggregations_s {
   double temp_mean_deg_c;
-  double pressure_mean_ubar;
-  double pressure_stdev_ubar;
+  double pressure_mean_deci_bar;
+  double pressure_stdev_deci_bar;
   uint32_t reading_count;
   BmRbrDataMsg::SensorType_t sensor_type;
 } rbr_coda_aggregations_t;
@@ -29,12 +29,12 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.
   static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -20;
-  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40;
-  static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 0;
-  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 20970000;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 35;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 5;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 85;
   static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MIN = 0;
-  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 327000;
+  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 40;
 
 public:
   bool subscribe() override;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "FreeRTOS.h"
+#include "abstractSensor.h"
+#include "avgSampler.h"
+#include "sensorController.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define RBR_CODA_MAX_NUM_SAMPLE_MEMBERS 3
+
+typedef struct rbr_coda_aggregations_s {
+  double temp_mean_deg_c;
+  double pressure_mean_ubar;
+  double pressure_stdev_ubar;
+  uint32_t reading_count;
+} rbr_coda_aggregations_t;
+
+typedef struct RbrCodaSensor : public AbstractSensor {
+  uint32_t rbr_coda_agg_period_ms;
+  AveragingSampler temp_deg_c;
+  AveragingSampler pressure_ubar;
+  uint32_t reading_count;
+
+  // TODO - double check these values
+  static constexpr uint32_t N_SAMPLES_PAD = 270;
+  static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 40;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 0;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 10000;
+
+public:
+  bool subscribe() override;
+  void aggregate(void);
+
+private:
+  static void rbrCodaSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                 const uint8_t *data, uint16_t data_len, uint8_t type,
+                                 uint8_t version);
+
+private:
+  static constexpr char subtag[] = "/rbr_coda";
+} RbrCoda_t;
+
+RbrCoda_t* createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms, uint32_t averager_max_samples);

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -109,7 +109,7 @@ void SoftSensor::aggregate(void) {
                  "%" PRIx64 "," // Node Id
                  "%" PRIi8 ","  // node_position
                  "soft,"        // node_app_name
-                 "%s,"          // timstamp(ticks/UTC)
+                 "%s,"          // timestamp(ticks/UTC)
                  "%" PRIu32 "," // reading_count
                  "%.3f\n",      // temp_mean_deg_c
                  node_id, node_position, time_str, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -114,7 +114,6 @@ void SoftSensor::aggregate(void) {
                  "%.3f\n",      // temp_mean_deg_c
                  node_id, node_position, time_str, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
-      // TODO - keep as individual log or switch to the bm_sensor common log
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
       printf("ERROR: Failed to print soft aggregate log\n");

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -66,7 +66,6 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                      reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
                      soft_data.temperature_deg_c);
         if (log_buflen > 0) {
-          // TODO - keep as individual log or switch to the bm_sensor common log
           BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
           printf("ERROR: Failed to print soft individual log\n");

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -807,6 +807,8 @@ static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t 
       } else if (strncmp(app_name, "bm_soft_module", strlen("bm_soft_module")) == 0) {
         _node_list.sensor_type[i] = SENSOR_TYPE_SOFT;
         break;
+      } else if (strncmp(app_name, "bm_rbr", strlen("bm_rbr")) == 0) {
+        _node_list.sensor_type[i] = SENSOR_TYPE_RBR_CODA;
       }
     }
   }


### PR DESCRIPTION
Adding RBR to the bridge. This involved adding an RBR driver to the `/bridge/sensor_drivers` folder, adding rbr discovery to the sensorController, and adding rbr support to the reportBuilder.

Here we can see the logging of the RBR.T agg data and that we successfully built the sensor report and sent it to Spotter, who does not yet know how to bitpack the RBR data.
<img width="773" alt="Screenshot 2024-02-15 at 2 48 38 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/a0ebc9f1-e1af-42b6-a121-551b3b05e83a">

