### PR TITLE
don't update a node if it's note in the topology

### DIFF
--- a/src/lib/bcmp/dfu/bm_dfu.h
+++ b/src/lib/bcmp/dfu/bm_dfu.h
@@ -1,95 +1,95 @@
 #pragma once
 
-#include <stdlib.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 // Includes for FreeRTOS
 #include "FreeRTOS.h"
 #include "queue.h"
 
 #include "bcmp_messages.h"
-#include "nvmPartition.h"
-#include "lib_state_machine.h"
 #include "configuration.h"
+#include "lib_state_machine.h"
+#include "nvmPartition.h"
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-#define BM_DFU_MAX_CHUNK_SIZE       (1024) // TODO: put this in an app config header
-#define BM_DFU_MAX_CHUNK_RETRIES    5
+#define BM_DFU_MAX_CHUNK_SIZE (1024) // TODO: put this in an app config header
+#define BM_DFU_MAX_CHUNK_RETRIES 5
 
-#define BM_IMG_PAGE_LENGTH          2048
+#define BM_IMG_PAGE_LENGTH 2048
 
 typedef enum {
-    BM_DFU_ERR_NONE,
-    BM_DFU_ERR_TOO_LARGE,
-    BM_DFU_ERR_SAME_VER,
-    BM_DFU_ERR_MISMATCH_LEN,
-    BM_DFU_ERR_BAD_CRC,
-    BM_DFU_ERR_IMG_CHUNK_ACCESS,
-    BM_DFU_ERR_TIMEOUT,
-    BM_DFU_ERR_BM_FRAME,
-    BM_DFU_ERR_ABORTED,
-    BM_DFU_ERR_WRONG_VER,
-    BM_DFU_ERR_IN_PROGRESS,
-    BM_DFU_ERR_CHUNK_SIZE,
-    // All errors below this are "fatal"
-    BM_DFU_ERR_FLASH_ACCESS,
+  BM_DFU_ERR_NONE,
+  BM_DFU_ERR_TOO_LARGE,
+  BM_DFU_ERR_SAME_VER,
+  BM_DFU_ERR_MISMATCH_LEN,
+  BM_DFU_ERR_BAD_CRC,
+  BM_DFU_ERR_IMG_CHUNK_ACCESS,
+  BM_DFU_ERR_TIMEOUT,
+  BM_DFU_ERR_BM_FRAME,
+  BM_DFU_ERR_ABORTED,
+  BM_DFU_ERR_WRONG_VER,
+  BM_DFU_ERR_IN_PROGRESS,
+  BM_DFU_ERR_CHUNK_SIZE,
+  BM_DFU_ERR_UNKNOWN_NODE_ID,
+  // All errors below this are "fatal"
+  BM_DFU_ERR_FLASH_ACCESS,
 } bm_dfu_err_t;
 
 enum BM_DFU_HFSM_STATES {
-    BM_DFU_STATE_INIT,
-    BM_DFU_STATE_IDLE,
-    BM_DFU_STATE_ERROR,
-    BM_DFU_STATE_CLIENT_RECEIVING,
-    BM_DFU_STATE_CLIENT_VALIDATING,
-    BM_DFU_STATE_CLIENT_REBOOT_REQ,
-    BM_DFU_STATE_CLIENT_REBOOT_DONE,
-    BM_DFU_STATE_CLIENT_ACTIVATING,
-    BM_DFU_STATE_HOST_REQ_UPDATE,
-    BM_DFU_STATE_HOST_UPDATE,
-    BM_NUM_DFU_STATES,
+  BM_DFU_STATE_INIT,
+  BM_DFU_STATE_IDLE,
+  BM_DFU_STATE_ERROR,
+  BM_DFU_STATE_CLIENT_RECEIVING,
+  BM_DFU_STATE_CLIENT_VALIDATING,
+  BM_DFU_STATE_CLIENT_REBOOT_REQ,
+  BM_DFU_STATE_CLIENT_REBOOT_DONE,
+  BM_DFU_STATE_CLIENT_ACTIVATING,
+  BM_DFU_STATE_HOST_REQ_UPDATE,
+  BM_DFU_STATE_HOST_UPDATE,
+  BM_NUM_DFU_STATES,
 };
 
 enum BM_DFU_EVT_TYPE {
-    DFU_EVENT_NONE,
-    DFU_EVENT_INIT_SUCCESS,
-    DFU_EVENT_RECEIVED_UPDATE_REQUEST,
-    DFU_EVENT_CHUNK_REQUEST,
-    DFU_EVENT_IMAGE_CHUNK,
-    DFU_EVENT_UPDATE_END,
-    DFU_EVENT_ACK_RECEIVED,
-    DFU_EVENT_ACK_TIMEOUT,
-    DFU_EVENT_CHUNK_TIMEOUT,
-    DFU_EVENT_HEARTBEAT,
-    DFU_EVENT_ABORT,
-    DFU_EVENT_BEGIN_HOST,
-    DFU_EVENT_REBOOT_REQUEST,
-    DFU_EVENT_REBOOT,
-    DFU_EVENT_BOOT_COMPLETE,
+  DFU_EVENT_NONE,
+  DFU_EVENT_INIT_SUCCESS,
+  DFU_EVENT_RECEIVED_UPDATE_REQUEST,
+  DFU_EVENT_CHUNK_REQUEST,
+  DFU_EVENT_IMAGE_CHUNK,
+  DFU_EVENT_UPDATE_END,
+  DFU_EVENT_ACK_RECEIVED,
+  DFU_EVENT_ACK_TIMEOUT,
+  DFU_EVENT_CHUNK_TIMEOUT,
+  DFU_EVENT_HEARTBEAT,
+  DFU_EVENT_ABORT,
+  DFU_EVENT_BEGIN_HOST,
+  DFU_EVENT_REBOOT_REQUEST,
+  DFU_EVENT_REBOOT,
+  DFU_EVENT_BOOT_COMPLETE,
 };
 
 typedef bool (*bcmp_dfu_tx_func_t)(bcmp_message_type_t type, uint8_t *buff, uint16_t len);
 typedef void (*update_finish_cb_t)(bool success, bm_dfu_err_t error, uint64_t node_id);
 
 typedef struct {
-    uint8_t type;
-    uint8_t * buf;
-    size_t len;
+  uint8_t type;
+  uint8_t *buf;
+  size_t len;
 } bm_dfu_event_t;
 
 typedef struct __attribute__((__packed__)) dfu_host_start_event {
-    bcmp_dfu_start_t start;
-    update_finish_cb_t finish_cb;
-    uint32_t timeoutMs;
+  bcmp_dfu_start_t start;
+  update_finish_cb_t finish_cb;
+  uint32_t timeoutMs;
 } dfu_host_start_event_t;
 
 #define DFU_REBOOT_MAGIC (0xBADC0FFE)
 
