### PR TITLE
Feature/dfu confirm workaround

### DIFF
--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -544,7 +544,7 @@ void bcmp_init(struct netif* netif, NvmPartition * dfu_partition, Configuration*
                                  pdTRUE, NULL, _message_list_timer_callback);
   configASSERT(xTimerStart(_ctx.messages_expiration_timer, 10) == pdPASS);
 
-  bm_dfu_init(bcmp_dfu_tx, dfu_partition);
+  bm_dfu_init(bcmp_dfu_tx, dfu_partition, sys_cfg);
   bcmp_config_init(user_cfg, sys_cfg);
   bcmp_resource_discovery::bcmp_resource_discovery_init();
 

--- a/src/lib/bcmp/dfu/bm_dfu.h
+++ b/src/lib/bcmp/dfu/bm_dfu.h
@@ -11,6 +11,7 @@
 #include "bcmp_messages.h"
 #include "nvmPartition.h"
 #include "lib_state_machine.h"
+#include "configuration.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -113,9 +114,12 @@ void bm_dfu_req_next_chunk(uint64_t dst_node_id, uint16_t chunk_num);
 void bm_dfu_update_end(uint64_t dst_node_id, uint8_t success, bm_dfu_err_t err_code);
 void bm_dfu_send_heartbeat(uint64_t dst_node_id);
 
-void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition);
+void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition, cfg::Configuration* sys_cfg);
 void bm_dfu_process_message(uint8_t * buf, size_t len);
 bool bm_dfu_initiate_update(bm_dfu_img_info_t info, uint64_t dest_node_id, update_finish_cb_t update_finish_callback, uint32_t timeoutMs );
