### PR TITLE
add a recurring timer for mfg test

### DIFF
--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -36,6 +36,10 @@
 // Use a No-op ";" command to tickle the Aanderaa
 static const char tx_tickle_data[] = ";\r\n";
 
+// Config flag to enable a tx test for manufacturing.
+static uint32_t mfg_tx_test_enable = 0;
+#define MFG_TEST_TX_PERIOD_MS (1000)
+
 /// Default mote configurations and local variables
 // How many minutes to collect readings for before shipping an aggregation.
 #define DEFAULT_CURRENT_AGG_PERIOD_MIN (0)
@@ -224,6 +228,8 @@ void setup(void) {
                                         payload_wd_to_s);
   systemConfigurationPartition->getConfig("plUartBaudRate", strlen("plUartBaudRate"),
                                         baud_rate);
+  systemConfigurationPartition->getConfig("mfgTxTestModeEnable", strlen("mfgTxTestModeEnable"),
+                                        mfg_tx_test_enable);
 
   max_readings_in_agg = (((uint64_t)CURRENT_AGG_PERIOD_MS / reading_interval_ms) + N_SAMPLES_PAD);
 
@@ -280,6 +286,10 @@ static double getDoubleOrNaN(Value value) {
   } else {
     return value.data.double_val;
   }
+}
+static void mfgTestSendTxWakeup(void) {
+  static constexpr char wakeup_data[] = "X\r\n";
+  PLUART::write((uint8_t *)wakeup_data, strlen(wakeup_data));
 }
 #endif
 
@@ -383,6 +393,16 @@ void loop(void) {
   (void)readings_skipped;
   spoof_aanderaa();
 #else // FAKE_AANDERAA
+
+  // Manufacturing TX test mode
+  if(mfg_tx_test_enable) {
+    static uint32_t mfgTxTimerMs = uptimeGetMs();
+    if(uptimeGetMs() - mfgTxTimerMs >= MFG_TEST_TX_PERIOD_MS) {
+      mfgTxTimerMs = uptimeGetMs();
+      mfgTestSendTxWakeup();
+    }
+  }
+
   // If there is a line to read, read it ad then parse it
   if (PLUART::lineAvailable()) {
     SensorWatchdog::SensorWatchdogPet(AANDERAA_WATCHDOG_ID);


### PR DESCRIPTION
Add a sys config `mfgTxTestModeEnable` that can be set (from the Spotter) so that the 
Aanderaa mote will send a `"X\r\n";` every second. 
If the Aanderaa device is able to receive and respond, it will be captured in the raw log. 

Remember to send a commit  after setting`mfgTxTestModeEnable`!

Adding the config from Spotter:
`bm cfg set 0x2d3fe85f3bfbfe45 s u mfgTxTestModeEnable 1`
`bm cfg commit 0x2d3fe85f3bfbfe45 s`

```
70781t 2d3fe85f3bfbfe45, [aanderaa] | tick: 38181, rtc: 0, line: *	ERROR	SYNTAX ERROR
71742t 2d3fe85f3bfbfe45, power | tick: 39145, rtc: 0, addr: 67, voltage: 23.945601, current: 0.027500
71763t 2d3fe85f3bfbfe45, power | tick: 39147, rtc: 0, addr: 65, voltage: 23.937599, current: 0.040500
71782t 2d3fe85f3bfbfe45, [aanderaa] | tick: 39181, rtc: 0, line: *	ERROR	SYNTAX ERROR 
```

`bm cfg del 0x2d3fe85f3bfbfe45 s mfgTxTestModeEnable`
`bm cfg commit 0x2d3fe85f3bfbfe45 s`

`[aanderaa] | tick: 38181, rtc: 0, line: *	` lines stop.

[aanderaa_raw.log](https://github.com/bristlemouth/bm_protocol/files/14704813/aanderaa_raw.log)
