### PR TITLE
Feature/bcmp linked list

### DIFF
--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -34,11 +34,6 @@
 // 1500 MTU minus ipv6 header
 #define MAX_PAYLOAD_LEN (1500 - sizeof(struct ip6_hdr))
 
-// TODO - add a linked list here
-// The linked list will consist of outgoing messages
-// and their sequence numbers and the callback to call
-// upon receipt of the reply.
-// The callback should also handle the timeout case.
 static constexpr uint32_t DEFAULT_MESSAGE_TIMEOUT_MS = 100;
 static constexpr uint32_t MESSAGE_TIMER_EXPIRY_PERIOD_MS = 500;
 

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -169,9 +169,8 @@ int32_t bcmp_process_packet(struct pbuf *pbuf, ip_addr_t *src, ip_addr_t *dst) {
           xSemaphoreGive(_ctx.messages_list_mutex);
         }
       } else {
-        // Not one of our messages, so we should ignore it.
-        printf("BCMP - Received message with seq_num %d that we didn't send\n", header->seq_num);
-        break;
+        // Not one of our messages, so we will let it pass and perhaps it will be forwarded.
+        printf("BCMP - Received message with seq_num %d that we didn't request, lets forward it!\n", header->seq_num);
       }
     }
 
@@ -237,6 +236,7 @@ int32_t bcmp_process_packet(struct pbuf *pbuf, ip_addr_t *src, ip_addr_t *dst) {
         if (should_forward) {
           // Forward the message to all ports other than the ingress port.
           bcmp_ll_forward(pbuf, ingress_port);
+          printf("Forwarding config message with seq_num: %d\n", header->seq_num);
         }
         break;
       }

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -652,17 +652,7 @@ static bool _message_is_sequenced_reply(uint16_t type) {
   bool rval = false;
   if (type == BCMP_CONFIG_VALUE ||
       type == BCMP_CONFIG_STATUS_RESPONSE ||
-      type == BCMP_CONFIG_DELETE_RESPONSE ||
-      type == BCMP_DFU_PAYLOAD_REQ ||
-      type == BCMP_DFU_PAYLOAD ||
-      type == BCMP_DFU_END ||
-      type == BCMP_DFU_ACK ||
-      type == BCMP_DFU_ABORT ||
-      type == BCMP_DFU_HEARTBEAT ||
-      type == BCMP_DFU_REBOOT_REQ ||
-      type == BCMP_DFU_REBOOT ||
-      type == BCMP_DFU_BOOT_COMPLETE ||
-      type == BCMP_ECHO_REPLY) {
+      type == BCMP_CONFIG_DELETE_RESPONSE) {
     rval = true;
   }
   return rval;
@@ -673,11 +663,7 @@ static bool _message_is_sequenced_request(uint16_t type) {
   if (type == BCMP_CONFIG_GET ||
       type == BCMP_CONFIG_SET ||
       type == BCMP_CONFIG_STATUS_REQUEST ||
-      type == BCMP_CONFIG_DELETE_REQUEST ||
-      type == BCMP_DFU_START ||
-      type == BCMP_DFU_PAYLOAD_REQ ||
-      type == BCMP_DFU_REBOOT_REQ ||
-      type == BCMP_ECHO_REQUEST) {
+      type == BCMP_CONFIG_DELETE_REQUEST) {
     rval = true;
   }
   return rval;

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -677,7 +677,6 @@ static bool _message_is_sequenced_request(uint16_t type) {
   bool rval = false;
   if (type == BCMP_CONFIG_GET ||
       type == BCMP_CONFIG_SET ||
-      type == BCMP_CONFIG_COMMIT ||
       type == BCMP_CONFIG_STATUS_REQUEST ||
       type == BCMP_CONFIG_DELETE_REQUEST ||
       type == BCMP_DFU_START ||

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -32,6 +32,12 @@
 // 1500 MTU minus ipv6 header
 #define MAX_PAYLOAD_LEN (1500 - sizeof(struct ip6_hdr))
 
+// TODO - add a linked list here
+// The linked list will consist of outgoing messages
+// and their sequence numbers and the callback to call
+// upon receipt of the reply.
+// The callback should also handle the timeout case.
+
 typedef struct {
   struct netif* netif;
   struct raw_pcb *pcb;

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -238,7 +238,7 @@ int32_t bcmp_process_packet(struct pbuf *pbuf, ip_addr_t *src, ip_addr_t *dst) {
       case BCMP_CONFIG_DELETE_REQUEST:
       case BCMP_CONFIG_DELETE_RESPONSE: {
         bool should_forward = bcmp_process_config_message(
-            static_cast<bcmp_message_type_t>(header->type), header->payload);
+            static_cast<bcmp_message_type_t>(header->type), header->payload, header->seq_num);
         if (should_forward) {
           // Forward the message to all ports other than the ingress port.
           bcmp_ll_forward(pbuf, ingress_port);

--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -21,6 +21,6 @@ using namespace cfg;
 #define BCMP_MAX_PAYLOAD_SIZE_BYTES (1500) // FIXME: Remove when we can split payloads.
 
 void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration* user_cfg, Configuration* sys_cfg);
-err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len);
+err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, bool is_reply=false, uint16_t seq_num=0);
 err_t bcmp_ll_forward(struct pbuf *pbuf, uint8_t ingress_port);
 void bcmp_link_change(uint8_t port, bool state);

--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -21,6 +21,6 @@ using namespace cfg;
 #define BCMP_MAX_PAYLOAD_SIZE_BYTES (1500) // FIXME: Remove when we can split payloads.
 
 void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration* user_cfg, Configuration* sys_cfg);
-err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, bool is_reply=false, uint16_t seq_num=0);
+err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num=0);
 err_t bcmp_ll_forward(struct pbuf *pbuf, uint8_t ingress_port);
 void bcmp_link_change(uint8_t port, bool state);

--- a/src/lib/bcmp/bcmp_config.cpp
+++ b/src/lib/bcmp/bcmp_config.cpp
@@ -91,7 +91,7 @@ bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partit
     return rval;
 }
 
