### PR TITLE
Sc 197851/rbr depth calibration

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -9,6 +9,7 @@
 #include "stm32_rtc.h"
 #include "task_priorities.h"
 #include "uptime.h"
+#include "util.h"
 #include <ctype.h>
 #include <math.h>
 #include <string.h>
@@ -139,8 +140,8 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       rtcPrint(rtcTimeBuffer, NULL);
       bm_fprintf(0, RBR_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
                  rtcTimeBuffer, read_len, _payload_buffer);
-      bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
-                rtcTimeBuffer, read_len, _payload_buffer);
+      bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
+                read_len, _payload_buffer);
       printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
              read_len, _payload_buffer);
 
@@ -232,3 +233,92 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
 * @brief Flush the data from the sensor driver.
 */
 void RbrSensor::flush(void) { PLUART::reset(); }
+
+bool RbrSensor::getPressurePa(float &pressure_pa) {
+  bool rval = false;
+  PLUART::write((uint8_t *)getSettingsCommandAtmosphericPressure,
+                strlen(getSettingsCommandAtmosphericPressure));
+  vTaskDelay(pdMS_TO_TICKS(200));
+  if (PLUART::lineAvailable()) {
+    do {
+      PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
+      const char *tagAtmosphericPressure =
+          strstr(_payload_buffer, settingsCommandAtmosphericPressureTag);
+      if (!tagAtmosphericPressure) {
+        break;
+      }
+      const char *tagEndLine = strstr(_payload_buffer, "\n");
+      if (!tagEndLine) {
+        break;
+      }
+      size_t line_len = tagEndLine - tagAtmosphericPressure;
+      if (line_len > sizeof(_payload_buffer)) {
+        break;
+      }
+      const char *atmophericPressureVal =
+          tagAtmosphericPressure + strlen(settingsCommandAtmosphericPressureTag);
+      if (atmophericPressureVal >= tagEndLine) {
+        break;
+      }
+      float atmosphericPressuredeciBar = 0.0;
+      if (!bStrtof(const_cast<char *>(atmophericPressureVal), &atmosphericPressuredeciBar)) {
+        break;
+      }
+      pressure_pa = convertPressureDecibarToPa(atmosphericPressuredeciBar);
+      rval = true;
+    } while (0);
+  }
+  return rval;
+}
+
+bool RbrSensor::getDensityGramPerCubicMeter(float &density_g_per_m3) {
+  bool rval = false;
+  PLUART::write((uint8_t *)getSettingsCommandDensity, strlen(getSettingsCommandDensity));
+  vTaskDelay(pdMS_TO_TICKS(200));
+  if (PLUART::lineAvailable()) {
+    do {
+      PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
+      const char *tagDensity = strstr(_payload_buffer, settingsCommandDensityTag);
+      if (!tagDensity) {
+        break;
+      }
+      const char *tagEndLine = strstr(_payload_buffer, "\n");
+      if (!tagEndLine) {
+        break;
+      }
+      size_t line_len = tagEndLine - tagDensity;
+      if (line_len > sizeof(_payload_buffer)) {
+        break;
+      }
+      const char *densityVal = tagDensity + strlen(settingsCommandDensityTag);
+      if (densityVal >= tagEndLine) {
+        break;
+      }
+      if (!bStrtof(const_cast<char *>(densityVal), &density_g_per_m3)) {
+        break;
+      }
+      rval = true;
+    } while (0);
+  }
+  return rval;
+}
+
+/*!
+* @brief Get the depth configuration.
+* @param depthM The depth in meters.
+* @return True if the depth configuration was successfully read and parsed.
+*/
+bool RbrSensor::getDepthConfiguration(float &depthM) {
+  bool rval = false;
+  uint8_t retries = 0;
+  float atmosphericPressurePa = 0.0;
+  float densityGramPerCubicMeter = 0.0;
+  do {
+    if (getPressurePa(atmosphericPressurePa) &&
+        getDensityGramPerCubicMeter(densityGramPerCubicMeter)) {
+      depthM = atmosphericPressurePa / (densityGramPerCubicMeter * GRAVITAIONAL_ACCELERATION);
+      rval = true;
+    }
+  } while (!rval && retries++ < 3);
+  return rval;
+}

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
@@ -18,7 +18,7 @@ public:
 
 private:
   bool getPressurePa(float &pressure_pa);
-  bool getDensityGramPerCubicMeter(float &density_g_per_m3);
+  bool getDensityKgPerCubicMeter(float &density_kg_per_m3);
   static inline float convertPressureDecibarToPa(float pressure_deci_bar) {
     return pressure_deci_bar * 10000;
   }

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
@@ -14,6 +14,14 @@ public:
   bool probeType(uint32_t timeout_ms = 1000);
   bool getData(BmRbrDataMsg::Data &d);
   void flush(void);
+  bool getDepthConfiguration(float &depthM);
+
+private:
+  bool getPressurePa(float &pressure_pa);
+  bool getDensityGramPerCubicMeter(float &density_g_per_m3);
+  static inline float convertPressureDecibarToPa(float pressure_deci_bar) {
+    return pressure_deci_bar * 10000;
+  }
 
 public:
   static constexpr char RBR_RAW_LOG[] = "rbr_raw.log";
