### PR TITLE
Always clear the reportBuilder list

### DIFF
--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -799,10 +799,11 @@ static void report_builder_task(void *parameters) {
               bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                              "No nodes to send data for\n");
             }
-            bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-                           "Clearing the list\n");
-            _ctx._reportBuilderLinkedList.clear();
           }
+          // Always clear the list and reset the sample counter when _ctx._sample_counter >= _ctx._samplesPerReport
+          bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                         "Clearing the list\n");
+          _ctx._reportBuilderLinkedList.clear();
           bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                          "Clearing the sample counter\n");
           _ctx._sample_counter = 0;


### PR DESCRIPTION
This is a fix so that we always clear the reportBuilder linked list, even if we have `transmitAggregations = 0`.

https://app.shortcut.com/sofar/story/200593/soft-bow-bugs
