### PR TITLE
Sc 198619/get rbr type from cbor map

### DIFF
--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -13,7 +13,6 @@ void bridgeLogPrintf(const char *str, size_t len) {
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len) {
     if(len > 0){
         switch(type) {
-            // TODO - keep as sensor specific logs or switch to the bm_sensor common log
             case BM_COMMON_IND:
                 printf("[%s] %.*s", "BM_COMMON_IND", len, str);
                 bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -823,7 +823,7 @@ static void report_builder_task(void *parameters) {
                   _ctx.report_period_max_network_config_cbor = last_network_config;
                   last_network_config = NULL;
                   _ctx.report_period_max_network_config_cbor_len = temp_cbor_config_size;
-                  BRIDGE_LOG_PRINT("Updated reportBuilders max CBOR map\n");
+                  BRIDGE_LOG_PRINT("Updated reportBuilders max network configuration CBOR map\n");
                   _ctx._report_period_num_nodes = temp_num_nodes;
                   memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
                   _ctx._report_period_max_network_crc32 = temp_network_crc32;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -823,7 +823,7 @@ static void report_builder_task(void *parameters) {
                   _ctx.report_period_max_network_config_cbor = last_network_config;
                   last_network_config = NULL;
                   _ctx.report_period_max_network_config_cbor_len = temp_cbor_config_size;
-                  printf("Updated reportBuilders CBOR map\n");
+                  BRIDGE_LOG_PRINT("Updated reportBuilders max CBOR map\n");
                   _ctx._report_period_num_nodes = temp_num_nodes;
                   memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
                   _ctx._report_period_max_network_crc32 = temp_network_crc32;

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -766,6 +766,11 @@ static void report_builder_task(void *parameters) {
           memset(_ctx._report_period_node_list, 0, sizeof(_ctx._report_period_node_list));
           memset(_ctx._report_period_sensor_type_list, 0,
                  sizeof(_ctx._report_period_sensor_type_list));
+          if (_ctx.report_period_max_network_config_cbor != NULL) {
+            vPortFree(_ctx.report_period_max_network_config_cbor);
+          }
+          _ctx.report_period_max_network_config_cbor = NULL;
+          _ctx.report_period_max_network_config_cbor_len = 0;
         }
         break;
       }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -21,6 +21,7 @@
 
 #define REPORT_BUILDER_QUEUE_SIZE (16)
 #define TOPO_TIMEOUT_MS (1000)
+#define NETWORK_CONFIG_MUTEX_TIMEOUT_MS (1000)
 
 /*
   This is the current max length the cbor buffer can be for the sensor report
@@ -101,6 +102,9 @@ typedef struct ReportBuilderContext_s {
   ReportBuilderLinkedList _reportBuilderLinkedList;
   uint64_t _report_period_node_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
   abstractSensorType_e _report_period_sensor_type_list[TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE];
+  uint8_t *report_period_max_network_config_cbor;
+  uint32_t report_period_max_network_config_cbor_len;
+  SemaphoreHandle_t _config_mutex;
   uint32_t _report_period_num_nodes;
   uint32_t _report_period_max_network_crc32;
 } ReportBuilderContext_t;
@@ -501,6 +505,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     bool rbr_coda_sample_valid = false;
     switch (rbr_coda_sample.sensor_type) {
     case BmRbrDataMsg::SensorType::TEMPERATURE: {
+      printf("Sending rbr temp\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_t_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
@@ -509,6 +514,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       break;
     }
     case BmRbrDataMsg::SensorType::PRESSURE: {
+      printf("Sending rbr pressure\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_d_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
@@ -517,6 +523,7 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       break;
     }
     case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
+      printf("Sending rbr pressure and temp\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_td_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
@@ -583,6 +590,9 @@ void reportBuilderInit(cfg::Configuration *sys_cfg) {
   sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS, strlen(AppConfig::TRANSMIT_AGGREGATIONS),
                      _ctx._transmitAggregations);
   _ctx._sample_counter = 0;
+  _ctx._config_mutex = xSemaphoreCreateMutex();
+  configASSERT(_ctx._config_mutex);
+  _ctx.report_period_max_network_config_cbor = NULL;
   _report_builder_queue =
       xQueueCreate(REPORT_BUILDER_QUEUE_SIZE, sizeof(report_builder_queue_item_t));
   configASSERT(_report_builder_queue);
@@ -808,20 +818,31 @@ static void report_builder_task(void *parameters) {
               BRIDGE_LOG_PRINT("Got topology in report builder!\n");
               if (temp_num_nodes >= _ctx._report_period_num_nodes) {
                 BRIDGE_LOG_PRINT("Updating CRC and topology in report builder!\n");
-                _ctx._report_period_num_nodes = temp_num_nodes;
-                memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
-                _ctx._report_period_max_network_crc32 = temp_network_crc32;
-                size_t report_period_sensor_type_list_size =
-                    sizeof(_ctx._report_period_sensor_type_list);
-                if (!topology_sampler_get_sensor_type_list(_ctx._report_period_sensor_type_list,
-                                                           report_period_sensor_type_list_size,
-                                                           _ctx._report_period_num_nodes,
-                                                           TOPO_TIMEOUT_MS)) {
-                  BRIDGE_LOG_PRINT("Failed to get the sensor type list in report builder!\n");
+                if (xSemaphoreTake(_ctx._config_mutex, pdMS_TO_TICKS(NETWORK_CONFIG_MUTEX_TIMEOUT_MS))) {
+                  if (_ctx.report_period_max_network_config_cbor != NULL) {
+                    vPortFree(_ctx.report_period_max_network_config_cbor);
+                  }
+                  _ctx.report_period_max_network_config_cbor = last_network_config;
+                  last_network_config = NULL;
+                  _ctx.report_period_max_network_config_cbor_len = temp_cbor_config_size;
+                  printf("Updated reportBuilders CBOR map\n");
+                  _ctx._report_period_num_nodes = temp_num_nodes;
+                  memcpy(_ctx._report_period_node_list, temp_node_list, sizeof(temp_node_list));
+                  _ctx._report_period_max_network_crc32 = temp_network_crc32;
+                  size_t report_period_sensor_type_list_size =
+                      sizeof(_ctx._report_period_sensor_type_list);
+                  if (!topology_sampler_get_sensor_type_list(_ctx._report_period_sensor_type_list,
+                                                            report_period_sensor_type_list_size,
+                                                            _ctx._report_period_num_nodes,
+                                                            TOPO_TIMEOUT_MS)) {
+                    BRIDGE_LOG_PRINT("Failed to get the sensor type list in report builder!\n");
+                  } else {
+                    BRIDGE_LOG_PRINT("Got sensor type list in report builder!\n");
+                  }
+                  xSemaphoreGive(_ctx._config_mutex);
                 } else {
-                  BRIDGE_LOG_PRINT("Got sensor type list in report builder!\n");
+                  BRIDGE_LOG_PRINT("Failed to take the config mutex in report builder!\n");
                 }
-
               } else {
                 BRIDGE_LOG_PRINT("Not updating CRC and topology in report builder, new "
                                  "topology is smaller than the old one!\n");
@@ -834,7 +855,9 @@ static void report_builder_task(void *parameters) {
           }
           // The last network config is not used here, but in the future it can be used to determine if varying sensor types have been
           // connected/disconnected to the network.
-          vPortFree(last_network_config);
+          if (last_network_config != NULL) {
+            vPortFree(last_network_config);
+          }
         }
         break;
       }
@@ -850,4 +873,33 @@ static void report_builder_task(void *parameters) {
       }
     }
   }
+}
+
+
+/*!
+ * @brief Get the last network configuration from the report builder. This will return the last
+ * @brief network configuration that may be used to stamp an outbound report.
+ * @note This function will allocate memory for the cbor config map, the caller is responsible for freeing it.
+ * @param[out] network_crc32 The network crc32
+ * @param[out] cbor_config_size The size of the cbor config map in bytes.
+ * @return The cbor config map or NULL if unable to retreive.
+ */
+uint8_t *report_builder_alloc_last_network_config(uint32_t &network_crc32,
+                                                    uint32_t &cbor_config_size) {
+  uint8_t *rval = NULL;
+  if (xSemaphoreTake(_ctx._config_mutex, pdMS_TO_TICKS(NETWORK_CONFIG_MUTEX_TIMEOUT_MS))) {
+    do {
+      if (!_ctx.report_period_max_network_config_cbor) {
+        break;
+      }
+      network_crc32 = _ctx._report_period_max_network_crc32;
+      cbor_config_size = _ctx.report_period_max_network_config_cbor_len;
+      rval = static_cast<uint8_t *>(pvPortMalloc(cbor_config_size));
+      configASSERT(rval);
+      memcpy(rval, _ctx.report_period_max_network_config_cbor,
+             cbor_config_size);
+    } while (0);
+    xSemaphoreGive(_ctx._config_mutex);
+  }
+  return rval;
 }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -818,7 +818,8 @@ static void report_builder_task(void *parameters) {
               BRIDGE_LOG_PRINT("Got topology in report builder!\n");
               if (temp_num_nodes >= _ctx._report_period_num_nodes) {
                 BRIDGE_LOG_PRINT("Updating CRC and topology in report builder!\n");
-                if (xSemaphoreTake(_ctx._config_mutex, pdMS_TO_TICKS(NETWORK_CONFIG_MUTEX_TIMEOUT_MS))) {
+                if (xSemaphoreTake(_ctx._config_mutex,
+                                   pdMS_TO_TICKS(NETWORK_CONFIG_MUTEX_TIMEOUT_MS))) {
                   if (_ctx.report_period_max_network_config_cbor != NULL) {
                     vPortFree(_ctx.report_period_max_network_config_cbor);
                   }
@@ -831,10 +832,10 @@ static void report_builder_task(void *parameters) {
                   _ctx._report_period_max_network_crc32 = temp_network_crc32;
                   size_t report_period_sensor_type_list_size =
                       sizeof(_ctx._report_period_sensor_type_list);
-                  if (!topology_sampler_get_sensor_type_list(_ctx._report_period_sensor_type_list,
-                                                            report_period_sensor_type_list_size,
-                                                            _ctx._report_period_num_nodes,
-                                                            TOPO_TIMEOUT_MS)) {
+                  if (!topology_sampler_get_sensor_type_list(
+                          _ctx._report_period_sensor_type_list,
+                          report_period_sensor_type_list_size, _ctx._report_period_num_nodes,
+                          TOPO_TIMEOUT_MS)) {
                     BRIDGE_LOG_PRINT("Failed to get the sensor type list in report builder!\n");
                   } else {
                     BRIDGE_LOG_PRINT("Got sensor type list in report builder!\n");
@@ -875,7 +876,6 @@ static void report_builder_task(void *parameters) {
   }
 }
 
-
 /*!
  * @brief Get the last network configuration from the report builder. This will return the last
  * @brief network configuration that may be used to stamp an outbound report.
@@ -885,7 +885,7 @@ static void report_builder_task(void *parameters) {
  * @return The cbor config map or NULL if unable to retreive.
  */
 uint8_t *report_builder_alloc_last_network_config(uint32_t &network_crc32,
-                                                    uint32_t &cbor_config_size) {
+                                                  uint32_t &cbor_config_size) {
   uint8_t *rval = NULL;
   if (xSemaphoreTake(_ctx._config_mutex, pdMS_TO_TICKS(NETWORK_CONFIG_MUTEX_TIMEOUT_MS))) {
     do {
@@ -896,8 +896,7 @@ uint8_t *report_builder_alloc_last_network_config(uint32_t &network_crc32,
       cbor_config_size = _ctx.report_period_max_network_config_cbor_len;
       rval = static_cast<uint8_t *>(pvPortMalloc(cbor_config_size));
       configASSERT(rval);
-      memcpy(rval, _ctx.report_period_max_network_config_cbor,
-             cbor_config_size);
+      memcpy(rval, _ctx.report_period_max_network_config_cbor, cbor_config_size);
     } while (0);
     xSemaphoreGive(_ctx._config_mutex);
   }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -766,11 +766,6 @@ static void report_builder_task(void *parameters) {
           memset(_ctx._report_period_node_list, 0, sizeof(_ctx._report_period_node_list));
           memset(_ctx._report_period_sensor_type_list, 0,
                  sizeof(_ctx._report_period_sensor_type_list));
-          if (_ctx.report_period_max_network_config_cbor != NULL) {
-            vPortFree(_ctx.report_period_max_network_config_cbor);
-          }
-          _ctx.report_period_max_network_config_cbor = NULL;
-          _ctx.report_period_max_network_config_cbor_len = 0;
         }
         break;
       }

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -505,7 +505,6 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
     bool rbr_coda_sample_valid = false;
     switch (rbr_coda_sample.sensor_type) {
     case BmRbrDataMsg::SensorType::TEMPERATURE: {
-      printf("Sending rbr temp\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_t_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
@@ -514,7 +513,6 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       break;
     }
     case BmRbrDataMsg::SensorType::PRESSURE: {
-      printf("Sending rbr pressure\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_d_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");
@@ -523,7 +521,6 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
       break;
     }
     case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
-      printf("Sending rbr pressure and temp\n");
       if (sensor_report_encoder_open_sample(context, RBR_CODA_NUM_SAMPLE_MEMBERS,
                                             "bm_rbr_td_v0") != CborNoError) {
         BRIDGE_LOG_PRINT("Failed to open rbr_coda sample in addSamplesToReport\n");

--- a/src/apps/bridge/reportBuilder.h
+++ b/src/apps/bridge/reportBuilder.h
@@ -22,3 +22,4 @@ typedef struct {
 
 void reportBuilderInit(cfg::Configuration* sys_cfg);
 void reportBuilderAddToQueue(uint64_t node_id, uint8_t sensor_type, void *sensor_data, uint32_t sensor_data_size, report_builder_message_e msg_type);
+uint8_t *report_builder_alloc_last_network_config(uint32_t &network_crc32, uint32_t &cbor_config_size);

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -215,6 +215,8 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
   if (network_config != NULL) {
     CborParser parser;
     CborValue all_nodes_array, individual_node_array, node_array_member;
+    char *app_name_str = NULL;
+    char *key_str = NULL;
     do {
       if (cbor_parser_init(network_config, cbor_config_size, 0, &parser, &all_nodes_array) !=
           CborNoError) {
@@ -305,15 +307,15 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
             printf("Failed to get the length of the node app name\n");
             break;
           }
-          char *strbuf = static_cast<char *>(pvPortMalloc(len + 1));
-          configASSERT(strbuf);
-          if (cbor_value_copy_text_string(&node_array_member, strbuf, &len, NULL) !=
+          app_name_str = static_cast<char *>(pvPortMalloc(len + 1));
+          configASSERT(app_name_str);
+          if (cbor_value_copy_text_string(&node_array_member, app_name_str, &len, NULL) !=
               CborNoError) {
             break;
           }
-          strbuf[len] = '\0';
-          printf("RBR Node app name: %s\n", strbuf);
-          vPortFree(strbuf);
+          app_name_str[len] = '\0';
+          printf("RBR Node app name: %s\n", app_name_str);
+          vPortFree(app_name_str);
           if (cbor_value_advance(&node_array_member) != CborNoError) {
             printf("Failed to advance the node array member\n");
             break;
@@ -366,7 +368,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
               printf("Failed to get the length of the sys_cfg_map key\n");
               break;
             }
-            char *key_str = static_cast<char *>(pvPortMalloc(len + 1));
+            key_str = static_cast<char *>(pvPortMalloc(len + 1));
             configASSERT(key_str);
             if (cbor_value_copy_text_string(&sys_cfg_map, key_str, &len, NULL) != CborNoError) {
               break;
@@ -412,6 +414,12 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
         }
       }
     } while (0);
+    if (app_name_str) {
+      vPortFree(app_name_str);
+    }
+    if (key_str) {
+      vPortFree(key_str);
+    }
     vPortFree(network_config);
   }
   return current_sensor_type;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -315,7 +315,6 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
           }
           app_name_str[len] = '\0';
           printf("RBR Node app name: %s\n", app_name_str);
-          vPortFree(app_name_str);
           if (cbor_value_advance(&node_array_member) != CborNoError) {
             printf("Failed to advance the node array member\n");
             break;
@@ -404,7 +403,6 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
               }
               break;
             }
-            vPortFree(key_str);
             if (cbor_value_advance(&sys_cfg_map) != CborNoError) {
               printf("Failed to advance the sys_cfg_map\n");
               break;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -212,7 +212,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
   uint32_t network_crc32 = 0;
   uint32_t cbor_config_size = 0;
   uint8_t *network_config =
-      topology_sampler_alloc_last_network_config(network_crc32, cbor_config_size);
+      report_builder_alloc_last_network_config(network_crc32, cbor_config_size);
   // bool found_rbr_type = false;
   // BmRbrDataMsg::SensorType_t sensor_type_rval = BmRbrDataMsg::SensorType::UNKNOWN;
 

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -148,18 +148,18 @@ void RbrCodaSensor::aggregate(void) {
       sensor_type_str = "RBR.UNKNOWN";
     }
 
-    log_buflen =
-        snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
-                 "%" PRIx64 "," // Node Id
-                 "%" PRIi8 ","  // node_position
-                 "%s,"          // node_app_name
-                 "%s,"          // timeStamp(ticks/UTC)
-                 "%" PRIu32 "," // reading_count
-                 "%.3f,"        // temp_mean_deg_c
-                 "%.3f,"        // pressure_mean_deci_bar
-                 "%.3f\n",      // pressure_stdev_deci_bar
-                 node_id, node_position, sensor_type_str, time_str, aggs.reading_count,
-                 aggs.temp_mean_deg_c, aggs.pressure_mean_deci_bar, aggs.pressure_stdev_deci_bar);
+    log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                          "%" PRIx64 "," // Node Id
+                          "%" PRIi8 ","  // node_position
+                          "%s,"          // node_app_name
+                          "%s,"          // timeStamp(ticks/UTC)
+                          "%" PRIu32 "," // reading_count
+                          "%.3f,"        // temp_mean_deg_c
+                          "%.3f,"        // pressure_mean_deci_bar
+                          "%.3f\n",      // pressure_stdev_deci_bar
+                          node_id, node_position, sensor_type_str, time_str, aggs.reading_count,
+                          aggs.temp_mean_deg_c, aggs.pressure_mean_deci_bar,
+                          aggs.pressure_stdev_deci_bar);
     if (log_buflen > 0) {
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {
@@ -211,7 +211,8 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
 
   uint32_t network_crc32 = 0;
   uint32_t cbor_config_size = 0;
-  uint8_t *network_config = topology_sampler_alloc_last_network_config(network_crc32, cbor_config_size);
+  uint8_t *network_config =
+      topology_sampler_alloc_last_network_config(network_crc32, cbor_config_size);
   // bool found_rbr_type = false;
   // BmRbrDataMsg::SensorType_t sensor_type_rval = BmRbrDataMsg::SensorType::UNKNOWN;
 
@@ -221,9 +222,10 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
     printf("GOT THE NETWORK CONFIG\n");
 
     CborParser parser;
-    CborValue all_nodes_array, individual_node_array, node_array_member;//, sys_cfg_map;
+    CborValue all_nodes_array, individual_node_array, node_array_member; //, sys_cfg_map;
     do {
-      if (cbor_parser_init(network_config, cbor_config_size, 0, &parser, &all_nodes_array) != CborNoError) {
+      if (cbor_parser_init(network_config, cbor_config_size, 0, &parser, &all_nodes_array) !=
+          CborNoError) {
         printf("Failed to initialize the cbor parser\n");
         break;
       }
@@ -264,7 +266,8 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
           break;
         }
 
-        if (cbor_value_enter_container(&individual_node_array, &node_array_member) != CborNoError) {
+        if (cbor_value_enter_container(&individual_node_array, &node_array_member) !=
+            CborNoError) {
           printf("Failed to enter the node sub array\n");
           break;
         }
@@ -318,7 +321,8 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
           }
           char *strbuf = static_cast<char *>(pvPortMalloc(len + 1));
           configASSERT(strbuf);
-          if (cbor_value_copy_text_string(&node_array_member, strbuf, &len, NULL) != CborNoError) {
+          if (cbor_value_copy_text_string(&node_array_member, strbuf, &len, NULL) !=
+              CborNoError) {
             break;
           }
           strbuf[len] = '\0';
@@ -366,7 +370,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
             break;
           }
           printf("GOT ALL THE WAY TO THE MAP!\n");
-          while(!cbor_value_at_end(&node_array_member)) {
+          while (!cbor_value_at_end(&node_array_member)) {
             if (!cbor_value_is_text_string(&sys_cfg_map)) {
               printf("expected string but it is not a string\n");
               break;
@@ -408,7 +412,8 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
               } else if (current_sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
                 printf("Sensor type RBR.D\n");
 
-              } else if (current_sensor_type == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+              } else if (current_sensor_type ==
+                         BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
                 printf("Sensor type RBR.DT\n");
 
               } else {
@@ -427,7 +432,6 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
       }
 
     } while (0);
-
 
     vPortFree(network_config);
   }

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -54,11 +54,11 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
 
         // Use the latest sensor type to determine the sensor type string
         const char *sensor_type_str;
-        if (br_data.sensor_type; == BmRbrDataMsg::SensorType::TEMPERATURE) {
+        if (rbr_data.sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {
           sensor_type_str = "RBR.T";
-        } else if (br_data.sensor_type; == BmRbrDataMsg::SensorType::PRESSURE) {
+        } else if (rbr_data.sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
           sensor_type_str = "RBR.D";
-        } else if (br_data.sensor_type; == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+        } else if (rbr_data.sensor_type == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
           sensor_type_str = "RBR.DT";
         } else {
           sensor_type_str = "RBR.UNKNOWN";

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -194,3 +194,28 @@ RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
   new_sub->reading_count = 0;
   return new_sub;
 }
+
+BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaSensorType(void) {
+  // TODO - here we need to call topology_sampler_alloc_last_network_config
+  // and then we will need to decode the cbor map in order to find the
+  // rbr sensor type.
+
+  // we should call this function in the aggregate function to get the sensor type
+  // so that way we stamp the sample with the correct sensor type that will be
+  // associated with the crc at the moment of the aggregation. This will
+  // tell the Spotter if the sensor type changes or we will 100% know the
+  // sensor type is the same as the one from the config that will associated
+  // with that message.
+  BmRbrDataMsg::SensorType current_sensor_type = BmRbrDataMsg::SensorType::UNKNOWN;
+
+  uint32_t network_crc32 = 0;
+  uint32_t cbor_config_size = 0;
+  uint8_t *network_config = topology_sampler_alloc_last_network_config(network_crc32, cbor_config_size);
+
+  if (network_config != NULL) {
+    // TODO - decode the cbor map to find the rbr sensor type
+    // and then return the sensor type.
+    vPortFree(network_config);
+  }
+  return current_sensor_type;
+}

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -231,7 +231,6 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
         printf("Failed to get the number of nodes\n");
         break;
       }
-      printf("Number of nodes: %d\n", num_nodes);
 
       if (cbor_value_enter_container(&all_nodes_array, &individual_node_array) != CborNoError) {
         printf("Failed to enter the nodes array\n");
@@ -412,9 +411,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
           break;
         }
       }
-
     } while (0);
-
     vPortFree(network_config);
   }
   return current_sensor_type;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -106,7 +106,7 @@ void RbrCodaSensor::aggregate(void) {
                                     .pressure_stdev_deci_bar = NAN,
                                     .reading_count = 0,
                                     .sensor_type = BmRbrDataMsg::SensorType::UNKNOWN};
-    aggs.sensor_type = latest_sensor_type;
+    aggs.sensor_type = rbrCodaGetSensorType();
     if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       aggs.temp_mean_deg_c = temp_deg_c.getMean();
       aggs.pressure_mean_deci_bar = pressure_ubar.getMean();
@@ -195,7 +195,7 @@ RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
   return new_sub;
 }
 
-BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaSensorType(void) {
+BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
   // TODO - here we need to call topology_sampler_alloc_last_network_config
   // and then we will need to decode the cbor map in order to find the
   // rbr sensor type.
@@ -215,6 +215,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaSensorType(void) {
   if (network_config != NULL) {
     // TODO - decode the cbor map to find the rbr sensor type
     // and then return the sensor type.
+    printf("GOT THE NETWORK CONFIG\n");
     vPortFree(network_config);
   }
   return current_sensor_type;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -221,31 +221,31 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
     printf("GOT THE NETWORK CONFIG\n");
 
     CborParser parser;
-    CborValue nodes_array, node_sub_array, node_array_member;// sys_cfg_map, value;
+    CborValue all_nodes_array, individual_node_array, node_array_member;//, sys_cfg_map;
     do {
-      if (cbor_parser_init(network_config, cbor_config_size, 0, &parser, &nodes_array) != CborNoError) {
+      if (cbor_parser_init(network_config, cbor_config_size, 0, &parser, &all_nodes_array) != CborNoError) {
         printf("Failed to initialize the cbor parser\n");
         break;
       }
-      if (!cbor_value_is_array(&nodes_array)) {
+      if (!cbor_value_is_array(&all_nodes_array)) {
         printf("Failed to get the nodes array\n");
         break;
       }
       // Get the number of nodes
       size_t num_nodes;
-      if (cbor_value_get_array_length(&nodes_array, &num_nodes) != CborNoError) {
+      if (cbor_value_get_array_length(&all_nodes_array, &num_nodes) != CborNoError) {
         printf("Failed to get the number of nodes\n");
         break;
       }
       printf("Number of nodes: %d\n", num_nodes);
 
-      if (cbor_value_enter_container(&nodes_array, &node_sub_array) != CborNoError) {
+      if (cbor_value_enter_container(&all_nodes_array, &individual_node_array) != CborNoError) {
         printf("Failed to enter the nodes array\n");
         break;
       }
 
       for (size_t node_idx = 0; node_idx < num_nodes; node_idx++) {
-        if (!cbor_value_is_array(&node_sub_array)) {
+        if (!cbor_value_is_array(&individual_node_array)) {
           printf("Failed to get the node sub array\n");
           break;
         }
@@ -253,7 +253,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
         // do we need to check if the array is 5 elements?
         // i'll do it just in case i guess.
         size_t num_elements;
-        if (cbor_value_get_array_length(&node_sub_array, &num_elements) != CborNoError) {
+        if (cbor_value_get_array_length(&individual_node_array, &num_elements) != CborNoError) {
           printf("Failed to get the number of elements in the node sub array\n");
           break;
         }
@@ -264,7 +264,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
           break;
         }
 
-        if (cbor_value_enter_container(&node_sub_array, &node_array_member) != CborNoError) {
+        if (cbor_value_enter_container(&individual_node_array, &node_array_member) != CborNoError) {
           printf("Failed to enter the node sub array\n");
           break;
         }
@@ -278,15 +278,28 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
         if (extracted_node_id != node_id) {
           printf("Node ID does not match\n");
           //close the container???
-          cbor_value_leave_container(&node_sub_array, &node_array_member);
-          cbor_value_advance(&node_sub_array);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_leave_container(&individual_node_array, &node_array_member);
+          // cbor_value_advance(&all_nodes_array);
           continue;
         } else {
           printf("Node ID matches\n");
-          cbor_value_leave_container(&node_sub_array, &node_array_member);
-          cbor_value_advance(&node_sub_array);
-          continue;
-          break;
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_advance(&node_array_member);
+          cbor_value_leave_container(&individual_node_array, &node_array_member);
+          // if (cbor_value_advance(&node_array_member) != CborNoError) {
+          //   printf("Failed to advance the node array member\n");
+          //   break;
+          // }
+          // if (cbor_value_is_text_string())
+
         }
       }
 

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -43,9 +43,6 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         rbr_coda->temp_deg_c.addSample(rbr_data.temperature_deg_c);
         rbr_coda->pressure_ubar.addSample(rbr_data.pressure_deci_bar);
         rbr_coda->reading_count++;
-        // Update the RBR CODA's latest sensor type
-        // TODO - verify that we should do this here v.s. when we aggregate. Although I'm not sure if we will be able to do that in the aggregate function.
-        rbr_coda->latest_sensor_type = rbr_data.sensor_type;
         // Large floats get formatted in scientific notation,
         // so we print integer seconds and millis separately.
         uint64_t reading_time_sec = rbr_data.header.reading_time_utc_ms / 1000U;
@@ -57,12 +54,11 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
 
         // Use the latest sensor type to determine the sensor type string
         const char *sensor_type_str;
-        if (rbr_coda->latest_sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {
+        if (br_data.sensor_type; == BmRbrDataMsg::SensorType::TEMPERATURE) {
           sensor_type_str = "RBR.T";
-        } else if (rbr_coda->latest_sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
+        } else if (br_data.sensor_type; == BmRbrDataMsg::SensorType::PRESSURE) {
           sensor_type_str = "RBR.D";
-        } else if (rbr_coda->latest_sensor_type ==
-                   BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+        } else if (br_data.sensor_type; == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
           sensor_type_str = "RBR.DT";
         } else {
           sensor_type_str = "RBR.UNKNOWN";
@@ -195,7 +191,6 @@ RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
   new_sub->reading_count = 0;
   return new_sub;
 }
-
 
 BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id) {
   BmRbrDataMsg::SensorType current_sensor_type = BmRbrDataMsg::SensorType::UNKNOWN;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -405,17 +405,13 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
               printf("sensor_type: %" PRIu64 "\n", sensor_type);
               if (current_sensor_type == BmRbrDataMsg::SensorType::UNKNOWN) {
                 printf("Sensor type UKNOWN\n");
-
               } else if (current_sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {
                 printf("Sensor type RBR.T\n");
-
               } else if (current_sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
                 printf("Sensor type RBR.D\n");
-
               } else if (current_sensor_type ==
                          BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
                 printf("Sensor type RBR.DT\n");
-
               } else {
                 printf("Failed to get the sensor type, setting to UNKOWN\n");
               }

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -283,6 +283,10 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
           continue;
         } else {
           printf("Node ID matches\n");
+          cbor_value_leave_container(&node_sub_array, &node_array_member);
+          cbor_value_advance(&node_sub_array);
+          continue;
+          break;
         }
       }
 

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -192,6 +192,18 @@ RbrCoda_t *createRbrCodaSub(uint64_t node_id, uint32_t rbr_coda_agg_period_ms,
   return new_sub;
 }
 
+/**
+ * @brief Retrieves the type of the sensor from the RBR Coda device.
+ *
+ * This function gets the RBR Coda type for the type of the sensor
+ * currently in use. The sensor type is returned as an enumerated value
+ * representing different possible sensor types. It gets the type from
+ * the network configurations CBOR map.
+ *
+ * @return An enumeration representing the type of the sensor.
+ * The specific values of the enumeration will depend on the types of sensors
+ * supported by the RBR Coda device.
+ */
 BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id) {
   BmRbrDataMsg::SensorType current_sensor_type = BmRbrDataMsg::SensorType::UNKNOWN;
 

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -399,7 +399,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
               }
               current_sensor_type = static_cast<BmRbrDataMsg::SensorType_t>(sensor_type);
               printf("sensor_type: %" PRIu64 "\n", sensor_type);
-              if (current_senspr_type == BmRbrDataMsg::SensorType::UNKNOWN) {
+              if (current_sensor_type == BmRbrDataMsg::SensorType::UNKNOWN) {
                 printf("Sensor type UKNOWN\n");
 
               } else if (current_sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -337,8 +337,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
             printf("Failed to get the git sha\n");
             break;
           }
-          printf("Git SHA: %d\n", gitSha);
-
+          printf("Git SHA: %" PRIx64 "\n", gitSha);
           if (cbor_value_advance(&node_array_member) != CborNoError) {
             printf("Failed to advance the node array member\n");
             break;
@@ -352,7 +351,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
             printf("Failed to get the git sha\n");
             break;
           }
-          printf("sys_confg_crc: %d\n", sys_confg_crc);
+          printf("sys_confg_crc: %" PRIx64 "\n", sys_confg_crc);
           if (cbor_value_advance(&node_array_member) != CborNoError) {
             printf("Failed to advance the node array member\n");
             break;
@@ -399,7 +398,22 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(void) {
                 break;
               }
               current_sensor_type = static_cast<BmRbrDataMsg::SensorType_t>(sensor_type);
-              printf("sensor_type: %d\n", sensor_type);
+              printf("sensor_type: %" PRIu64 "\n", sensor_type);
+              if (current_senspr_type == BmRbrDataMsg::SensorType::UNKNOWN) {
+                printf("Sensor type UKNOWN\n");
+
+              } else if (current_sensor_type == BmRbrDataMsg::SensorType::TEMPERATURE) {
+                printf("Sensor type RBR.T\n");
+
+              } else if (current_sensor_type == BmRbrDataMsg::SensorType::PRESSURE) {
+                printf("Sensor type RBR.D\n");
+
+              } else if (current_sensor_type == BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+                printf("Sensor type RBR.DT\n");
+
+              } else {
+                printf("Failed to get the sensor type, setting to UNKOWN\n");
+              }
               break;
             }
             vPortFree(key_str);

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -44,7 +44,7 @@ private:
   static void rbrCodaSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                  const uint8_t *data, uint16_t data_len, uint8_t type,
                                  uint8_t version);
-
+  BmRbrDataMsg::SensorType_t rbrCodaSensorType(void);
 private:
   static constexpr char subtag[] = "/bm_rbr_data";
 } RbrCoda_t;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -44,7 +44,7 @@ private:
   static void rbrCodaSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                  const uint8_t *data, uint16_t data_len, uint8_t type,
                                  uint8_t version);
-  BmRbrDataMsg::SensorType_t rbrCodaGetSensorType(void);
+  static BmRbrDataMsg::SensorType_t rbrCodaGetSensorType(uint64_t node_id);
 
 private:
   static constexpr char subtag[] = "/bm_rbr_data";

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -44,7 +44,7 @@ private:
   static void rbrCodaSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                  const uint8_t *data, uint16_t data_len, uint8_t type,
                                  uint8_t version);
-  BmRbrDataMsg::SensorType_t rbrCodaSensorType(void);
+  BmRbrDataMsg::SensorType_t rbrCodaGetSensorType(void);
 private:
   static constexpr char subtag[] = "/bm_rbr_data";
 } RbrCoda_t;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -45,6 +45,7 @@ private:
                                  const uint8_t *data, uint16_t data_len, uint8_t type,
                                  uint8_t version);
   BmRbrDataMsg::SensorType_t rbrCodaGetSensorType(void);
+
 private:
   static constexpr char subtag[] = "/bm_rbr_data";
 } RbrCoda_t;

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -42,7 +42,6 @@
 #define NODE_CONFIG_CBOR_MAP_REQUEST_TIMEOUT_MS (NODE_CONFIG_CBOR_MAP_REQUEST_TIMEOUT_S * 1000)
 // Accounts for name of app + cbor config map + encoding inefficiencies
 #define NODE_CONFIG_PADDING (512)
-#define NUM_CONFIG_FIELDS_PER_NODE (5)
 
 typedef struct network_configuration_info {
   uint32_t network_crc32;

--- a/src/lib/common/topology_sampler.h
+++ b/src/lib/common/topology_sampler.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 
+#define NUM_CONFIG_FIELDS_PER_NODE (5)
 #define TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE (16) // Note: Derived from satellite message definition, 1 bridge + 15 more nodes.
 
 void topology_sampler_init(BridgePowerController *power_controller, cfg::Configuration* hw_cfg, cfg::Configuration* sys_cfg);


### PR DESCRIPTION
Here I have updated reportBuilder such that it keeps a local copy of the "max" CBOR map it receives during a sample interval. Then someone can get a copy of that "max" CBOR map and decode it to discover any relevant information they want. In this case upon aggregation, the rbrCodaSensor driver will copy the "max" CBOR map and parse through it looking for the desired node's `rbrCodaType` system config. The rbrCodaSensor driver will then stamp its aggregated sample with that type such that the Report Builder pass that RBR type on to Spotter who will then be able to bitpack the data appropriately. 

The reason for decoding the CBOR map is so that the `rbrCodaType` that the rbrCodaSensor driver, Report Builder, and Topology/CRC reference is the same. This will guarantee that when a BMSensorData1 message is received on the backend there will be no mismatch between the BMSensorData1 messages CRC and its bitpacked data.