-bool bcmp_config_status_response(uint64_t target_node_id, bm_common_config_partition_e partition, bool commited, uint8_t num_keys, const ConfigKey_t* keys, err_t &err) {
+bool bcmp_config_status_response(uint64_t target_node_id, bm_common_config_partition_e partition, bool commited, uint8_t num_keys, const ConfigKey_t* keys, err_t &err, uint16_t seq_num) {
     bool rval = false;
     err = ERR_VAL;
     size_t msg_size = sizeof(bm_common_config_status_response_t);
@@ -117,7 +117,7 @@ bool bcmp_config_status_response(uint64_t target_node_id, bm_common_config_parti
             key_data += sizeof(bm_common_config_status_key_data_t);
             key_data += keys[i].keyLen;
         }
-        err = bcmp_tx(&multicast_ll_addr, BCMP_CONFIG_STATUS_RESPONSE, reinterpret_cast<uint8_t *>(status_resp_msg), msg_size);
+        err = bcmp_tx(&multicast_ll_addr, BCMP_CONFIG_STATUS_RESPONSE, reinterpret_cast<uint8_t *>(status_resp_msg), msg_size, seq_num);
         if(err == ERR_OK) {
             rval = true;
         }
@@ -143,7 +143,7 @@ static void bcmp_config_process_commit_msg(bm_common_config_commit_t * msg) {
     }
 }
 
-static void bcmp_config_process_status_request_msg(bm_common_config_status_request_t * msg) {
+static void bcmp_config_process_status_request_msg(bm_common_config_status_request_t * msg, uint16_t seq_num) {
     configASSERT(msg);
     err_t err;
     do {
@@ -158,14 +158,14 @@ static void bcmp_config_process_status_request_msg(bm_common_config_status_reque
         }
         uint8_t num_keys;
         const ConfigKey_t * keys = cfg->getStoredKeys(num_keys);
-        bcmp_config_status_response(msg->header.source_node_id, msg->partition, cfg->needsCommit(),num_keys,keys,err);
+        bcmp_config_status_response(msg->header.source_node_id, msg->partition, cfg->needsCommit(),num_keys,keys,err,seq_num);
         if(err != ERR_OK){
             printf("Error processing config status request.\n");
         }
     } while(0);
 }
 
-static bool bcmp_config_send_value(uint64_t target_node_id, bm_common_config_partition_e partition,uint32_t data_length, void* data, err_t &err) {
+static bool bcmp_config_send_value(uint64_t target_node_id, bm_common_config_partition_e partition,uint32_t data_length, void* data, err_t &err, uint16_t seq_num) {
     bool rval = false;
     err = ERR_VAL;
     size_t msg_len = data_length + sizeof(bm_common_config_value_t);
@@ -177,7 +177,7 @@ static bool bcmp_config_send_value(uint64_t target_node_id, bm_common_config_par
         value_msg->partition = partition;
         value_msg->data_length = data_length;
         memcpy(value_msg->data, data, data_length);
-        err = bcmp_tx(&multicast_ll_addr, BCMP_CONFIG_VALUE, (uint8_t *)value_msg, msg_len);
+        err = bcmp_tx(&multicast_ll_addr, BCMP_CONFIG_VALUE, (uint8_t *)value_msg, msg_len, seq_num);
         if(err == ERR_OK) {
             rval = true;
         }
@@ -186,7 +186,7 @@ static bool bcmp_config_send_value(uint64_t target_node_id, bm_common_config_par
     return rval;
 }
 
-static void bcmp_config_process_config_get_msg(bm_common_config_get_t *msg){
+static void bcmp_config_process_config_get_msg(bm_common_config_get_t *msg, uint16_t seq_num){
     configASSERT(msg);
     do {
         Configuration *cfg;
@@ -202,13 +202,13 @@ static void bcmp_config_process_config_get_msg(bm_common_config_get_t *msg){
         configASSERT(buffer);
         if(cfg->getConfigCbor(msg->key,msg->key_length, buffer, buffer_len)){
             err_t err;
-            bcmp_config_send_value(msg->header.source_node_id,msg->partition, buffer_len, buffer, err);
+            bcmp_config_send_value(msg->header.source_node_id,msg->partition, buffer_len, buffer, err, seq_num);
         }
         vPortFree(buffer);
     } while(0);
 }
 
-static void bcmp_config_process_config_set_msg(bm_common_config_set_t *msg){
+static void bcmp_config_process_config_set_msg(bm_common_config_set_t *msg, uint16_t seq_num){
     configASSERT(msg);
     do {
         Configuration *cfg;
@@ -224,7 +224,7 @@ static void bcmp_config_process_config_set_msg(bm_common_config_set_t *msg){
         }
         if(cfg->setConfigCbor(reinterpret_cast<const char *>(msg->keyAndData), msg->key_length, &msg->keyAndData[msg->key_length], msg->data_length)){
             err_t err;
-            bcmp_config_send_value(msg->header.source_node_id,msg->partition, msg->data_length, &msg->keyAndData[msg->key_length], err);
+            bcmp_config_send_value(msg->header.source_node_id,msg->partition, msg->data_length, &msg->keyAndData[msg->key_length], err, seq_num);
         }
     } while(0);
 }
@@ -392,7 +392,7 @@ static void bcmp_process_del_response_message(bm_common_config_delete_key_respon
 /*!
     \return true if the caller should forward the message, false if the message was handled
 */
-bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload) {
+bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload, uint16_t seq_num) {
     bool should_forward = false;
     do {
         bm_common_config_header_t * msg_header = reinterpret_cast<bm_common_config_header_t *>(payload);
@@ -402,19 +402,20 @@ bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *pay
         }
         switch(bcmp_msg_type){
             case BCMP_CONFIG_GET: {
-                bcmp_config_process_config_get_msg(reinterpret_cast<bm_common_config_get_t *>(payload));
+                bcmp_config_process_config_get_msg(reinterpret_cast<bm_common_config_get_t *>(payload), seq_num);
                 break;
             }
             case BCMP_CONFIG_SET: {
-                bcmp_config_process_config_set_msg(reinterpret_cast<bm_common_config_set_t *>(payload));
+                bcmp_config_process_config_set_msg(reinterpret_cast<bm_common_config_set_t *>(payload), seq_num);
                 break;
             }
             case BCMP_CONFIG_COMMIT: {
+                (void) seq_num;
                 bcmp_config_process_commit_msg(reinterpret_cast<bm_common_config_commit_t *>(payload));
                 break;
             }
             case BCMP_CONFIG_STATUS_REQUEST: {
-                bcmp_config_process_status_request_msg(reinterpret_cast<bm_common_config_status_request_t *>(payload));
+                bcmp_config_process_status_request_msg(reinterpret_cast<bm_common_config_status_request_t *>(payload), seq_num);
                 break;
             }
             case BCMP_CONFIG_STATUS_RESPONSE: {
@@ -435,21 +436,25 @@ bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *pay
                 break;
             }
             case BCMP_CONFIG_VALUE: {
+                (void) seq_num; // TODO - use it here too!
                 bm_common_config_value_t *msg = reinterpret_cast<bm_common_config_value_t *>(payload);
                 bcmp_process_value_message(msg);
                 break;
             }
             case BCMP_CONFIG_DELETE_REQUEST: {
+                (void) seq_num; // TODO - use it here too!
                 bm_common_config_delete_key_request_t *msg = reinterpret_cast<bm_common_config_delete_key_request_t *>(payload);
                 bcmp_process_del_request_message(msg);
                 break;
             }
             case BCMP_CONFIG_DELETE_RESPONSE: {
+                (void) seq_num; // TODO - use it here too!
                 bm_common_config_delete_key_response_t *msg = reinterpret_cast<bm_common_config_delete_key_response_t *>(payload);
                 bcmp_process_del_response_message(msg);
                 break;
             }
             default:
+                (void) seq_num; // TODO - use it here too!
                 printf("Invalid config msg\n");
                 break;
         }

--- a/src/lib/bcmp/bcmp_config.h
+++ b/src/lib/bcmp/bcmp_config.h
@@ -17,4 +17,4 @@ bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partit
 bool bcmp_config_status_response(uint64_t target_node_id,bm_common_config_partition_e partition, bool commited, err_t &err);
 bool bcmp_config_del_key(uint64_t target_node_id,bm_common_config_partition_e partition, size_t key_len, const char * key);
 
-bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload);
+bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload, uint16_t seq_num);

--- a/src/lib/bcmp/bcmp_ping.cpp
+++ b/src/lib/bcmp/bcmp_ping.cpp
@@ -59,7 +59,7 @@ err_t bcmp_send_ping_request(uint64_t node_id, const ip_addr_t *addr, const uint
 
   printf("PING (%" PRIx64 "): %" PRIu16 " data bytes\n", echo_req->target_node_id, echo_req->payload_len);
 
-  err_t rval = bcmp_tx(addr, BCMP_ECHO_REQUEST, reinterpret_cast<uint8_t*>(echo_req), echo_len);
+  err_t rval = bcmp_tx(addr, BCMP_ECHO_REQUEST, reinterpret_cast<uint8_t*>(echo_req), echo_len, false, 0);
 
   _ping_request_time = uptimeGetMicroSeconds();
 
@@ -75,9 +75,9 @@ err_t bcmp_send_ping_request(uint64_t node_id, const ip_addr_t *addr, const uint
   \param *addr - ip address to send ping reply to
   \ret ERR_OK if successful
 */
-err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr) {
+err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr, uint16_t seq_num) {
 
-  return bcmp_tx(addr, BCMP_ECHO_REPLY, reinterpret_cast<uint8_t*>(echo_reply), sizeof(*echo_reply) + echo_reply->payload_len);
+  return bcmp_tx(addr, BCMP_ECHO_REPLY, reinterpret_cast<uint8_t*>(echo_reply), sizeof(*echo_reply) + echo_reply->payload_len, true, seq_num);
 }
 
 /*!
@@ -88,12 +88,12 @@ err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr)
   \param *dst - destination ip of request (used for responding to the correct multicast address)
   \ret ERR_OK if successful
 */
-err_t bcmp_process_ping_request(bcmp_echo_request_t *echo_req, const ip_addr_t *src, const ip_addr_t *dst) {
+err_t bcmp_process_ping_request(bcmp_echo_request_t *echo_req, const ip_addr_t *src, const ip_addr_t *dst, uint16_t seq_num) {
   (void) src;
   configASSERT(echo_req);
   if ((echo_req->target_node_id == 0) || (getNodeId() == echo_req->target_node_id)) {
     echo_req->target_node_id = getNodeId();
-    return bcmp_send_ping_reply(reinterpret_cast<bcmp_echo_reply_t*>(echo_req), dst);
+    return bcmp_send_ping_reply(reinterpret_cast<bcmp_echo_reply_t*>(echo_req), dst, seq_num);
   }
 
   return ERR_OK;

--- a/src/lib/bcmp/bcmp_ping.cpp
+++ b/src/lib/bcmp/bcmp_ping.cpp
@@ -59,7 +59,7 @@ err_t bcmp_send_ping_request(uint64_t node_id, const ip_addr_t *addr, const uint
 
   printf("PING (%" PRIx64 "): %" PRIu16 " data bytes\n", echo_req->target_node_id, echo_req->payload_len);
 
-  err_t rval = bcmp_tx(addr, BCMP_ECHO_REQUEST, reinterpret_cast<uint8_t*>(echo_req), echo_len, false, 0);
+  err_t rval = bcmp_tx(addr, BCMP_ECHO_REQUEST, reinterpret_cast<uint8_t*>(echo_req), echo_len, 0);
 
   _ping_request_time = uptimeGetMicroSeconds();
 
@@ -77,7 +77,7 @@ err_t bcmp_send_ping_request(uint64_t node_id, const ip_addr_t *addr, const uint
 */
 err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr, uint16_t seq_num) {
 
-  return bcmp_tx(addr, BCMP_ECHO_REPLY, reinterpret_cast<uint8_t*>(echo_reply), sizeof(*echo_reply) + echo_reply->payload_len, true, seq_num);
+  return bcmp_tx(addr, BCMP_ECHO_REPLY, reinterpret_cast<uint8_t*>(echo_reply), sizeof(*echo_reply) + echo_reply->payload_len, seq_num);
 }
 
 /*!

--- a/src/lib/bcmp/bcmp_ping.h
+++ b/src/lib/bcmp/bcmp_ping.h
@@ -4,6 +4,6 @@
 #include "lwip/ip_addr.h"
 
 err_t bcmp_send_ping_request(uint64_t node_id, const ip_addr_t *addr, const uint8_t* payload, uint16_t payload_len);
-err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr);
-err_t bcmp_process_ping_request(bcmp_echo_request_t *echo_req, const ip_addr_t *src, const ip_addr_t *dst);
+err_t bcmp_send_ping_reply(bcmp_echo_reply_t *echo_reply, const ip_addr_t *addr, uint16_t seq_num);
+err_t bcmp_process_ping_request(bcmp_echo_request_t *echo_req, const ip_addr_t *src, const ip_addr_t *dst, uint16_t seq_num);
 err_t bcmp_process_ping_reply(bcmp_echo_reply_t *echo_reply);


### PR DESCRIPTION
This PR has a linked list for outgoing "sequenced" messages. These element on the linked list will be removed when we get a BCMP message with the same sequence number, otherwise after 500ms we will time out and remove the element from the linked list. 

This PR just has the linked list implemented and basic req/rep for configs and ping (note: PING needs to be removed before the final merge, but it is an easy one to test with in a 2 node system.)

I have created 2 helper functions to categorize the BCMP message types into sequenced requests and sequenced responses. These helper functions are used when sending a BCMP message out and when receiving a BCMP message to determine if we a) care about the sequence number, b) need to stamp the request message with the local sequence number, c) forward the received sequence number in a reply.

Example of a mote requesting sys config status from a bridge:
```
bm cfg status 4d58ce2f22dfb374 s
BCMP - Sending message with seq_num 4
Successful status request send
BCMP message with seq_num 4 found
BCMP - Received reply to message with seq_num 4
Response msg -- Node Id:4d58ce2f22dfb374,Partition:1, Commit Status:0
Num Keys: 10
bridgePowerControllerEnabled
samplesPerReport
transmitAggregations
sampleIntervalMs
sampleDurationMs
subsampleIntervalMs
subsampleEnabled
currentReadingPeriodMs
alignmentInterval5Min
subsampleDurationMs
```

Testing TODO:
3+ node system