### PR TITLE
fix: soft temperature encoded range

### DIFF
--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.h
@@ -36,7 +36,7 @@ typedef struct RbrCodaSensor : public AbstractSensor {
   static constexpr double PRESSURE_SAMPLE_MEMBER_MIN = 5;
   static constexpr double PRESSURE_SAMPLE_MEMBER_MAX = 200;
   static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MIN = 0;
-  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 40;
+  static constexpr double PRESSURE_STDEV_SAMPLE_MEMBER_MAX = 3.2766;
 
 public:
   bool subscribe() override;

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -102,9 +102,10 @@ void SoftSensor::aggregate(void) {
     if (temp_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
       soft_aggs.temp_mean_deg_c = temp_deg_c.getMean();
       soft_aggs.reading_count = reading_count;
-      if (soft_aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN ||
-          soft_aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
-        soft_aggs.temp_mean_deg_c = NAN;
+      if (soft_aggs.temp_mean_deg_c < TEMP_SAMPLE_MEMBER_MIN) {
+        soft_aggs.temp_mean_deg_c = -HUGE_VAL;
+      } else if (soft_aggs.temp_mean_deg_c > TEMP_SAMPLE_MEMBER_MAX) {
+        soft_aggs.temp_mean_deg_c = HUGE_VAL;
       }
     }
     static constexpr uint8_t TIME_STR_BUFSIZE = 50;

--- a/src/apps/bridge/sensor_drivers/softSensor.h
+++ b/src/apps/bridge/sensor_drivers/softSensor.h
@@ -25,8 +25,8 @@ typedef struct SoftSensor : public AbstractSensor {
   // 2 minutes is the minimum bridge on period and the soft by default is sampling at 2Hz. So 2*120 + 30 = 270.
   static constexpr uint32_t N_SAMPLES_PAD = 270;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
-  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -5;
-  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 50;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -20;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 61.88;
 
 public:
   bool subscribe() override;


### PR DESCRIPTION
Here's a snippet of printf logs from the bridge showing a fake soft giving 100ºC for every sample, which correctly gets aggregated as infinity.

```
SOFT data received from node 8b718c26aea126dc On topic: sensor/8b718c26aea126dc/sofar/bm_soft_temp
[BM_COMMON_IND] 8b718c26aea126dc,1,soft,183261,1711510984.824,0.000,100.000
SOFT data received from node 8b718c26aea126dc On topic: sensor/8b718c26aea126dc/sofar/bm_soft_temp
[BM_COMMON_IND] 8b718c26aea126dc,1,soft,183771,1711510985.335,0.000,100.000
SOFT data received from node 8b718c26aea126dc On topic: sensor/8b718c26aea126dc/sofar/bm_soft_temp
[BM_COMMON_IND] 8b718c26aea126dc,1,soft,184281,1711510985.847,0.000,100.000
Bridge State Sampling Off until 1711511100 epoch seconds
Adin paused, ignoring event 2
Powered device 0 : off
Bridge bus power: 0
Controller task will wait 114000 ms
Aggregation period done!
[BM_COMMON_AGG] 8b718c26aea126dc,1,soft,1711510986.007,577,inf
Adding sample for 8b718c26aea126dc to list
Incrementing sample counter to 1
Found data for node 8b718c26aea126dc adding it to the the report
Clearing the list
Clearing the sample counter
Pub data on topic "spotter/utc-time" from 0000000000000000 Type: 1, Version: 1
Adin paused, ignoring event 0
Updating RTC to 2024-3-27 03:43:08.0808
Adin paused, ignoring event 0
Pub data on topic "spotter/utc-time" from 0000000000000000 Type: 1, Version: 1
Adin paused, ignoring event 0
Updating RTC to 2024-3-27 03:43:18.0808
🏚  Neighbor offline :'( 8b718c26aea126dc
Neighbor 8b718c26aea126dc lost
```