### PR TITLE
Sc 200071/print mods and timer

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -46,10 +46,6 @@ void loop(void) {
   /* USER LOOP CODE GOES HERE */
   static BmRbrDataMsg::Data d;
   static uint32_t last_probe_time_ms = uptimeGetMs();
-  if (uptimeGetMs() - last_probe_time_ms > PROBE_TIME_PERIOD_MS) {
-    rbr_sensor.probeType();
-    last_probe_time_ms = uptimeGetMs();
-  }
   if (rbr_sensor.getData(d)) {
     SensorWatchdog::SensorWatchdogPet(BM_RBR_WATCHDOG_ID);
     static uint8_t cbor_buf[BM_RBR_DATA_MSG_MAX_SIZE];
@@ -60,6 +56,10 @@ void loop(void) {
     } else {
       printf("Failed to encode data message\n");
     }
+  }
+  if (uptimeGetMs() - last_probe_time_ms > PROBE_TIME_PERIOD_MS) {
+    rbr_sensor.probeType();
+    last_probe_time_ms = uptimeGetMs();
   }
 }
 

--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -13,6 +13,8 @@
 
 static constexpr char BM_RBR_WATCHDOG_ID[] = "bm_rbr";
 static constexpr uint32_t PAYLOAD_WATCHDOG_TIMEOUT_MS = 10 * 1000;
+// Note that PROBE_TIME_PERIOD_MS should be different than the watchdog timeout
+// to avoid trying to probe while the sensor powered down.
 static constexpr uint32_t PROBE_TIME_PERIOD_MS = 8 * 1000;
 static constexpr uint32_t BM_RBR_DATA_MSG_MAX_SIZE = 256;
 static constexpr uint8_t NO_MAX_TRIGGER = 0;
@@ -74,7 +76,8 @@ static bool BmRbrWatchdogHandler(void *arg) {
 }
 
 static int createBmRbrDataTopic(void) {
-  int topiclen = snprintf(bmRbrTopic, BM_TOPIC_MAX_LEN, "sensor/%" PRIx64 "/sofar/bm_rbr_data", getNodeId());
+  int topiclen = snprintf(bmRbrTopic, BM_TOPIC_MAX_LEN, "sensor/%" PRIx64 "/sofar/bm_rbr_data",
+                          getNodeId());
   configASSERT(topiclen > 0);
   return topiclen;
 }


### PR DESCRIPTION
This PR cleans up a few prints:

- Print to log when we fail to probe the Type of the RBR 
- Clean up "recovered" -> "online"
- Only print ^ when we've exceeded the debounce count. 

and also adds comment clarification about timer choices