### PR TITLE
Refactor/remove sensor controller timer

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -226,7 +226,7 @@ void BridgePowerController::_update(void) {
         if (nextSampleEpochS > currentCycleS) {
           powerBusAndSetSignal(false);
         }
-        xTaskNotify(sensor_controller_task_handle, AANDERAA_AGGREGATION_TIMER_BITS, eSetBits);
+        xTaskNotify(sensor_controller_task_handle, AGGREGATION_TIMER_BITS, eSetBits);
         break;
       }
     } else { // Sampling Not Enabled

--- a/src/apps/bridge/sensorController.h
+++ b/src/apps/bridge/sensorController.h
@@ -13,7 +13,7 @@
 
 typedef enum {
   SAMPLER_TIMER_BITS = 0x01,
-  AANDERAA_AGGREGATION_TIMER_BITS = 0x02,
+  AGGREGATION_TIMER_BITS = 0x02,
 } sensorControllerBits_t;
 
 extern TaskHandle_t sensor_controller_task_handle;

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -218,7 +218,7 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
     // Should these two be outside of the do-while loop? That way we will always notify the other tasks?
     // The first four inputs are not used by this message type
     reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
-    xTaskNotify(sensor_controller_task_handle, AANDERAA_AGGREGATION_TIMER_BITS, eSetBits);
+    xTaskNotify(sensor_controller_task_handle, SAMPLER_TIMER_BITS, eSetBits);
 
   } while (0);
   xSemaphoreGive(_node_list.node_list_mutex);

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -214,11 +214,13 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
         _send_on_boot = false;
       }
     }
+
+    // The first four inputs are not used by this message type
+    reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
+
   } while (0);
   xSemaphoreGive(_node_list.node_list_mutex);
 
-  // The first four inputs are not used by this message type
-  reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
   // Notify the sensor controller task to sample for sensors
   xTaskNotify(sensor_controller_task_handle, SAMPLER_TIMER_BITS, eSetBits);
 

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -24,6 +24,7 @@
 #include "config_cbor_map_srv_request_msg.h"
 #include "crc.h"
 #include "device_info.h"
+#include "sensorController.h"
 #include "sm_config_crc_list.h"
 #include "stm32_rtc.h"
 #include "sys_info_service.h"
@@ -214,8 +215,10 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
       }
     }
 
+    // Should these two be outside of the do-while loop? That way we will always notify the other tasks?
     // The first four inputs are not used by this message type
     reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
+    xTaskNotify(sensor_controller_task_handle, AANDERAA_AGGREGATION_TIMER_BITS, eSetBits);
 
   } while (0);
   xSemaphoreGive(_node_list.node_list_mutex);

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -214,14 +214,13 @@ static void topology_sample_cb(networkTopology_t *networkTopology) {
         _send_on_boot = false;
       }
     }
-
-    // Should these two be outside of the do-while loop? That way we will always notify the other tasks?
-    // The first four inputs are not used by this message type
-    reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
-    xTaskNotify(sensor_controller_task_handle, SAMPLER_TIMER_BITS, eSetBits);
-
   } while (0);
   xSemaphoreGive(_node_list.node_list_mutex);
+
+  // The first four inputs are not used by this message type
+  reportBuilderAddToQueue(0, 0, NULL, 0, REPORT_BUILDER_CHECK_CRC);
+  // Notify the sensor controller task to sample for sensors
+  xTaskNotify(sensor_controller_task_handle, SAMPLER_TIMER_BITS, eSetBits);
 
   if (cbor_buffer) {
     vPortFree(cbor_buffer);


### PR DESCRIPTION
I removed the `sensorController`'s 30s timer and moved the task notification to `topology_sampler`. Now we will sample for sensors 5 seconds after BUS ON and this will decrease the latency between start-up time and the time SOFT/RBR data makes it into SENS_IND.log on Spotter.

here is an example where on boot we can see that we sampled for sensors right after the first topology sample (where we assembled/printed the network cbor map every time on boot!):
<img width="713" alt="Screenshot 2024-03-11 at 2 35 30 PM" src="https://github.com/bristlemouth/bm_protocol/assets/85895527/a9cbfcd1-94b6-47d3-aedf-a9dabbe78b1c">
