### PR TITLE
Fix/toplogy node position log

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -63,7 +63,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
         if ((current_timestamp - last_timestamp > aanderaa->current_agg_period_ms + 30000u) ||
             aanderaa->reading_count == 1U) {
-          printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
+          printf("Updating aanderaa %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
                  node_id, current_timestamp, last_timestamp, aanderaa->reading_count);
           node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -53,7 +53,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
         uint64_t sensor_reading_time_sec = d.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = d.header.sensor_reading_time_ms % 1000U;
 
-        int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+        int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
 
         size_t log_buflen = snprintf(
             log_buf, SENSOR_LOG_BUF_SIZE,
@@ -159,7 +159,7 @@ void AanderaaSensor::aggregate(void) {
       snprintf(timeStrbuf, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
 
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                           "%" PRIx64 "," // Node Id

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -58,9 +58,9 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         static uint32_t current_timestamp = 0;
 
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - last_timestamp > soft->current_agg_period_ms + 1000u) || soft->reading_count == 1U) {
+        if ((current_timestamp - last_timestamp > rbr_coda->current_agg_period_ms + 1000u) || soft->reading_count == 1U) {
           // TODO - remove this debug print before merging
-          printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n", node_id, current_timestamp, last_timestamp, soft->reading_count);
+          printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n", node_id, current_timestamp, last_timestamp, soft->reading_count);
           node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
         }
         last_timestamp = current_timestamp;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -63,7 +63,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
           printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
                  node_id, current_timestamp, last_timestamp, rbr_coda->reading_count);
-          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
+          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
         }
         last_timestamp = current_timestamp;
 
@@ -145,7 +145,7 @@ void RbrCodaSensor::aggregate(void) {
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
 
     // Use the latest sensor type to determine the sensor type string
     const char *sensor_type_str;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -58,7 +58,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         static uint32_t current_timestamp = 0;
 
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - last_timestamp > rbr_coda->current_agg_period_ms + 1000u) ||
+        if ((current_timestamp - last_timestamp > rbr_coda->rbr_coda_agg_period_ms + 1000u) ||
             soft->reading_count == 1U) {
           printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -59,10 +59,10 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
 
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
         if ((current_timestamp - last_timestamp > rbr_coda->rbr_coda_agg_period_ms + 1000u) ||
-            soft->reading_count == 1U) {
+            rbr_coda->reading_count == 1U) {
           printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
-                 node_id, current_timestamp, last_timestamp, soft->reading_count);
+                 node_id, current_timestamp, last_timestamp, rbr_coda->reading_count);
           node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
         }
         last_timestamp = current_timestamp;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -51,7 +51,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         uint32_t sensor_reading_time_millis = rbr_data.header.sensor_reading_time_ms % 1000U;
 
         // Keep track of when we last got a reading from this node
-        // If it is the first reading, or if it has been more than the current aggregation period + 1 second
+        // If it is the first reading, or if it has been more than the rbr aggregation period + 1 second
         // then we will update the node position.
         static int8_t node_position = 0;
         static uint32_t last_timestamp = 0;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -58,9 +58,11 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         static uint32_t current_timestamp = 0;
 
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - last_timestamp > rbr_coda->current_agg_period_ms + 1000u) || soft->reading_count == 1U) {
-          // TODO - remove this debug print before merging
-          printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n", node_id, current_timestamp, last_timestamp, soft->reading_count);
+        if ((current_timestamp - last_timestamp > rbr_coda->current_agg_period_ms + 1000u) ||
+            soft->reading_count == 1U) {
+          printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
+                 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
+                 node_id, current_timestamp, last_timestamp, soft->reading_count);
           node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
         }
         last_timestamp = current_timestamp;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -50,7 +50,20 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         uint64_t sensor_reading_time_sec = rbr_data.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = rbr_data.header.sensor_reading_time_ms % 1000U;
 
-        int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+        // Keep track of when we last got a reading from this node
+        // If it is the first reading, or if it has been more than the current aggregation period + 1 second
+        // then we will update the node position.
+        static int8_t node_position = 0;
+        static uint32_t last_timestamp = 0;
+        static uint32_t current_timestamp = 0;
+
+        current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
+        if ((current_timestamp - last_timestamp > soft->current_agg_period_ms + 1000u) || soft->reading_count == 1U) {
+          // TODO - remove this debug print before merging
+          printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n", node_id, current_timestamp, last_timestamp, soft->reading_count);
+          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
+        }
+        last_timestamp = current_timestamp;
 
         // Use the latest sensor type to determine the sensor type string
         const char *sensor_type_str;

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -49,7 +49,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         uint64_t sensor_reading_time_sec = soft_data.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = soft_data.header.sensor_reading_time_ms % 1000U;
 
