### PR TITLE
Sc 201297/bridge power controller ticks

### DIFF
--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -92,6 +92,20 @@ power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
                      strlen(AppConfig::ALIGNMENT_INTERVAL_5MIN), pwrcfg.alignmentInterval5Min);
     save_config = true;
   }
+
+  pwrcfg.ticksSamplingEnabled = BridgePowerController::DEFAULT_TICKS_SAMPLING_ENABLED;
+  if (!syscfg.getConfig(AppConfig::kTicksSamplingEnabled,
+                        strlen(AppConfig::kTicksSamplingEnabled),
+                        pwrcfg.ticksSamplingEnabled)) {
+    bridgeLogPrint(
+        BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+        "Failed to get alignment ticks sampling enabled from config, using default value and "
+        "writing to config: %" PRIu32 "ms\n",
+        pwrcfg.ticksSamplingEnabled);
+    syscfg.setConfig(AppConfig::kTicksSamplingEnabled, strlen(AppConfig::kTicksSamplingEnabled),
+                     pwrcfg.ticksSamplingEnabled);
+    save_config = true;
+  }
   if (save_config) {
     syscfg.saveConfig(false);
   }

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -94,15 +94,15 @@ power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
   }
 
   pwrcfg.ticksSamplingEnabled = BridgePowerController::DEFAULT_TICKS_SAMPLING_ENABLED;
