### PR TITLE
Fix/node position

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -13,6 +13,9 @@
 #include "util.h"
 #include <new>
 
+// TODO - get this from the sensor node itself
+#define DEFAULT_AANDERAA_READING_PERIOD_MS 60 * 1000 // 1 minute
+
 bool AanderaaSensor::subscribe() {
   bool rval = false;
   char *sub = static_cast<char *>(pvPortMalloc(BM_TOPIC_MAX_LEN));
@@ -54,7 +57,7 @@ void AanderaaSensor::aanderaSubCallback(uint64_t node_id, const char *topic, uin
         uint32_t sensor_reading_time_millis = d.header.sensor_reading_time_ms % 1000U;
 
         uint32_t current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - aanderaa->last_timestamp > aanderaa->current_agg_period_ms + 30000u) ||
+        if ((current_timestamp - aanderaa->last_timestamp > DEFAULT_AANDERAA_READING_PERIOD_MS + 30000u) ||
             aanderaa->reading_count == 1U) {
           printf("Updating aanderaa %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.h
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.h
@@ -32,6 +32,8 @@ typedef struct AanderaaSensor : public AbstractSensor {
   AveragingSampler abs_tilt_rad;
   AveragingSampler std_tilt_rad;
   uint32_t reading_count;
+  int8_t node_position;
+  uint32_t last_timestamp;
 
   static constexpr uint32_t N_SAMPLES_PAD =
       10; // Extra sample padding to account for timing slop.

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -14,6 +14,9 @@
 #include "util.h"
 #include <new>
 
+// TODO - get this from the sensor node itself
+#define DEFAULT_RBR_CODA_READING_PERIOD_MS 500 // 2Hz
+
 bool RbrCodaSensor::subscribe() {
   bool rval = false;
   char *sub = static_cast<char *>(pvPortMalloc(BM_TOPIC_MAX_LEN));
@@ -51,7 +54,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         uint32_t sensor_reading_time_millis = rbr_data.header.sensor_reading_time_ms % 1000U;
 
         uint32_t current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - rbr_coda->last_timestamp > rbr_coda->rbr_coda_agg_period_ms + 1000u) ||
+        if ((current_timestamp - rbr_coda->last_timestamp > DEFAULT_RBR_CODA_READING_PERIOD_MS + 1000u) ||
             rbr_coda->reading_count == 1U) {
           printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -50,22 +50,15 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
         uint64_t sensor_reading_time_sec = rbr_data.header.sensor_reading_time_ms / 1000U;
         uint32_t sensor_reading_time_millis = rbr_data.header.sensor_reading_time_ms % 1000U;
 
-        // Keep track of when we last got a reading from this node
-        // If it is the first reading, or if it has been more than the rbr aggregation period + 1 second
-        // then we will update the node position.
-        static int8_t node_position = 0;
-        static uint32_t last_timestamp = 0;
-        static uint32_t current_timestamp = 0;
-
-        current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - last_timestamp > rbr_coda->rbr_coda_agg_period_ms + 1000u) ||
+        uint32_t current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
+        if ((current_timestamp - rbr_coda->last_timestamp > rbr_coda->rbr_coda_agg_period_ms + 1000u) ||
             rbr_coda->reading_count == 1U) {
           printf("Updating rbr_coda %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",
-                 node_id, current_timestamp, last_timestamp, rbr_coda->reading_count);
-          node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
+                 node_id, current_timestamp, rbr_coda->last_timestamp, rbr_coda->reading_count);
+          rbr_coda->node_position = topology_sampler_get_node_position(node_id, pdTICKS_TO_MS(5000));
         }
-        last_timestamp = current_timestamp;
+        rbr_coda->last_timestamp = current_timestamp;
 
         // Use the latest sensor type to determine the sensor type string
         const char *sensor_type_str;
@@ -91,7 +84,7 @@ void RbrCodaSensor::rbrCodaSubCallback(uint64_t node_id, const char *topic, uint
             "%03" PRIu32 "," // sensor_reading_time_ms millis part
             "%.3f,"          // temperature_deg_c
             "%.3f\n",        // pressure_ubar
-            node_id, node_position, sensor_type_str, rbr_data.header.reading_uptime_millis,
+            node_id, rbr_coda->node_position, sensor_type_str, rbr_data.header.reading_uptime_millis,
             reading_time_sec, reading_time_millis, sensor_reading_time_sec,
             sensor_reading_time_millis, rbr_data.temperature_deg_c, rbr_data.pressure_deci_bar);
         if (log_buflen > 0) {

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -24,6 +24,8 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   AveragingSampler pressure_ubar;
   uint32_t reading_count;
   BmRbrDataMsg::SensorType_t latest_sensor_type;
+  int8_t node_position;
+  uint32_t last_timestamp;
 
   // Extra sample padding to account for timing slop. Calculated as the sample frequency + 2 minutes bridge on period + some extra slop.
   // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -13,6 +13,9 @@
 #include "util.h"
 #include <new>
 
+// TODO - get this from the sensor node itself
+#define DEFAULT_SOFT_READING_PERIOD_MS 500 // 2Hz
+
 bool SoftSensor::subscribe() {
   bool rval = false;
   char *sub = static_cast<char *>(pvPortMalloc(BM_TOPIC_MAX_LEN));
@@ -50,7 +53,7 @@ void SoftSensor::softSubCallback(uint64_t node_id, const char *topic, uint16_t t
         uint32_t sensor_reading_time_millis = soft_data.header.sensor_reading_time_ms % 1000U;
 
         uint32_t current_timestamp = pdTICKS_TO_MS(xTaskGetTickCount());
-        if ((current_timestamp - soft->last_timestamp > soft->current_agg_period_ms + 1000u) ||
+        if ((current_timestamp - soft->last_timestamp > DEFAULT_SOFT_READING_PERIOD_MS + 1000u) ||
             soft->reading_count == 1U) {
           printf("Updating soft %" PRIx64 " node position, current_time = %" PRIu32
                  ", last_time = %" PRIu32 ", reading count: %" PRIu32 "\n",

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -18,6 +18,8 @@ typedef struct SoftSensor : public AbstractSensor {
   uint32_t current_agg_period_ms;
   AveragingSampler temp_deg_c;
   uint32_t reading_count;
+  int8_t node_position;
+  uint32_t last_timestamp;
 
   // Extra sample padding to account for timing slop. Calculated as the sample frequency + 2 minutes bridge on period + some extra slop.
   // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.


### PR DESCRIPTION
I recently updated the Node position code such that it only updates every once in a while. What I forgot is that the `softSubCallback` function is a static function and therefore called by all SoftSensor class objects. I had made the `node_position` variable a static variable within the `softSubCallback` thinking that each class object had its own `softSubCallback`. But what this really meant was that the `node_position` for one node was being used by every node. So in this PR I made the `node_position` and `last_timestamp` part of the `Soft_t`, `RbrCoda_t`, and `Aanderaa_t` classes so that each subscription tracks its own data.

Here is an example of lines in a log captured during a test where we have a node_position for one node override every other nodes positions:
```
48d57401250b4d7c,1,soft,678,0.000,0.000,22.351
246f92446ac231c3,2,soft,673,0.000,0.000,22.356
48d57401250b4d7c,2,soft,1198,0.000,0.000,22.351
246f92446ac231c3,2,soft,1193,0.000,0.000,22.356
48d57401250b4d7c,2,soft,1718,0.000,0.000,22.351
246f92446ac231c3,2,soft,1713,0.000,0.000,22.356
48d57401250b4d7c,2,soft,2238,0.000,0.000,22.351
246f92446ac231c3,2,soft,2233,0.000,0.000,22.356
48d57401250b4d7c,2,soft,2758,0.000,0.000,22.351
246f92446ac231c3,2,soft,2753,0.000,0.000,22.356
48d57401250b4d7c,2,soft,3278,0.000,0.000,22.351
246f92446ac231c3,2,soft,3273,0.000,0.000,22.356
48d57401250b4d7c,2,soft,3798,0.000,0.000,22.351
29bdebdc1e7268a2,4,soft,3798,0.000,0.000,22.337
497cd89f0feecac3,3,soft,3798,0.000,0.000,22.335
246f92446ac231c3,3,soft,3793,0.000,0.000,22.356
48d57401250b4d7c,3,soft,4318,0.000,0.000,22.351
29bdebdc1e7268a2,3,soft,4318,0.000,0.000,22.337
```

Here is an example of it working after these changes:
We get the node_position on the first sample for both nodes and we can see in the following lines that the node_positions stay 1 and 2 for the respective nodes.
<img width="697" alt="Screenshot 2024-03-07 at 2 22 59 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/75665b8b-1a19-48c6-be1f-301c511def73">

Here we can see after I unplugged the nodes from the bridge that we detect a time difference of > 500ms and we update the node positions.
<img width="783" alt="Screenshot 2024-03-07 at 2 22 13 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/2e6fab09-afb1-4da9-a5a9-8c4e1f8fd5f5">

https://app.shortcut.com/sofar/story/199921/node-position-sticks-between-sensors
