### PR TITLE
NOT March MVP - don't overload alignment increment and default value

### DIFF
--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -372,7 +372,7 @@ static void defaultTask(void *parameters) {
       VBUS_SW_EN, pwrcfg.sampleIntervalMs, pwrcfg.sampleDurationMs, pwrcfg.subsampleIntervalMs,
       pwrcfg.subsampleDurationMs, static_cast<bool>(pwrcfg.subsampleEnabled),
       static_cast<bool>(pwrcfg.bridgePowerControllerEnabled),
-      (pwrcfg.alignmentInterval5Min * BridgePowerController::DEFAULT_ALIGNMENT_S));
+      (pwrcfg.alignmentInterval5Min * BridgePowerController::ALIGNMENT_INCREMENT_S));
 
   ncpInit(&usart3, &dfu_partition, &bridge_power_controller, &debug_configuration_user,
           &debug_configuration_system, &debug_configuration_hardware);

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -57,6 +57,7 @@ public:
   static constexpr uint32_t MAX_SUBSAMPLE_INTERVAL_S = (60 * 60);
   static constexpr uint32_t MAX_SUBSAMPLE_DURATION_S = (60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_S = (5 * 60);
+  static constexpr uint32_t ALIGNMENT_INCREMENT_S = (5 * 60);
   static constexpr uint32_t MAX_ALIGNMENT_S = (24 * 60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_5_MIN_INTERVAL = (1);
 


### PR DESCRIPTION
Don't overload the increment of alignment adjustments (5 minutes) with the current default value for the configuration (5 minutes).

Saves future selves some sorrow if we ever adjust the default setting for bridge UTC alignment.