### PR TITLE
print to spotter if we can't talk to power sensors

### DIFF
--- a/src/lib/sensor_sampler/powerSampler.cpp
+++ b/src/lib/sensor_sampler/powerSampler.cpp
@@ -68,6 +68,7 @@ static bool powerSample() {
       taskEXIT_CRITICAL();
     } else {
       printf("ERR Failed to sample power monitor %u!", dev_num);
+      bm_printf(0, "ERR Failed to sample power monitor %u!", dev_num);
     }
     rval &= success;
   }

--- a/src/lib/sensor_sampler/powerSampler.cpp
+++ b/src/lib/sensor_sampler/powerSampler.cpp
@@ -69,6 +69,7 @@ static bool powerSample() {
     } else {
       printf("ERR Failed to sample power monitor %u!", dev_num);
       bm_printf(0, "ERR Failed to sample power monitor %u!", dev_num);
+      bm_fprintf(0, "power.log", "ERR Failed to sample power monitor %u!", dev_num);
     }
     rval &= success;
   }


### PR DESCRIPTION
Adding a bit of observability up to spotter (printf) when a module can't talk to the power sensor(s).