### PR TITLE
Sc 200214/bridge write default configs

### DIFF
--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -1,37 +1,100 @@
 #include "app_config.h"
+#include "bridgeLog.h"
 #include "bridgePowerController.h"
 
 power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
   power_config_s pwrcfg;
 
+  bool save_config = false;
   pwrcfg.sampleIntervalMs = BridgePowerController::DEFAULT_SAMPLE_INTERVAL_S * 1000;
-  syscfg.getConfig(AppConfig::SAMPLE_INTERVAL_MS, strlen(AppConfig::SAMPLE_INTERVAL_MS),
+  if (!syscfg.getConfig(AppConfig::SAMPLE_INTERVAL_MS, strlen(AppConfig::SAMPLE_INTERVAL_MS),
+                        pwrcfg.sampleIntervalMs)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get sample interval from config, using default value and writing "
+                   "to config: %" PRIu32 "ms\n",
                    pwrcfg.sampleIntervalMs);
+    syscfg.setConfig(AppConfig::SAMPLE_INTERVAL_MS, strlen(AppConfig::SAMPLE_INTERVAL_MS),
+                     pwrcfg.sampleIntervalMs);
+    save_config = true;
+  }
 
   pwrcfg.sampleDurationMs = BridgePowerController::DEFAULT_SAMPLE_DURATION_S * 1000;
-  syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+  if (!syscfg.getConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+                        pwrcfg.sampleDurationMs)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get sample duration from config, using default value and writing "
+                   "to config: %" PRIu32 "ms\n",
                    pwrcfg.sampleDurationMs);
+    syscfg.setConfig(AppConfig::SAMPLE_DURATION_MS, strlen(AppConfig::SAMPLE_DURATION_MS),
+                     pwrcfg.sampleDurationMs);
+    save_config = true;
+  }
 
   pwrcfg.subsampleIntervalMs = BridgePowerController::DEFAULT_SUBSAMPLE_INTERVAL_S * 1000;
-  syscfg.getConfig(AppConfig::SUBSAMPLE_INTERVAL_MS, strlen(AppConfig::SUBSAMPLE_INTERVAL_MS),
+  if (!syscfg.getConfig(AppConfig::SUBSAMPLE_INTERVAL_MS,
+                        strlen(AppConfig::SUBSAMPLE_INTERVAL_MS), pwrcfg.subsampleIntervalMs)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get subsample interval from config, using default value and "
+                   "writing to config: %" PRIu32 "ms\n",
                    pwrcfg.subsampleIntervalMs);
+    syscfg.setConfig(AppConfig::SUBSAMPLE_INTERVAL_MS, strlen(AppConfig::SUBSAMPLE_INTERVAL_MS),
+                     pwrcfg.subsampleIntervalMs);
+    save_config = true;
+  }
 
   pwrcfg.subsampleDurationMs = BridgePowerController::DEFAULT_SUBSAMPLE_DURATION_S * 1000;
-  syscfg.getConfig(AppConfig::SUBSAMPLE_DURATION_MS, strlen(AppConfig::SUBSAMPLE_DURATION_MS),
+  if (!syscfg.getConfig(AppConfig::SUBSAMPLE_DURATION_MS,
+                        strlen(AppConfig::SUBSAMPLE_DURATION_MS), pwrcfg.subsampleDurationMs)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get subsample duration from config, using default value and "
+                   "writing to config: %" PRIu32 "ms\n",
                    pwrcfg.subsampleDurationMs);
+    syscfg.setConfig(AppConfig::SUBSAMPLE_DURATION_MS, strlen(AppConfig::SUBSAMPLE_DURATION_MS),
+                     pwrcfg.subsampleDurationMs);
+    save_config = true;
+  }
 
   pwrcfg.subsampleEnabled = BridgePowerController::DEFAULT_SUBSAMPLE_ENABLED;
-  syscfg.getConfig(AppConfig::SUBSAMPLE_ENABLED, strlen(AppConfig::SUBSAMPLE_ENABLED),
+  if (!syscfg.getConfig(AppConfig::SUBSAMPLE_ENABLED, strlen(AppConfig::SUBSAMPLE_ENABLED),
+                        pwrcfg.subsampleEnabled)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get subsample enabled from config, using default value and "
+                   "writing to config: %" PRIu32 "\n",
                    pwrcfg.subsampleEnabled);
+    syscfg.setConfig(AppConfig::SUBSAMPLE_ENABLED, strlen(AppConfig::SUBSAMPLE_ENABLED),
+                     pwrcfg.subsampleEnabled);
+    save_config = true;
+  }
 
   pwrcfg.bridgePowerControllerEnabled = BridgePowerController::DEFAULT_POWER_CONTROLLER_ENABLED;
-  syscfg.getConfig(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED,
-                   strlen(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED),
+  if (!syscfg.getConfig(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED,
+                        strlen(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED),
+                        pwrcfg.bridgePowerControllerEnabled)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get bridge power controller enabled from config, using default "
+                   "value and writing to config: %" PRIu32 "\n",
                    pwrcfg.bridgePowerControllerEnabled);
+    syscfg.setConfig(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED,
+                     strlen(AppConfig::BRIDGE_POWER_CONTROLLER_ENABLED),
+                     pwrcfg.bridgePowerControllerEnabled);
+    save_config = true;
+  }
 
   pwrcfg.alignmentInterval5Min = BridgePowerController::DEFAULT_ALIGNMENT_5_MIN_INTERVAL;
