### PR TITLE
Feature/bcmp cfg callbacks

### DIFF
--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -42,6 +42,7 @@ typedef struct bcmp_request_element {
   uint16_t type;
   uint32_t send_timestamp_ms;
   uint32_t timeout_ms;
+  bcmp_reply_message_cb callback;
   bcmp_request_element *next;
 } bcmp_request_element_t;
 

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -79,7 +79,7 @@ static bcmpContext_t _ctx;
 
 static bool _message_list_add_message(bcmp_request_element *message);
 static bool _message_list_remove_message(bcmp_request_element *message);
-static bcmp_request_element *_message_list_create_element(uint16_t seq_num, uint16_t type, uint32_t timeout_ms);
+static bcmp_request_element *_message_list_create_element(uint16_t seq_num, uint16_t type, uint32_t timeout_ms, bcmp_reply_message_cb callback);
 static void _message_list_timer_callback(TimerHandle_t tmr);
 static bcmp_request_element *_message_list_find_message(uint16_t seq_num);
 static void _message_list_timer_expiry_cb(void *arg);
@@ -159,12 +159,15 @@ int32_t bcmp_process_packet(struct pbuf *pbuf, ip_addr_t *src, ip_addr_t *dst) {
       break;
     }
 
+    bcmp_reply_message_cb cb = NULL;
+
     // Check if this message is a reply to a message we sent
     if (_message_is_sequenced_reply(header->type) && !_message_is_sequenced_request(header->type)) {
       bcmp_request_element *sent_message = _message_list_find_message(header->seq_num);
       if (sent_message) {
         printf("BCMP - Received reply to our request message with seq_num %d\n", header->seq_num);
         if (xSemaphoreTake(_ctx.messages_list_mutex, pdMS_TO_TICKS(DEFAULT_MESSAGE_TIMEOUT_MS)) == pdPASS) {
+          cb = sent_message->callback;
           _message_list_remove_message(sent_message);
           xSemaphoreGive(_ctx.messages_list_mutex);
         }
@@ -228,11 +231,15 @@ int32_t bcmp_process_packet(struct pbuf *pbuf, ip_addr_t *src, ip_addr_t *dst) {
       case BCMP_CONFIG_STATUS_RESPONSE:
       case BCMP_CONFIG_DELETE_REQUEST:
       case BCMP_CONFIG_DELETE_RESPONSE: {
-        bool should_forward = bcmp_process_config_message(
-            static_cast<bcmp_message_type_t>(header->type), header->payload, header->seq_num);
-        if (should_forward) {
-          // Forward the message to all ports other than the ingress port.
-          bcmp_ll_forward(pbuf, ingress_port);
+        if (cb) {
+          cb(header->payload);
+        } else {
+          bool should_forward = bcmp_process_config_message(
+              static_cast<bcmp_message_type_t>(header->type), header->payload, header->seq_num);
+          if (should_forward) {
+            // Forward the message to all ports other than the ingress port.
+            bcmp_ll_forward(pbuf, ingress_port);
+          }
         }
         break;
       }
@@ -405,7 +412,7 @@ static void bcmp_thread(void *parameters) {
   \param len message length
   \return ERR_OK on success, something else otherwise
 */
-err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num) {
+err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num, bcmp_reply_message_cb reply_cb) {
   err_t rval;
 
   do {
@@ -430,7 +437,7 @@ err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uin
       // If we are sending a new request, use our own sequence number
       header->seq_num = _ctx.message_count;
       _ctx.message_count++;
-      bcmp_request_element *sent_message = _message_list_create_element(header->seq_num, header->type, DEFAULT_MESSAGE_TIMEOUT_MS);
+      bcmp_request_element *sent_message = _message_list_create_element(header->seq_num, header->type, DEFAULT_MESSAGE_TIMEOUT_MS, reply_cb);
       _message_list_add_message(sent_message);
       printf("BCMP - Sending message with seq_num %d\n", header->seq_num);
     } else {
@@ -594,13 +601,14 @@ static bool _message_list_remove_message(bcmp_request_element *message) {
   return rval;
 }
 
-static bcmp_request_element *_message_list_create_element(uint16_t seq_num, uint16_t type, uint32_t timeout_ms) {
+static bcmp_request_element *_message_list_create_element(uint16_t seq_num, uint16_t type, uint32_t timeout_ms, bcmp_reply_message_cb callback) {
   bcmp_request_element *element = static_cast<bcmp_request_element *>(pvPortMalloc(sizeof(bcmp_request_element)));
   configASSERT(element);
   element->seq_num = seq_num;
   element->type = type;
   element->send_timestamp_ms = pdTICKS_TO_MS(xTaskGetTickCount());
   element->timeout_ms = timeout_ms;
+  element->callback = callback;
   element->next = NULL;
   return element;
 }

--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -35,6 +35,6 @@ using namespace cfg;
 typedef bool (*bcmp_reply_message_cb)(uint8_t *payload);
 
 void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration* user_cfg, Configuration* sys_cfg);
-err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num=0);
+err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num=0, bcmp_reply_message_cb reply_cb=NULL);
 err_t bcmp_ll_forward(struct pbuf *pbuf, uint8_t ingress_port);
 void bcmp_link_change(uint8_t port, bool state);

--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -20,6 +20,20 @@ using namespace cfg;
 #define IP_PROTO_BCMP (0xBC)
 #define BCMP_MAX_PAYLOAD_SIZE_BYTES (1500) // FIXME: Remove when we can split payloads.
 
+/**
+ * @brief A function pointer type for handling reply messages in the BCMP protocol.
+ *
+ * This typedef defines a type for function pointers that can be used as callbacks
+ * to handle sequenced reply messages in the BCMP protocol. These functions should
+ * take a pointer to a payload of type uint8_t as a parameter and return a boolean
+ * value.
+ *
+ * The return value should be:
+ * - true if the reply message was handled successfully,
+ * - false if there was an error handling the reply message.
+ */
+typedef bool (*bcmp_reply_message_cb)(uint8_t *payload);
+
 void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration* user_cfg, Configuration* sys_cfg);
 err_t bcmp_tx(const ip_addr_t *dst, bcmp_message_type_t type, uint8_t *buff, uint16_t len, uint16_t seq_num=0);
 err_t bcmp_ll_forward(struct pbuf *pbuf, uint8_t ingress_port);

--- a/src/lib/bcmp/bcmp_config.h
+++ b/src/lib/bcmp/bcmp_config.h
@@ -9,12 +9,12 @@
 using namespace cfg;
 
 void bcmp_config_init(Configuration* user_cfg, Configuration* sys_cfg);
-bool bcmp_config_get(uint64_t target_node_id, bm_common_config_partition_e partition, size_t key_len, const char* key, err_t &err);
+bool bcmp_config_get(uint64_t target_node_id, bm_common_config_partition_e partition, size_t key_len, const char* key, err_t &err, bcmp_reply_message_cb reply_cb = NULL);
 bool bcmp_config_set(uint64_t target_node_id, bm_common_config_partition_e partition,
-    size_t key_len, const char* key, size_t value_size, void * val, err_t &err);
+    size_t key_len, const char* key, size_t value_size, void * val, err_t &err, bcmp_reply_message_cb reply_cb = NULL);
 bool bcmp_config_commit(uint64_t target_node_id, bm_common_config_partition_e partition, err_t &err);
-bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partition_e partition, err_t &err);
+bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partition_e partition, err_t &err, bcmp_reply_message_cb reply_cb = NULL);
 bool bcmp_config_status_response(uint64_t target_node_id,bm_common_config_partition_e partition, bool commited, err_t &err);
