### PR TITLE
support logging of network configs

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -120,6 +120,7 @@ set(LIB_FILES
     ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
     ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
     ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
+    ${SRC_DIR}/third_party/tinycbor/src/cborpretty.c
     )
 
 set(LIB_INCLUDES

--- a/src/apps/bridge/app_pub_sub.h
+++ b/src/apps/bridge/app_pub_sub.h
@@ -1,52 +1,55 @@
 #pragma once
 
-#include <stdint.h>
 #include "bm_common_pub_sub.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define APP_PUB_SUB_UTC_TOPIC           "spotter/utc-time"
-#define APP_PUB_SUB_UTC_TYPE            1
-#define APP_PUB_SUB_UTC_VERSION         1
+#define APP_PUB_SUB_UTC_TOPIC "spotter/utc-time"
+#define APP_PUB_SUB_UTC_TYPE 1
+#define APP_PUB_SUB_UTC_VERSION 1
 
+#define APP_PUB_SUB_LAST_NET_CFG_TOPIC "spotter/request-last-network-config"
+#define APP_PUB_SUB_LAST_NET_CFG_TYPE 1
+#define APP_PUB_SUB_LAST_NET_CFG_VERSION 1
 
-#define APP_PUB_SUB_LAST_NET_CFG_TOPIC          "spotter/request-last-network-config"
-#define APP_PUB_SUB_LAST_NET_CFG_TYPE            1
-#define APP_PUB_SUB_LAST_NET_CFG_VERSION         1
+#define APP_PUB_SUB_PRINTF_TOPIC "printf"
+#define APP_PUB_SUB_PRINTF_TYPE 1
+#define APP_PUB_SUB_PRINTF_VERSION 1
 
-#define APP_PUB_SUB_PRINTF_TOPIC        "printf"
-#define APP_PUB_SUB_PRINTF_TYPE         1
-#define APP_PUB_SUB_PRINTF_VERSION      1
+#define APP_PUB_SUB_BUTTON_TOPIC "button"
+#define APP_PUB_SUB_BUTTON_TYPE 1
+#define APP_PUB_SUB_BUTTON_VERSION 1
+#define APP_PUB_SUB_BUTTON_CMD_ON "on"
+#define APP_PUB_SUB_BUTTON_CMD_OFF "off"
 
-#define APP_PUB_SUB_BUTTON_TOPIC        "button"
-#define APP_PUB_SUB_BUTTON_TYPE         1
-#define APP_PUB_SUB_BUTTON_VERSION      1
-#define APP_PUB_SUB_BUTTON_CMD_ON       "on"
-#define APP_PUB_SUB_BUTTON_CMD_OFF      "off"
+#define APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC "bridge/printf"
+#define APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE 1
+#define APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION 1
 
-#define APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC       "bridge/printf"
-#define APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC "bridge/cfg_printf"
+#define APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TYPE 1
+#define APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_VERSION 1
 
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC       "bridge/sensor_ind_log"
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC "bridge/sensor_ind_log"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE 1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION 1
 
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC       "bridge/sensor_agg_log"
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC "bridge/sensor_agg_log"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE 1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION 1
 
 typedef struct app_pub_sub_bm_bridge_sensor_report_data {
-    uint32_t bm_config_crc32;
-    size_t cbor_buffer_len;
-    uint8_t cbor_buffer[0];
+  uint32_t bm_config_crc32;
+  size_t cbor_buffer_len;
+  uint8_t cbor_buffer[0];
 } __attribute__((packed)) app_pub_sub_bm_bridge_sensor_report_data_t;
 
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC       "bridge/sensor_report"
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE        1
-#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION     1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TOPIC "bridge/sensor_report"
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_TYPE 1
+#define APP_PUB_SUB_BM_BRIDGE_SENSOR_REPORT_VERSION 1
 
 #ifdef __cplusplus
 }

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -1,29 +1,54 @@
 #include "bridgeLog.h"
+#include "app_pub_sub.h"
+#include "bm_serial.h"
+#include "device_info.h"
 #include <stdio.h>
 #include <string.h>
-#include "app_pub_sub.h"
-#include "device_info.h"
-#include "bm_serial.h"
 