+
+bool bm_dfu_confirm_is_enabled(void);
+void bm_dfu_confirm_enable(bool en);
 
 /*!
  * UNIT TEST FUNCTIONS BELOW HERE

--- a/src/lib/bcmp/dfu/bm_dfu_client.cpp
+++ b/src/lib/bcmp/dfu/bm_dfu_client.cpp
@@ -482,9 +482,16 @@ void s_client_update_done_entry(void) {
     client_ctx.host_node_id = client_update_reboot_info.host_node_id;
     client_ctx.chunk_retry_num = 0;
     if(getGitSHA() == client_update_reboot_info.gitSHA) {
-        bm_dfu_client_send_boot_complete(client_update_reboot_info.host_node_id);
-        /* Kickoff Chunk timeout */
-        configASSERT(xTimerStart(client_ctx.chunk_timer, 10));
+        // We usually want to confirm the update, but if we want to force-confirm, we read a flag in the configuration, 
+        // confirm, reset the config flag, and then reboot.
+        if(!bm_dfu_confirm_is_enabled()){
+            boot_set_confirmed();
+            bm_dfu_confirm_enable(true); // Reboot!
+        } else {
+            bm_dfu_client_send_boot_complete(client_update_reboot_info.host_node_id);
+            /* Kickoff Chunk timeout */
+            configASSERT(xTimerStart(client_ctx.chunk_timer, 10));
+        }
     } else {
         bm_dfu_update_end(client_update_reboot_info.host_node_id, false, BM_DFU_ERR_WRONG_VER);
         bm_dfu_client_fail_update_and_reboot();

--- a/src/lib/bcmp/dfu/bm_dfu_client.cpp
+++ b/src/lib/bcmp/dfu/bm_dfu_client.cpp
@@ -485,6 +485,7 @@ void s_client_update_done_entry(void) {
         // We usually want to confirm the update, but if we want to force-confirm, we read a flag in the configuration, 
         // confirm, reset the config flag, and then reboot.
         if(!bm_dfu_confirm_is_enabled()){
+            memset(&client_update_reboot_info, 0, sizeof(client_update_reboot_info));
             boot_set_confirmed();
             bm_dfu_confirm_enable(true); // Reboot!
         } else {

--- a/src/lib/bcmp/dfu/bm_dfu_core.cpp
+++ b/src/lib/bcmp/dfu/bm_dfu_core.cpp
@@ -609,7 +609,7 @@ bm_dfu_err_t bm_dfu_get_error(void) {
 }
 
 bool bm_dfu_confirm_is_enabled(void) {
-    uint32_t val = 0;
+    uint32_t val = 1;
     dfu_ctx.sys_cfg->getConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key), val);
     return val;
 }

--- a/src/lib/bcmp/dfu/bm_dfu_core.cpp
+++ b/src/lib/bcmp/dfu/bm_dfu_core.cpp
@@ -11,6 +11,8 @@
 #include "device_info.h"
 #include "lpm.h"
 
+using namespace cfg;
+
 typedef struct dfu_core_ctx_t {
     libSmContext_t sm_ctx;
     bm_dfu_event_t current_event;
@@ -22,7 +24,10 @@ typedef struct dfu_core_ctx_t {
     bcmp_dfu_tx_func_t bcmp_dfu_tx;
     NvmPartition *dfu_partition;
     update_finish_cb_t update_finish_callback;
+    Configuration* sys_cfg;
 } dfu_core_ctx_t;
+
+static constexpr char dfu_confirm_config_key[] = "dfu_confirm";
 
 #ifndef CI_TEST
 ReboootClientUpdateInfo_t client_update_reboot_info __attribute__((section(".noinit")));
@@ -511,8 +516,9 @@ static void bm_dfu_event_thread(void*) {
     }
 }
 
-void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition) {
+void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition, cfg::Configuration* sys_cfg) {
     configASSERT(bcmp_dfu_tx);
+    configASSERT(sys_cfg);
     if(!dfu_partition) {
         printf("Dfu NVM partition not configured, DFU unavailible.\n");
         // TODO - update direct-to-flash
@@ -520,6 +526,7 @@ void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition) {
     }
     dfu_ctx.dfu_partition = dfu_partition;
     dfu_ctx.bcmp_dfu_tx = bcmp_dfu_tx;
+    dfu_ctx.sys_cfg = sys_cfg;
     bm_dfu_event_t evt;
     int retval;
 
@@ -601,6 +608,17 @@ bm_dfu_err_t bm_dfu_get_error(void) {
     return dfu_ctx.error;
 }
 
+bool bm_dfu_confirm_is_enabled(void) {
+    uint32_t val = 0;
+    dfu_ctx.sys_cfg->getConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key), val);
+    return val;
+}
+
+void bm_dfu_confirm_enable(bool en) {
+    uint32_t val = en;
+    dfu_ctx.sys_cfg->setConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key), val);
+    dfu_ctx.sys_cfg->saveConfig(true);
+}
 
 /*!
  * UNIT TEST FUNCTIONS BELOW HERE

--- a/test/src/common/CMakeLists.txt
+++ b/test/src/common/CMakeLists.txt
@@ -165,6 +165,7 @@ target_include_directories(bcmp_dfu_tests
     ${SRC_DIR}/third_party/FreeRTOS/Source/include
     ${SRC_DIR}/lib/sys
     ${SRC_DIR}/third_party/crc
+    ${SRC_DIR}/third_party/tinycbor/src
     ${TEST_DIR}/third_party/fff
     ${SRC_DIR}/lib/sys
     ${SRC_DIR}/lib/bcmp/dfu
@@ -186,8 +187,16 @@ target_sources(bcmp_dfu_tests
 
     # Support files
     ${SRC_DIR}/third_party/crc/crc16.c
+    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/nvmPartition.cpp
+    ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
+    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
+    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
+    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
+    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
+
     # Mocks
     ${TEST_DIR}/stubs/mock_mcu_boot.cpp
     ${TEST_DIR}/stubs/mock_FreeRTOS.c


### PR DESCRIPTION
To future-proof BCMP/comms layer protocol update incompatibility, we are adding a NVM Config force flag to enable users to set `dfu_confirm` to `0`, which will allow the DFU client to autoconfirm the update without the need for an ACK back to it's DFU host.  

Tested on BM SOFT:
1. Downgrade bridge + mote to v0.9.1
2. Set the "dfu_confirm" sys config on the mote to 0
3. update mote to new firmware 
See that the nodes can't quite communicate properly (on soft the pubsub still works for some reason??)
But the heartbeat and topo is breaking 
4. update bridge to new firmware 
5. profit

Tested that in the case `dfu_confirm` is absent, the image reverts.

Remember to reset the 
`dfu_confirm` config  between attempts

A side effect of disabling confirm that when the update completes, the host will get timeout error on it's end, even though the update was successfull