-bool bcmp_config_del_key(uint64_t target_node_id,bm_common_config_partition_e partition, size_t key_len, const char * key);
+bool bcmp_config_del_key(uint64_t target_node_id,bm_common_config_partition_e partition, size_t key_len, const char * key, bcmp_reply_message_cb reply_cb = NULL);
 
 bool bcmp_process_config_message(bcmp_message_type_t bcmp_msg_type, uint8_t *payload, uint16_t seq_num);


### PR DESCRIPTION
add the ability to call: `bcmp_config_get`, `bcmp_config_set`, `bcmp_config_status_request`, `bcmp_config_del_key` and provide a callback to be used when processing the reply, otherwise use the default behavior (print it out).

Example where I added a callback to the `bm status` command (I will remove this before merging since it should just use the default behavior).
```
bm cfg status 4d58ce2f22dfb374 s
BCMP - Sending message with seq_num 0
Successful status request send
BCMP message with seq_num 0 found
BCMP - Received reply to our request message with seq_num 0
Status callback <------------------------------------------------------------------- :)
Response msg -- Node Id:4d58ce2f22dfb374,Partition:1, Commit Status:0
Num Keys: 10
bridgePowerControllerEnabled
samplesPerReport
transmitAggregations
sampleIntervalMs
sampleDurationMs
subsampleIntervalMs
subsampleEnabled
currentReadingPeriodMs
alignmentInterval5Min
subsampleDurationMs
```

Example of the default behavior still happening when no callback is present:
```
bm cfg get 4d58ce2f22dfb374 s subsampleDurationMs
BCMP - Sending message with seq_num 1
Succesfully sent config get msg
BCMP message with seq_num 1 found
BCMP - Received reply to our request message with seq_num 1
Node Id: 4d58ce2f22dfb374 Value:5000
```