-void bridgeLogPrintf(const char *str, size_t len) {
-    printf("%.*s", len, str);
-    bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE, APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION);
+void bridgeLogPrintf(const char *str, size_t len, bridgeLogType_e type) {
+  printf("%.*s", len, str);
+  switch (type) {
+  case BRIDGE_SYS:
+    bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC,
+                  sizeof(APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC) - 1,
+                  reinterpret_cast<const uint8_t *>(str), len,
+                  APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE, APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION);
+    break;
+  case BRIDGE_CFG:
+    bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC,
+                  sizeof(APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC) - 1,
+                  reinterpret_cast<const uint8_t *>(str), len,
+                  APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TYPE,
+                  APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_VERSION);
+    break;
+  default:
+    printf("ERROR: Unknown log type in bridgeLogPrintf\n");
+    break;
+  }
 }
 
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len) {
-    if(len > 0){
-        switch(type) {
-            case BM_COMMON_IND:
-                printf("[%s] %.*s", "BM_COMMON_IND", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE, APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);
-                break;
-            case BM_COMMON_AGG:
-                printf("[%s] %.*s", "BM_COMMON_AGG", len, str);
-                bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC, sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC)-1, reinterpret_cast<const uint8_t*>(str),len, APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE, APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION);
-                break;
-            default:
-                printf("ERROR: Unknown log type in bridgerSensorLogPrintf\n");
-                break;
-        }
+  if (len > 0) {
+    switch (type) {
+    case BM_COMMON_IND:
+      printf("[%s] %.*s", "BM_COMMON_IND", len, str);
+      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC,
+                    sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC) - 1,
+                    reinterpret_cast<const uint8_t *>(str), len,
+                    APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE,
+                    APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);
+      break;
+    case BM_COMMON_AGG:
+      printf("[%s] %.*s", "BM_COMMON_AGG", len, str);
+      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC,
+                    sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC) - 1,
+                    reinterpret_cast<const uint8_t *>(str), len,
+                    APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE,
+                    APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION);
+      break;
+    default:
+      printf("ERROR: Unknown log type in bridgerSensorLogPrintf\n");
+      break;
     }
+  }
 }

--- a/src/apps/bridge/bridgeLog.h
+++ b/src/apps/bridge/bridgeLog.h
@@ -4,14 +4,21 @@
 constexpr size_t SENSOR_LOG_BUF_SIZE = 512;
 
 typedef enum {
-    BM_COMMON_IND,
-    BM_COMMON_AGG,
+  BM_COMMON_IND,
+  BM_COMMON_AGG,
 } bridgeSensorLogType_e;
 
-void bridgeLogPrintf(const char *str, size_t len);
+typedef enum {
+  BRIDGE_SYS,
+  BRIDGE_CFG,
+} bridgeLogType_e;
+
+void bridgeLogPrintf(const char *str, size_t len, bridgeLogType_e type);
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len);
 
-#define BRIDGE_LOG_PRINT(x)  bridgeLogPrintf(x, sizeof(x))
-#define BRIDGE_LOG_PRINTN(x,n)  bridgeLogPrintf(x, n)
-#define BRIDGE_SENSOR_LOG_PRINT(type, x)  bridgeSensorLogPrintf(type, x, sizeof(x))
-#define BRIDGE_SENSOR_LOG_PRINTN(type, x,n)  bridgeSensorLogPrintf(type, x, n)
+#define BRIDGE_LOG_PRINT(x) bridgeLogPrintf(x, sizeof(x), BRIDGE_SYS)
+#define BRIDGE_LOG_PRINTN(x, n) bridgeLogPrintf(x, n, BRIDGE_SYS)
+#define BRIDGE_CFG_LOG_PRINT(x) bridgeLogPrintf(x, sizeof(x), BRIDGE_CFG)
+#define BRIDGE_CFG_LOG_PRINTN(x, n) bridgeLogPrintf(x, n, BRIDGE_CFG)
+#define BRIDGE_SENSOR_LOG_PRINT(type, x) bridgeSensorLogPrintf(type, x, sizeof(x))
+#define BRIDGE_SENSOR_LOG_PRINTN(type, x, n) bridgeSensorLogPrintf(type, x, n)

--- a/src/apps/bridge/sm_config_crc_list.cpp
+++ b/src/apps/bridge/sm_config_crc_list.cpp
@@ -69,6 +69,20 @@ void SMConfigCRCList::clear() {
   encode();
 }
 
+/*!
+  \brief Get the list of CRCs.
+
+  This function reads the list from the configuration.
+
+  \param[out] num_crcs[out] The number of CRCs in the list.
+  \return A pointer to the list of CRCs.
+*/
+uint32_t *SMConfigCRCList::get(uint32_t &num_crcs) {
+  decode();
+  num_crcs = _num_crcs;
+  return _crc_list;
+}
+
 // ---------------------------- PRIVATE ----------------------------
 
 /*!
@@ -175,18 +189,4 @@ void SMConfigCRCList::encode() {
     size_t buffer_size = cbor_encoder_get_buffer_size(&encoder, buffer);
     _cfg->setConfigCbor(KEY, KEY_LEN, buffer, buffer_size);
   } while (0);
-}
-
-/*!
-  \brief Get the list of CRCs.
-
-  This function reads the list from the configuration.
-
-  \param[out] num_crcs[out] The number of CRCs in the list.
-  \return A pointer to the list of CRCs.
-*/
-uint32_t *SMConfigCRCList::get(uint32_t &num_crcs) {
-  decode();
-  num_crcs = _num_crcs;
-  return _crc_list;
 }