-  if (!syscfg.getConfig(AppConfig::kTicksSamplingEnabled,
-                        strlen(AppConfig::kTicksSamplingEnabled),
+  if (!syscfg.getConfig(AppConfig::TICKS_SAMPLING_ENABLED,
+                        strlen(AppConfig::TICKS_SAMPLING_ENABLED),
                         pwrcfg.ticksSamplingEnabled)) {
     bridgeLogPrint(
         BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
         "Failed to get alignment ticks sampling enabled from config, using default value and "
         "writing to config: %" PRIu32 "ms\n",
         pwrcfg.ticksSamplingEnabled);
-    syscfg.setConfig(AppConfig::kTicksSamplingEnabled, strlen(AppConfig::kTicksSamplingEnabled),
+    syscfg.setConfig(AppConfig::TICKS_SAMPLING_ENABLED, strlen(AppConfig::TICKS_SAMPLING_ENABLED),
                      pwrcfg.ticksSamplingEnabled);
     save_config = true;
   }

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -99,7 +99,7 @@ power_config_s getPowerConfigs(cfg::Configuration &syscfg) {
                         pwrcfg.ticksSamplingEnabled)) {
     bridgeLogPrint(
         BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-        "Failed to get alignment ticks sampling enabled from config, using default value and "
+        "Failed to get ticks sampling enabled from config, using default value and "
         "writing to config: %" PRIu32 "ms\n",
         pwrcfg.ticksSamplingEnabled);
     syscfg.setConfig(AppConfig::TICKS_SAMPLING_ENABLED, strlen(AppConfig::TICKS_SAMPLING_ENABLED),

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -19,7 +19,7 @@ constexpr const char *SAMPLES_PER_REPORT = "samplesPerReport";
 constexpr const char *CURRENT_READING_PERIOD_MS = "currentReadingPeriodMs";
 constexpr const char *SOFT_READING_PERIOD_MS = "softReadingPeriodMs";
 constexpr const char *RBR_CODA_READING_PERIOD_MS = "rbrCodaReadingPeriodMs";
-constexpr const char *kTicksSamplingEnabled = "ticksSamplingEnabled";
+constexpr const char *TICKS_SAMPLING_ENABLED = "ticksSamplingEnabled";
 
 } // namespace AppConfig
 

--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -19,12 +19,14 @@ constexpr const char *SAMPLES_PER_REPORT = "samplesPerReport";
 constexpr const char *CURRENT_READING_PERIOD_MS = "currentReadingPeriodMs";
 constexpr const char *SOFT_READING_PERIOD_MS = "softReadingPeriodMs";
 constexpr const char *RBR_CODA_READING_PERIOD_MS = "rbrCodaReadingPeriodMs";
+constexpr const char *kTicksSamplingEnabled = "ticksSamplingEnabled";
 
 } // namespace AppConfig
 
 struct power_config_s {
   uint32_t sampleIntervalMs, sampleDurationMs, subsampleIntervalMs, subsampleDurationMs,
-      subsampleEnabled, bridgePowerControllerEnabled, alignmentInterval5Min;
+      subsampleEnabled, bridgePowerControllerEnabled, alignmentInterval5Min,
+      ticksSamplingEnabled;
 };
 
 power_config_s getPowerConfigs(cfg::Configuration &syscfg);

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -372,7 +372,8 @@ static void defaultTask(void *parameters) {
       VBUS_SW_EN, pwrcfg.sampleIntervalMs, pwrcfg.sampleDurationMs, pwrcfg.subsampleIntervalMs,
       pwrcfg.subsampleDurationMs, static_cast<bool>(pwrcfg.subsampleEnabled),
       static_cast<bool>(pwrcfg.bridgePowerControllerEnabled),
-      (pwrcfg.alignmentInterval5Min * BridgePowerController::ALIGNMENT_INCREMENT_S));
+      (pwrcfg.alignmentInterval5Min * BridgePowerController::ALIGNMENT_INCREMENT_S),
+      static_cast<bool>(pwrcfg.ticksSamplingEnabled));
 
   ncpInit(&usart3, &dfu_partition, &bridge_power_controller, &debug_configuration_user,
           &debug_configuration_system, &debug_configuration_hardware);

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -350,8 +350,8 @@ uint32_t BridgePowerController::_alignNextInterval(uint32_t nowEpochS,
       // but the code would get much more complicated.
       alignedEpoch += adjustment;
       bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-                     "Aligning next sample interval to UTC by delaying an additional %" PRIu32
-                     " seconds to %" PRIu32 "\n",
+                     "Aligning next sample interval to %s by delaying an additional %" PRIu32
+                     " seconds to %" PRIu32 "\n", (_ticksSamplingEnabled) ? "uptime" : "UTC",
                      adjustment, alignedEpoch);
     }
   }

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -139,9 +139,10 @@ void BridgePowerController::subsampleEnable(bool enable) { _subsamplingEnabled =
 
 bool BridgePowerController::isSubsampleEnabled() { return _subsamplingEnabled; }
 
-static void stateLogPrintTarget(const char *state, uint32_t target) {
+void BridgePowerController::stateLogPrintTarget(const char *state, uint32_t target) {
   bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-                 "Bridge State %s until %" PRIu32 " epoch seconds\n", state, target);
+                 "Bridge State %s until %" PRIu32 " %s seconds\n", state, target,
+                 (_ticksSamplingEnabled) ? "uptime" : "epoch");
 }
 
 void BridgePowerController::_update(void) {

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -241,14 +241,14 @@ void BridgePowerController::_update(void) {
           powerBusAndSetSignal(true);
         }
       } else if (!_timebaseSet && _powerControlEnabled && IORead(&_BusPowerPin, &enabled)) {
-        if (enabled) { // If our RTC is not set and we've enabled the power manager, we should disable the VBUS
-          bridgeLogPrint(
-              BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-              "Bridge State Disabled - controller enabled, but RTC is not yet set - bus off\n");
+        if (enabled) { // If our timebase is not set and we've enabled the power manager, we should disable the VBUS
+          bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                         "Bridge State Disabled - controller enabled, but timebase is not yet "
+                         "set - bus off\n");
           powerBusAndSetSignal(false);
         }
 
-        // Align the first sample to UTC when the RTC finally gets set
+        // Align the first sample to UTC or tick offset when the timebase finally gets set
         checkAndUpdateTimebase();
         uint32_t currentCycleS = getCurrentTimeS();
         if (_timebaseSet && _sampleIntervalStartS > currentCycleS) {
@@ -298,7 +298,7 @@ bool BridgePowerController::getAdinDevice() {
 }
 
 void BridgePowerController::checkAndUpdateTimebase() {
-  if ((isRTCSet() && !_timebaseSet) || _ticksSamplingEnabled) {
+  if ((isRTCSet() || _ticksSamplingEnabled) && !_timebaseSet) {
     printf("Bridge Power Controller timebase is set.\n");
     _sampleIntervalStartS =
         _alignNextInterval(getCurrentTimeS(), _sampleIntervalStartS, _sampleIntervalS);

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -16,12 +16,13 @@
 BridgePowerController::BridgePowerController(
     IOPinHandle_t &BusPowerPin, uint32_t sampleIntervalMs, uint32_t sampleDurationMs,
     uint32_t subsampleIntervalMs, uint32_t subsampleDurationMs, bool subsamplingEnabled,
-    bool powerControllerEnabled, uint32_t alignmentS)
+    bool powerControllerEnabled, uint32_t alignmentS, bool ticksSamplingEnabled)
     : _BusPowerPin(BusPowerPin), _powerControlEnabled(powerControllerEnabled),
       _sampleIntervalS(sampleIntervalMs / 1000), _sampleDurationS(sampleDurationMs / 1000),
       _subsampleIntervalS(subsampleIntervalMs / 1000),
       _subsampleDurationS(subsampleDurationMs / 1000), _sampleIntervalStartS(0),
-      _subsampleIntervalStartS(0), _alignmentS(alignmentS), _rtcSet(false), _initDone(false),
+      _subsampleIntervalStartS(0), _alignmentS(alignmentS),
+      _ticksSamplingEnabled(ticksSamplingEnabled), _rtcSet(false), _initDone(false),
       _subsamplingEnabled(subsamplingEnabled), _configError(false), _adin_handle(NULL) {
   if (_sampleIntervalS > MAX_SAMPLE_INTERVAL_S || _sampleIntervalS < MIN_SAMPLE_INTERVAL_S) {
     printf("INVALID SAMPLE INTERVAL, using default.\n");

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -323,7 +323,7 @@ uint32_t BridgePowerController::getCurrentTimeS() {
  *
  * Given the current epoch time, the last interval start time, and the
  * duration of an interval, return the start time of the next interval
- * aligned to UTC according to the alignment config value.
+ * aligned to uptime or UTC according to the alignment config value.
  *
  * \param[in] nowEpochS - The current time in seconds since epoch.
  * \param[in] lastIntervalStartS - The start time of the last interval in seconds since epoch.
@@ -340,7 +340,7 @@ uint32_t BridgePowerController::_alignNextInterval(uint32_t nowEpochS,
     alignedEpoch += sampleIntervalS;
   }
 
-  // If an alignment is configured, we need to align sampling intervals to UTC.
+  // If an alignment is configured, we need to align sampling intervals to uptime or UTC.
   if (_alignmentS != 0) {
     uint32_t remainder = alignedEpoch % _alignmentS;
     if (remainder != 0) {

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -67,8 +67,8 @@ BridgePowerController::BridgePowerController(
 }
 
 /*!
-* Enable / disable the power control. If the power control is disabled (and RTC is set) the bus is ON.
-* If the the power control is disabled and RTC is not set, the bus is OFF
+* Enable / disable the power control. If the power control is disabled (and timebase is set) the bus is ON.
+* If the the power control is disabled and timebase is not set, the bus is OFF
 * If power control is enabled, bus control is set by the min/max control parameters.
 * \param[in] : enable - true if power control is enabled, false if off.
 */
@@ -334,7 +334,7 @@ uint32_t BridgePowerController::_alignNextInterval(uint32_t nowEpochS,
                                                    uint32_t sampleIntervalS) {
   uint32_t alignedEpoch = lastIntervalStartS + sampleIntervalS;
   while (alignedEpoch < nowEpochS) {
-    // If the aligned epoch is in the past, the RTC must have just jumped forward.
+    // If the aligned epoch is in the past, the timebase must have just jumped forward.
     // We need to add sample intervals until we reach the future.
     alignedEpoch += sampleIntervalS;
   }

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -37,6 +37,7 @@ private:
   bool getAdinDevice();
   void checkAndUpdateTimebase();
   uint32_t getCurrentTimeS();
+  void stateLogPrintTarget(const char *state, uint32_t target);
 
 public:
   static constexpr uint32_t OFF = (1 << 0);

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -11,13 +11,12 @@
 class BridgePowerController {
 public:
   explicit BridgePowerController(
-      IOPinHandle_t &BusPowerPin,
-      uint32_t sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_S * 1000,
+      IOPinHandle_t &BusPowerPin, uint32_t sampleIntervalMs = DEFAULT_SAMPLE_INTERVAL_S * 1000,
       uint32_t sampleDurationMs = DEFAULT_SAMPLE_DURATION_S * 1000,
       uint32_t subsampleIntervalMs = DEFAULT_SUBSAMPLE_INTERVAL_S * 1000,
       uint32_t subsampleDurationMs = DEFAULT_SUBSAMPLE_DURATION_S * 1000,
       bool subsamplingEnabled = false, bool powerControllerEnabled = false,
-      uint32_t alignmentS = DEFAULT_ALIGNMENT_S);
+      uint32_t alignmentS = DEFAULT_ALIGNMENT_S, bool ticksSamplingEnabled = false);
   void powerControlEnable(bool enable);
   bool isPowerControlEnabled();
   void subsampleEnable(bool enable);
@@ -49,7 +48,8 @@ public:
   static constexpr uint32_t DEFAULT_SUBSAMPLE_INTERVAL_S = (60);
   static constexpr uint32_t DEFAULT_SUBSAMPLE_DURATION_S = (30);
   static constexpr uint32_t MIN_SAMPLE_DURATION_S = (6);
-  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S = (6); // Set to 6s to allow for enough time for devices to broadcast for the topology.
+  static constexpr uint32_t MIN_SAMPLE_INTERVAL_S =
+      (6); // Set to 6s to allow for enough time for devices to broadcast for the topology.
   static constexpr uint32_t MAX_SAMPLE_INTERVAL_S = (24 * 60 * 60);
   static constexpr uint32_t MAX_SAMPLE_DURATION_S = (24 * 60 * 60);
   static constexpr uint32_t MIN_SUBSAMPLE_INTERVAL_S = (6);
@@ -60,6 +60,7 @@ public:
   static constexpr uint32_t ALIGNMENT_INCREMENT_S = (5 * 60);
   static constexpr uint32_t MAX_ALIGNMENT_S = (24 * 60 * 60);
   static constexpr uint32_t DEFAULT_ALIGNMENT_5_MIN_INTERVAL = (1);
+  static constexpr uint32_t DEFAULT_TICKS_SAMPLING_ENABLED = (0);
 
 private:
   static constexpr uint32_t MIN_TASK_SLEEP_MS = (1000);
@@ -75,6 +76,7 @@ private:
   uint32_t _sampleIntervalStartS;
   uint32_t _subsampleIntervalStartS;
   uint32_t _alignmentS;
+  bool _ticksSamplingEnabled;
 
   bool _rtcSet;
   bool _initDone;

--- a/src/apps/bridge/bridgePowerController.h
+++ b/src/apps/bridge/bridgePowerController.h
@@ -35,8 +35,8 @@ private:
   void powerBusAndSetSignal(bool on, bool notifyL2 = true);
   static void powerControllerRun(void *arg);
   bool getAdinDevice();
-  void checkAndUpdateRTC();
-  uint32_t getEpochS();
+  void checkAndUpdateTimebase();
+  uint32_t getCurrentTimeS();
 
 public:
   static constexpr uint32_t OFF = (1 << 0);
@@ -78,7 +78,7 @@ private:
   uint32_t _alignmentS;
   bool _ticksSamplingEnabled;
 
-  bool _rtcSet;
+  bool _timebaseSet;
   bool _initDone;
   bool _subsamplingEnabled;
   bool _configError;


### PR DESCRIPTION
Main changes:
* Adding `kTicksSamplingEnabled` configuration for ticks sampling
* Use ticks as the timebase instead of RTC if config is enabled
* Rename a lot of variables
* Unit tests

This approach rolls over every ~50 days for sampling (which causes either an extra long period or extra short period). We could write/re-write the ticks implementation to better handle rolls - but this is a larger effort and probably should be separate from this PR. 

Soak logs

[0000_BRIDGE_CFG.log](https://github.com/bristlemouth/bm_protocol/files/14923297/0000_BRIDGE_CFG.log)
[0000_BRIDGE_SYS.log](https://github.com/bristlemouth/bm_protocol/files/14923298/0000_BRIDGE_SYS.log)
