### PR TITLE
increase the bridges freertos heap size to 400KB

### DIFF
--- a/src/apps/bridge/FreeRTOSConfig.h
+++ b/src/apps/bridge/FreeRTOSConfig.h
@@ -69,7 +69,7 @@ extern "C" {
 #define configTICK_RATE_HZ                       ((TickType_t)1000)
 #define configMAX_PRIORITIES                     ( 32 )
 #define configMINIMAL_STACK_SIZE                 ((uint16_t)128)
-#define configTOTAL_HEAP_SIZE                    ((size_t)1024*256)
+#define configTOTAL_HEAP_SIZE                    ((size_t)1024*400)
 #define configMAX_TASK_NAME_LEN                  ( 16 )
 #define configUSE_TRACE_FACILITY                 1
 #define configUSE_16_BIT_TICKS                   0


### PR DESCRIPTION
This will allow us to have space for our buffering system for RBR, soft, and aanderaa readings. This does decrease the size of available .bss, but there should still be ~171KB of available SRAM for future .bss or expansion of the heap.