--- a/src/apps/bridge/sm_config_crc_list.cpp
+++ b/src/apps/bridge/sm_config_crc_list.cpp
@@ -176,3 +176,17 @@ void SMConfigCRCList::encode() {
     _cfg->setConfigCbor(KEY, KEY_LEN, buffer, buffer_size);
   } while (0);
 }
+
+/*!
+  \brief Get the list of CRCs.
+
+  This function reads the list from the configuration.
+
+  \param[out] num_crcs[out] The number of CRCs in the list.
+  \return A pointer to the list of CRCs.
+*/
+uint32_t *SMConfigCRCList::get(uint32_t &num_crcs) {
+  decode();
+  num_crcs = _num_crcs;
+  return _crc_list;
+}

--- a/src/apps/bridge/sm_config_crc_list.cpp
+++ b/src/apps/bridge/sm_config_crc_list.cpp
@@ -70,17 +70,21 @@ void SMConfigCRCList::clear() {
 }
 
 /*!
-  \brief Get the list of CRCs.
+  \brief Alloc the list of CRCs.
 
   This function reads the list from the configuration.
+  User needs to free the returned list.
 
   \param[out] num_crcs[out] The number of CRCs in the list.
   \return A pointer to the list of CRCs.
 */
-uint32_t *SMConfigCRCList::get(uint32_t &num_crcs) {
+uint32_t *SMConfigCRCList::alloc_list(uint32_t &num_crcs) {
   decode();
   num_crcs = _num_crcs;
-  return _crc_list;
+  uint32_t *crc_list = static_cast<uint32_t *>(pvPortMalloc(_num_crcs * sizeof(uint32_t)));
+  configASSERT(crc_list);
+  memcpy(crc_list, _crc_list, _num_crcs * sizeof(uint32_t));
+  return crc_list;
 }
 
 // ---------------------------- PRIVATE ----------------------------

--- a/src/apps/bridge/sm_config_crc_list.h
+++ b/src/apps/bridge/sm_config_crc_list.h
@@ -16,7 +16,7 @@ public:
   bool contains(uint32_t crc);
   void add(uint32_t crc);
   void clear();
-  uint32_t *get(uint32_t &num_crcs);
+  uint32_t *alloc_list(uint32_t &num_crcs);
 
 private:
   cfg::AbstractConfiguration *_cfg;

--- a/src/apps/bridge/sm_config_crc_list.h
+++ b/src/apps/bridge/sm_config_crc_list.h
@@ -16,6 +16,7 @@ public:
   bool contains(uint32_t crc);
   void add(uint32_t crc);
   void clear();
+  uint32_t *get(uint32_t &num_crcs);
 
 private:
   cfg::AbstractConfiguration *_cfg;

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -25,6 +25,7 @@
 #include "crc.h"
 #include "device_info.h"
 #include "sm_config_crc_list.h"
+#include "stm32_rtc.h"
 #include "sys_info_service.h"
 #include "sys_info_svc_reply_msg.h"
 #include "topology_sampler.h"
@@ -172,9 +173,14 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
         static constexpr uint8_t CRC_MSG_SIZE = 128;
         char *crc_msg = static_cast<char *>(pvPortMalloc(CRC_MSG_SIZE));
         configASSERT(crc_msg);
+        uint32_t epoch = 0;
+        RTCTimeAndDate_t rtc;
+        rtcGet(&rtc);
+        epoch = rtcGetMicroSeconds(&rtc) / 1000000;
         int msglen = snprintf(crc_msg, CRC_MSG_SIZE,
-                              "Network configuration change detected! crc: 0x%" PRIx32 "\n",
-                              network_crc32_calc);
+                              "Network configuration change detected! crc: 0x%" PRIx32
+                              " at UTC:%" PRIu32 "\n",
+                              network_crc32_calc, epoch);
         if (msglen) {
           BRIDGE_CFG_LOG_PRINTN(crc_msg, msglen);
         }

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -175,7 +175,9 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
         int msglen = snprintf(crc_msg, CRC_MSG_SIZE,
                               "Network configuration change detected! crc: 0x%" PRIx32 "\n",
                               network_crc32_calc);