@@ -24,8 +32,13 @@ private:
   static constexpr ValueType parserValueTypeOne[] = {TYPE_UINT64, TYPE_DOUBLE};
   static constexpr ValueType parserValueTypeTwo[] = {TYPE_UINT64, TYPE_DOUBLE, TYPE_DOUBLE};
   static constexpr char typeCommand[] = "outputformat channelslist\n";
+  static constexpr char getSettingsCommandAtmosphericPressure[] = "settings atmosphere\n";
+  static constexpr char settingsCommandAtmosphericPressureTag[] = "settings atmosphere = ";
+  static constexpr char getSettingsCommandDensity[] = "settings density\n";
+  static constexpr char settingsCommandDensityTag[] = "settings density = ";
   static constexpr uint8_t SENSOR_DROP_DEBOUNCE_MAX_COUNT = 3;
   static constexpr uint8_t NUM_PARSERS = 4;
+  static constexpr float GRAVITAIONAL_ACCELERATION = 9.81;
 
 private:
   BmRbrDataMsg::SensorType_t _type;

--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -16,6 +16,7 @@ static constexpr uint32_t PAYLOAD_WATCHDOG_TIMEOUT_MS = 10 * 1000;
 static constexpr uint32_t PROBE_TIME_PERIOD_MS = 8 * 1000;
 static constexpr uint32_t BM_RBR_DATA_MSG_MAX_SIZE = 256;
 static constexpr uint8_t NO_MAX_TRIGGER = 0;
+static constexpr char RBR_CODA_TYPE_CONFIG_STR[] = "rbrCodaType";
 static constexpr char DEPTH_CAL_CONFIG_STR[] = "rbrCodaDepthCalM";
 
 extern cfg::Configuration *systemConfigurationPartition;
@@ -31,7 +32,10 @@ void setup(void) {
   /* USER ONE-TIME SETUP CODE GOES HERE */
   configASSERT(systemConfigurationPartition);
   uint32_t sensor_type = static_cast<uint32_t>(BmRbrDataMsg::SensorType_t::UNKNOWN);
-  systemConfigurationPartition->getConfig("rbrCodaType", strlen("rbrCodaType"), sensor_type);
+  systemConfigurationPartition->getConfig(RBR_CODA_TYPE_CONFIG_STR,
+                                          strlen(RBR_CODA_TYPE_CONFIG_STR), sensor_type);
+  systemConfigurationPartition->getConfig(DEPTH_CAL_CONFIG_STR, strlen(DEPTH_CAL_CONFIG_STR),
+                                          depthConfigM);
   rbr_sensor.init(static_cast<BmRbrDataMsg::SensorType_t>(sensor_type));
   SensorWatchdog::SensorWatchdogAdd(BM_RBR_WATCHDOG_ID, PAYLOAD_WATCHDOG_TIMEOUT_MS,
                                     BmRbrWatchdogHandler, NO_MAX_TRIGGER,

--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -10,6 +10,7 @@
 #include "sensorWatchdog.h"
 #include "uptime.h"
 #include "util.h"
+#include <math.h>
 
 static constexpr char BM_RBR_WATCHDOG_ID[] = "bm_rbr";
 static constexpr uint32_t PAYLOAD_WATCHDOG_TIMEOUT_MS = 10 * 1000;
@@ -23,7 +24,7 @@ extern cfg::Configuration *systemConfigurationPartition;
 static RbrSensor rbr_sensor;
 static char bmRbrTopic[BM_TOPIC_MAX_LEN];
 static int bmRbrTopicStrLen;
-static float depthConfigM = 0.0;
+static float depthConfigM = NAN;
 
 static bool BmRbrWatchdogHandler(void *arg);
 static int createBmRbrDataTopic(void);
@@ -62,6 +63,7 @@ void loop(void) {
       printf("DEBUG - Depth configuration updated to %f\n", depthConfigM);
       systemConfigurationPartition->setConfig(DEPTH_CAL_CONFIG_STR,
                                               strlen(DEPTH_CAL_CONFIG_STR), depthConfigM);
+      systemConfigurationPartition->saveConfig(false);
     }
     last_probe_time_ms = uptimeGetMs();
   }


### PR DESCRIPTION
Attempts to poll the sensor for the depth configuration (m) every 8s (same as probe type).
Will write to `rbrCodaDepthCalM` sys config on success. 

I'm around 70% sure this is the definition of "calibrated for x depth"

It would be nice to verify that with a known "RBR depth value" on a particular sensor to cross check these computations.

<img width="802" alt="Screen Shot 2024-03-06 at 2 04 43 PM" src="https://github.com/bristlemouth/bm_protocol/assets/5218083/00b5d3bf-df16-4f9f-8580-cc13f6d2b13c">

```
DEBUG - Depth configuration updated to 10.328747
```

Computation:
```
Settings - 
Atmospheric pressure: 10.1325007812 
Density: 1.000000 g/cm3

p = rho * g * h
h = p / (rho * g)

h - depth (m)
g - 9.81 m/s^2
p - pressure (pascal)
rho - density (kg * m^3)

h = (10.1325007812 * 10000) / ((1 * 1000) * 9.81)
h  = 10.328747 m 
```

