### PR TITLE
fix: too many power monitor retries

### DIFF
--- a/src/lib/sensor_sampler/powerSampler.cpp
+++ b/src/lib/sensor_sampler/powerSampler.cpp
@@ -31,9 +31,9 @@ static bool powerSample() {
   float voltage, current;
   bool success = false;
   bool rval = true;
-  uint8_t retriesRemaining = SENSORS_NUM_RETRIES;
 
   for (uint8_t dev_num = 0; dev_num < NUM_INA232_DEV; dev_num++) {
+    uint8_t retriesRemaining = SENSORS_NUM_RETRIES;
     do {
       success = _inaSensors[dev_num]->measurePower();
       if (success) {


### PR DESCRIPTION
I was debugging on a potted RBR module with a broken power monitor, and saw this:

```
1709846009.769 142da2ea9eccbe3c, --zz-- sensor sampler polling 1 sensors
1709846009.921 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 0, success 0, retries remaining 3
1709846010.074 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 0, success 0, retries remaining 2
1709846010.226 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 0, success 0, retries remaining 1
1709846010.375 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 0
1709846010.527 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 255
1709846010.679 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 254
1709846010.828 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 253
1709846010.980 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 252
1709846011.132 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 251
1709846011.281 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 250
1709846011.433 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 249
1709846011.585 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 248
1709846011.734 142da2ea9eccbe3c, --zz-- powerSample measurePower on device 1, success 0, retries remaining 247
```

In the case when we have complete failure of the I2C bus, we were never resetting the number of retries, so the first power monitor got 3 retries as intended, then the second one got 255.