-        BRIDGE_CFG_LOG_PRINTN(crc_msg, msglen);
+        if (msglen) {
+          BRIDGE_CFG_LOG_PRINTN(crc_msg, msglen);
+        }
         vPortFree(crc_msg);
         log_cbor_network_configurations(cbor_buffer, cbor_bufsize);
       }

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -169,6 +169,14 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
         configASSERT(_node_list.last_network_configuration_info.cbor_config_map);
         memcpy(_node_list.last_network_configuration_info.cbor_config_map, cbor_buffer,
                cbor_bufsize);
+        static constexpr uint8_t CRC_MSG_SIZE = 128;
+        char *crc_msg = static_cast<char *>(pvPortMalloc(CRC_MSG_SIZE));
+        configASSERT(crc_msg);
+        int msglen = snprintf(crc_msg, CRC_MSG_SIZE,
+                              "Network configuration change detected! crc: 0x%" PRIx32 "\n",
+                              network_crc32_calc);
+        BRIDGE_CFG_LOG_PRINTN(crc_msg, msglen);
+        vPortFree(crc_msg);
         log_cbor_network_configurations(cbor_buffer, cbor_bufsize);
       }
       printf("\n");

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -891,7 +891,7 @@ static void log_network_crc_info(uint32_t network_crc32, SMConfigCRCList &sm_con
   }
   memset(crc_msg, 0, CRC_MSG_SIZE);
   uint32_t num_stored_crcs = 0;
-  uint32_t *stored_crcs = sm_config_crc_list.get(num_stored_crcs);
+  uint32_t *stored_crcs = sm_config_crc_list.alloc_list(num_stored_crcs);
   BRIDGE_CFG_LOG_PRINT("Stored CRCs: \n");
   for (uint32_t i = 0; i < num_stored_crcs; i++) {
     msglen = snprintf(crc_msg, CRC_MSG_SIZE, "0x%" PRIx32 "\n", stored_crcs[i]);
@@ -899,5 +899,6 @@ static void log_network_crc_info(uint32_t network_crc32, SMConfigCRCList &sm_con
       BRIDGE_CFG_LOG_PRINTN(crc_msg, msglen);
     }
   }
+  vPortFree(stored_crcs);
   vPortFree(crc_msg);
 }

--- a/test/mocks/mock_bridgeLog.h
+++ b/test/mocks/mock_bridgeLog.h
@@ -2,4 +2,4 @@
 #include "bridgeLog.h"
 #include "fff.h"
 
-DECLARE_FAKE_VOID_FUNC(bridgeLogPrintf,char const*, unsigned long);
+DECLARE_FAKE_VOID_FUNC(bridgeLogPrintf,char const*, unsigned long,  bridgeLogType_e);

--- a/test/stubs/mock_bridgeLog.cpp
+++ b/test/stubs/mock_bridgeLog.cpp
@@ -1,3 +1,3 @@
 #include "mock_bridgeLog.h"
 
-DEFINE_FAKE_VOID_FUNC(bridgeLogPrintf,char const*, unsigned long);
+DEFINE_FAKE_VOID_FUNC(bridgeLogPrintf,char const*, unsigned long, bridgeLogType_e);


### PR DESCRIPTION
```
2024-02-27T01:44:03.929Z [BRIDGE_CFG] [INFO] Node ID: 0 Partition: system Value: 60000
2024-02-27T01:44:03.933Z [BRIDGE_CFG] [INFO] Node ID: 0 Partition: system Value: 1
2024-02-27T01:44:03.941Z [BRIDGE_CFG] [INFO] Node ID: 0 Partition: system Value: 0
2024-02-27T01:44:03.949Z [BRIDGE_CFG] [INFO] Node ID: 0 Partition: hardware - Failed to decode value
Network configuration change detected! crc: 0xfd360c31 at UTC:1708998246
Bridge network config: 
[[8046209027809048845, "bridge-dbg", 3471088096, 2703802277, {"bridgePowerControllerEnabled": 1, "sampleIntervalMs": 300000, "sampleDurationMs": 180000, "subsampleEnabled": 0, "samplesPerReport": 1, "currentReadingPeriodMs": 60000, "alignmentInterval5Min": 1, "foo": 0}], [14453092352742153229, "bm_rbr-dbg", 4106273564, 81022053, {}]]

```
[0012_BRIDGE_CFG.log](https://github.com/bristlemouth/bm_protocol/files/14427010/0012_BRIDGE_CFG.log)

Linked to https://github.com/wavespotter/fleet-spotter-fw/pull/844
