### PR TITLE
fix: rbr range to spec

### DIFF
--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -117,6 +117,7 @@ void RbrCodaSensor::aggregate(void) {
                                     .reading_count = 0,
                                     .sensor_type = BmRbrDataMsg::SensorType::UNKNOWN};
     aggs.sensor_type = rbrCodaGetSensorType(node_id);
+    latest_sensor_type = aggs.sensor_type;
     if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       aggs.temp_mean_deg_c = temp_deg_c.getMean();
       aggs.pressure_mean_deci_bar = pressure_deci_bar.getMean();
@@ -127,8 +128,6 @@ void RbrCodaSensor::aggregate(void) {
         aggs.temp_mean_deg_c = -HUGE_VAL;
       } else if (aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
         aggs.temp_mean_deg_c = HUGE_VAL;
-      } else {
-        aggs.temp_mean_deg_c = NAN;
       }
 
       if (aggs.pressure_mean_deci_bar < PRESSURE_SAMPLE_MEMBER_MIN ||

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -390,11 +390,11 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
               break;
             }
             key_str[len] = '\0';
+            if (cbor_value_advance(&sys_cfg_map) != CborNoError) {
+              printf("Failed to advance sys_cfg_map past string key\n");
+              break;
+            }
             if (strcmp(key_str, "rbrCodaType") == 0) {
-              if (cbor_value_advance(&sys_cfg_map) != CborNoError) {
-                printf("Failed to advance the sys_cfg_map\n");
-                break;
-              }
               if (!cbor_value_is_unsigned_integer(&sys_cfg_map)) {
                 printf("expected uint but it is not a string\n");
                 break;
@@ -421,7 +421,7 @@ BmRbrDataMsg::SensorType_t RbrCodaSensor::rbrCodaGetSensorType(uint64_t node_id)
               break;
             }
             if (cbor_value_advance(&sys_cfg_map) != CborNoError) {
-              printf("Failed to advance the sys_cfg_map\n");
+              printf("Failed to advance sys_cfg_map past a value\n");
               break;
             }
           }

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -21,7 +21,7 @@ typedef struct rbr_coda_aggregations_s {
 typedef struct RbrCodaSensor : public AbstractSensor {
   uint32_t rbr_coda_agg_period_ms;
   AveragingSampler temp_deg_c;
-  AveragingSampler pressure_ubar;
+  AveragingSampler pressure_deci_bar;
   uint32_t reading_count;
   BmRbrDataMsg::SensorType_t latest_sensor_type;
   int8_t node_position;
@@ -31,10 +31,10 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.
   static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
-  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 50;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -20;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 84.8572;
   static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 5;
-  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 85;
+  static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 200;
   static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MIN = 0;
   static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 40;
 

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
@@ -49,9 +49,9 @@ bool validSensorDataString(const char *s, size_t strlen) {
 bool validSensorData(DataType_e type, double val) {
   switch (type) {
   case TEMPERATURE: // in degrees C
-    return val >= -5.0 && val <= 50.0;
+    return val >= -40.0 && val <= 125.0;
   case PRESSURE: // in decibar
-    return val >= 5.0 && val <= 85.0;
+    return val >= 5.0 && val <= 200.0;
   default:
     return false;
   }

--- a/test/src/apps/bm_rbr/rbr_sensor_util_ut.cpp
+++ b/test/src/apps/bm_rbr/rbr_sensor_util_ut.cpp
@@ -32,19 +32,19 @@ TEST(rbrSensorUtilTest, InvalidString) {
 
 TEST(rbrSensorUtilTest, validData) {
   EXPECT_TRUE(validSensorData(DataType_e::TEMPERATURE, 17.7684));
-  EXPECT_TRUE(validSensorData(DataType_e::TEMPERATURE, 50.0));
-  EXPECT_TRUE(validSensorData(DataType_e::TEMPERATURE, -5.0));
-  EXPECT_TRUE(validSensorData(DataType_e::PRESSURE, 85.0));
+  EXPECT_TRUE(validSensorData(DataType_e::TEMPERATURE, 125.0));
+  EXPECT_TRUE(validSensorData(DataType_e::TEMPERATURE, -40.0));
+  EXPECT_TRUE(validSensorData(DataType_e::PRESSURE, 200.0));
   EXPECT_TRUE(validSensorData(DataType_e::PRESSURE, 5.0));
   EXPECT_TRUE(validSensorData(DataType_e::PRESSURE, 45));
 }
 
 TEST(rbrSensorUtilTest, InvalidData) {
-  EXPECT_FALSE(validSensorData(DataType_e::TEMPERATURE, 50.1));
-  EXPECT_FALSE(validSensorData(DataType_e::TEMPERATURE, -5.1));
+  EXPECT_FALSE(validSensorData(DataType_e::TEMPERATURE, 125.1));
+  EXPECT_FALSE(validSensorData(DataType_e::TEMPERATURE, -40.1));
   EXPECT_FALSE(validSensorData(DataType_e::PRESSURE, -10));
   EXPECT_FALSE(validSensorData(DataType_e::PRESSURE, 4.9));
-  EXPECT_FALSE(validSensorData(DataType_e::PRESSURE, 85.1));
+  EXPECT_FALSE(validSensorData(DataType_e::PRESSURE, 200.1));
 }
 
 TEST(rbrSensorUtilTest, validOutputFormat) {


### PR DESCRIPTION
Also ended up fixing a misplaced `cbor_value_advance` when the bridge, during aggregation, is determining the type of RBR sensor that is connected to a module downstream. The code would have worked previously if `rbrCodaType` was the first sys cfg key in the cbor map, but it failed to detect the type when it needed to advance past non-matching keys. Also found that `latest_sensor_type` in the RBR sensor driver was never being set.

Bridge log snippet during aggregation after the fix:
```
[BM_COMMON_IND] 8b718c26aea126dc,1,RBR.DT,182999,1711486984.160,182.999,-35.000,199.000
RBR CODA data received from node 8b718c26aea126dc On topic: sensor/8b718c26aea126dc/sofar/bm_rbr_data
[BM_COMMON_IND] 8b718c26aea126dc,1,RBR.DT,183509,1711486984.667,183.509,-34.000,198.000
RBR CODA data received from node 8b718c26aea126dc On topic: sensor/8b718c26aea126dc/sofar/bm_rbr_data
[BM_COMMON_IND] 8b718c26aea126dc,1,RBR.DT,184019,1711486985.179,184.019,-33.000,198.500
Bridge State Sampling Off until 1711487100 epoch seconds
Adin paused, ignoring event 2
Powered device 0 : off
Bridge bus power: 0
Controller task will wait 115000 ms
Aggregation period done!
RBR Node app name: bm_rbr-dbg
Git SHA: 704bf10a
sys_confg_crc: 152998d
rbrCodaType: 3
RBR type RBR.DT
[BM_COMMON_AGG] 8b718c26aea126dc,1,RBR.DT,1711486985.593,521,-inf,198.874,0.739
Adding sample for 8b718c26aea126dc to list
Incrementing sample counter to 1
Found data for node 8b718c26aea126dc adding it to the the report
Clearing the list
Clearing the sample counter
```