-  syscfg.getConfig(AppConfig::ALIGNMENT_INTERVAL_5MIN,
-                   strlen(AppConfig::ALIGNMENT_INTERVAL_5MIN), pwrcfg.alignmentInterval5Min);
+  if (!syscfg.getConfig(AppConfig::ALIGNMENT_INTERVAL_5MIN,
+                        strlen(AppConfig::ALIGNMENT_INTERVAL_5MIN),
+                        pwrcfg.alignmentInterval5Min)) {
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get alignment interval from config, using default value and "
+                   "writing to config: %" PRIu32 "ms\n",
+                   pwrcfg.alignmentInterval5Min);
+    syscfg.setConfig(AppConfig::ALIGNMENT_INTERVAL_5MIN,
+                     strlen(AppConfig::ALIGNMENT_INTERVAL_5MIN), pwrcfg.alignmentInterval5Min);
+    save_config = true;
+  }
+  if (save_config) {
+    syscfg.saveConfig(true);
+  }
 
   return pwrcfg;
 }

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -93,7 +93,7 @@ power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
     save_config = true;
   }
   if (save_config) {
-    syscfg.saveConfig(true);
+    syscfg.saveConfig(false);
   }
 
   return pwrcfg;

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -42,9 +42,9 @@ private:
 public:
   static constexpr uint32_t OFF = (1 << 0);
   static constexpr uint32_t ON = (1 << 1);
-  static constexpr uint32_t DEFAULT_POWER_CONTROLLER_ENABLED = 0;
-  static constexpr uint32_t DEFAULT_SAMPLE_INTERVAL_S = (20 * 60);
-  static constexpr uint32_t DEFAULT_SAMPLE_DURATION_S = (5 * 60);
+  static constexpr uint32_t DEFAULT_POWER_CONTROLLER_ENABLED = 1;
+  static constexpr uint32_t DEFAULT_SAMPLE_INTERVAL_S = (30 * 60);
+  static constexpr uint32_t DEFAULT_SAMPLE_DURATION_S = ((5 * 60) + 10);
   static constexpr uint32_t DEFAULT_SUBSAMPLE_ENABLED = 0;
   static constexpr uint32_t DEFAULT_SUBSAMPLE_INTERVAL_S = (60);
   static constexpr uint32_t DEFAULT_SUBSAMPLE_DURATION_S = (30);

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -629,7 +629,7 @@ void reportBuilderInit(cfg::Configuration *sys_cfg) {
     save_config = true;
   }
   if (save_config) {
-    sys_cfg->saveConfig(true);
+    sys_cfg->saveConfig(false);
   }
   _ctx._sample_counter = 0;
   _ctx._config_mutex = xSemaphoreCreateMutex();

--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -604,12 +604,33 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
 // Task init
 void reportBuilderInit(cfg::Configuration *sys_cfg) {
   configASSERT(sys_cfg);
+  bool save_config = false;
   _ctx._samplesPerReport = DEFAULT_SAMPLES_PER_REPORT;
-  sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT),
-                     _ctx._samplesPerReport);
+  if (!sys_cfg->getConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT),
+                          _ctx._samplesPerReport)) {
+    bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get samples per report from config, using default %" PRIu32
+                   " and saving to config\n",
+                   _ctx._samplesPerReport);
+    sys_cfg->setConfig(AppConfig::SAMPLES_PER_REPORT, strlen(AppConfig::SAMPLES_PER_REPORT),
+                       _ctx._samplesPerReport);
+    save_config = true;
+  }
   _ctx._transmitAggregations = DEFAULT_TRANSMIT_AGGREGATIONS;
-  sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS, strlen(AppConfig::TRANSMIT_AGGREGATIONS),
-                     _ctx._transmitAggregations);
+  if (!sys_cfg->getConfig(AppConfig::TRANSMIT_AGGREGATIONS,
+                          strlen(AppConfig::TRANSMIT_AGGREGATIONS),
+                          _ctx._transmitAggregations)) {
+    bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Failed to get transmit aggregations from config, using default %" PRIu32
+                   " and saving to config\n",
+                   _ctx._transmitAggregations);
+    sys_cfg->setConfig(AppConfig::TRANSMIT_AGGREGATIONS,
+                       strlen(AppConfig::TRANSMIT_AGGREGATIONS), _ctx._transmitAggregations);
+    save_config = true;
+  }
+  if (save_config) {
+    sys_cfg->saveConfig(true);
+  }
   _ctx._sample_counter = 0;
   _ctx._config_mutex = xSemaphoreCreateMutex();
   configASSERT(_ctx._config_mutex);


### PR DESCRIPTION
```
[[8046209027809048845, "bridge-dbg", 2140659395, 1707199808, {"sampleIntervalMs": 1200000, "sampleDurationMs": 300000, "subsampleIntervalMs": 60000, "subsampleDurationMs": 30000, "subsampleEnabled": 0, "bridgePowerControllerEnabled": 0, "alignmentInterval5Min": 1, "samplesPerReport": 2, "transmitAggregations": 1, "currentReadingPeriodMs": 60000, "softReadingPeriodMs": 500, "rbrCodaReadingPeriodMs": 500}]]
```