-typedef struct  __attribute__((__packed__)) {
+typedef struct __attribute__((__packed__)) {
   uint32_t magic;
   uint8_t major;
   uint8_t minor;
@@ -114,9 +114,11 @@ void bm_dfu_req_next_chunk(uint64_t dst_node_id, uint16_t chunk_num);
 void bm_dfu_update_end(uint64_t dst_node_id, uint8_t success, bm_dfu_err_t err_code);
 void bm_dfu_send_heartbeat(uint64_t dst_node_id);
 
-void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition * dfu_partition, cfg::Configuration* sys_cfg);
-void bm_dfu_process_message(uint8_t * buf, size_t len);
-bool bm_dfu_initiate_update(bm_dfu_img_info_t info, uint64_t dest_node_id, update_finish_cb_t update_finish_callback, uint32_t timeoutMs );
+void bm_dfu_init(bcmp_dfu_tx_func_t bcmp_dfu_tx, NvmPartition *dfu_partition,
+                 cfg::Configuration *sys_cfg);
+void bm_dfu_process_message(uint8_t *buf, size_t len);
+bool bm_dfu_initiate_update(bm_dfu_img_info_t info, uint64_t dest_node_id,
+                            update_finish_cb_t update_finish_callback, uint32_t timeoutMs);
 
 bool bm_dfu_confirm_is_enabled(void);
 void bm_dfu_confirm_enable(bool en);
@@ -125,7 +127,7 @@ void bm_dfu_confirm_enable(bool en);
  * UNIT TEST FUNCTIONS BELOW HERE
  */
 #ifdef CI_TEST
-libSmContext_t* bm_dfu_test_get_sm_ctx(void);
+libSmContext_t *bm_dfu_test_get_sm_ctx(void);
 void bm_dfu_test_set_dfu_event_and_run_sm(bm_dfu_event_t evt);
 void bm_dfu_test_set_client_fa(const struct flash_area *fa);
 #endif //CI_TEST

--- a/src/lib/bm_ncp/ncp_dfu.cpp
+++ b/src/lib/bm_ncp/ncp_dfu.cpp
@@ -142,9 +142,11 @@ bool ncp_dfu_start_cb(bm_serial_dfu_start_t *dfu_start) {
     uint16_t computed_crc16;
     if (!_ctx.dfu_cli_partition->crc16(DFU_IMG_START_OFFSET_BYTES, dfu_start->image_size,
                                        computed_crc16, IMG_CRC_TIMEOUT_MS)) {
+      err = BM_DFU_ERR_BAD_CRC;
       break;
     }
     if (computed_crc16 != dfu_start->crc16) {
+      err = BM_DFU_ERR_BAD_CRC;
       break;
     }
     if (getNodeId() == dfu_start->node_id) {

--- a/src/lib/bm_ncp/ncp_dfu.cpp
+++ b/src/lib/bm_ncp/ncp_dfu.cpp
@@ -112,7 +112,7 @@ static bm_dfu_err_t _do_bcmp_update(bm_serial_dfu_start_t *dfu_start) {
       }
     }
     // If we didn't find the node_id in the list, return an error
-    if (i == num_nodes) {
+    if (i >= num_nodes) {
       rval = BM_DFU_ERR_UNKNOWN_NODE_ID;
       break;
     }


### PR DESCRIPTION
`bridge dfu test.bin abcdef123456 120000 force`

```
2024-03-29T16:52:37.238Z [BM_DFU] [INFO] Transfer complete!
2024-03-29T16:52:37.238Z [BM_DFU] [INFO] Transitioning to state: update
2024-03-29T16:52:37.242Z [BM_DFU] [INFO] File transferred, entering update phase.
2024-03-29T16:52:37.242Z [BM_DFU] [INFO] Opening test.bin
2024-03-29T16:52:37.542Z [BM_DFU] [INFO] Node 0000abcdef123456 update status: 0, 12
Update finished: 0000abcdef123456 success: 0 err:c
```

Will note hotplugging will cause DFU availability delay until topology sampler kicks in (up to 1 min) in the spec upon merge.