-        int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+        int8_t node_position = topology_sampler_get_node_position(node_id, portMAX_DELAY);
 
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
@@ -102,7 +102,7 @@ void SoftSensor::aggregate(void) {
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, 1000);
+    int8_t node_position = topology_sampler_get_node_position(node_id, portMAX_DELAY);
 
     log_buflen =
         snprintf(log_buf, SENSOR_LOG_BUF_SIZE,

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -49,7 +49,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         uint64_t sensor_reading_time_sec = soft_data.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = soft_data.header.sensor_reading_time_ms % 1000U;
 
-        int8_t node_position = topology_sampler_get_node_position(node_id, portMAX_DELAY);
+        int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(10000));
 
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
@@ -102,7 +102,7 @@ void SoftSensor::aggregate(void) {
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, portMAX_DELAY);
+    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(10000));
 
     log_buflen =
         snprintf(log_buf, SENSOR_LOG_BUF_SIZE,

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -49,7 +49,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         uint64_t sensor_reading_time_sec = soft_data.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = soft_data.header.sensor_reading_time_ms % 1000U;
 
-        int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(10000));
+        int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
 
         size_t log_buflen =
             snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
@@ -102,7 +102,7 @@ void SoftSensor::aggregate(void) {
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(10000));
+    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
 
     log_buflen =
         snprintf(log_buf, SENSOR_LOG_BUF_SIZE,

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -57,9 +57,11 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         static uint32_t current_timestamp = 0;
 
         current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - last_timestamp > soft->current_agg_period_ms + 1000u) || soft->reading_count == 1U) {
-          // TODO - remove this debug print before merging
-          printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n", node_id, current_timestamp, last_timestamp, soft->reading_count);
+        if ((current_timestamp - last_timestamp > soft->current_agg_period_ms + 1000u) ||
+            soft->reading_count == 1U) {
+          printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32
+                 ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
+                 node_id, current_timestamp, last_timestamp, soft->reading_count);
           node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
         }
         last_timestamp = current_timestamp;
@@ -75,9 +77,9 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
                      "%" PRIu64 "."   // sensor_reading_time_ms seconds part
                      "%03" PRIu32 "," // sensor_reading_time_ms millis part
                      "%.3f\n",        // temp_deg_c
-                     node_id, node_position, soft_data.header.reading_uptime_millis, reading_time_sec,
-                     reading_time_millis, sensor_reading_time_sec, sensor_reading_time_millis,
-                     soft_data.temperature_deg_c);
+                     node_id, node_position, soft_data.header.reading_uptime_millis,
+                     reading_time_sec, reading_time_millis, sensor_reading_time_sec,
+                     sensor_reading_time_millis, soft_data.temperature_deg_c);
         if (log_buflen > 0) {
           BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_IND, log_buf, log_buflen);
         } else {
@@ -117,15 +119,15 @@ void SoftSensor::aggregate(void) {
 
     int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
 
-    log_buflen =
-        snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
-                 "%" PRIx64 "," // Node Id
-                 "%" PRIi8 ","  // node_position
-                 "soft,"        // node_app_name
-                 "%s,"          // timestamp(ticks/UTC)
-                 "%" PRIu32 "," // reading_count
-                 "%.3f\n",      // temp_mean_deg_c
-                 node_id, node_position, time_str, soft_aggs.reading_count, soft_aggs.temp_mean_deg_c);
+    log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
+                          "%" PRIx64 "," // Node Id
+                          "%" PRIi8 ","  // node_position
+                          "soft,"        // node_app_name
+                          "%s,"          // timestamp(ticks/UTC)
+                          "%" PRIu32 "," // reading_count
+                          "%.3f\n",      // temp_mean_deg_c
+                          node_id, node_position, time_str, soft_aggs.reading_count,
+                          soft_aggs.temp_mean_deg_c);
     if (log_buflen > 0) {
       BRIDGE_SENSOR_LOG_PRINTN(BM_COMMON_AGG, log_buf, log_buflen);
     } else {

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -62,7 +62,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
           printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
                  node_id, current_timestamp, last_timestamp, soft->reading_count);
-          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
+          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
         }
         last_timestamp = current_timestamp;
 
@@ -117,7 +117,7 @@ void SoftSensor::aggregate(void) {
       snprintf(time_str, TIME_STR_BUFSIZE, "0");
     }
 
-    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(2000));
+    int8_t node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
 
     log_buflen = snprintf(log_buf, SENSOR_LOG_BUF_SIZE,
                           "%" PRIx64 "," // Node Id

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -732,6 +732,8 @@ int8_t topology_sampler_get_node_position(uint64_t node_id, uint32_t timeout_ms)
       }
     } while (0);
     xSemaphoreGive(_node_list.node_list_mutex);
+  } else {
+    printf("Failed to take node list mutex\n");
   }
   return requested_nodes_position;
 }


### PR DESCRIPTION
This will only update the node-position in IND logs when we have a large gap between individual readings (indicating a potential unplugging event and replugging in a different order) or when we have the first reading. This change is to reduce the amount we have to take the node_list mutex and potentially wait for it, while maintaining a consistent node_position in the IND logs.