### PR TITLE
fix: Handle RBR reading simultaneous with probeType

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -80,7 +80,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       success = handleDataString(_payload_buffer, read_len, d);
     } else {
       bm_fprintf(0, RBR_RAW_LOG, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
-      bm_printf(0, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
+      bm_printf(0, "Invalid line from sensor: %.*s", read_len, _payload_buffer);
       printf("Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
     }
   }
@@ -89,10 +89,10 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
   if (_awaitingProbeResponse && uptimeGetMs() - _lastProbeTime >= PROBE_TYPE_TIMEOUT_MS) {
     _awaitingProbeResponse = false;
     _sensorDropDebounceCount++;
-    if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
+    if (_sensorDropDebounceCount == SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
       _type = BmRbrDataMsg::SensorType::UNKNOWN;
       bm_fprintf(0, RBR_RAW_LOG, "RBR sensor was lost\n");
-      bm_printf(0, "RBR sensor was lost\n");
+      bm_printf(0, "RBR sensor was lost");
       printf("RBR sensor was lost\n");
     }
   }
@@ -104,7 +104,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
   // If the sensor was previously lost, print a message that it is back online.
   if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
     bm_fprintf(0, RBR_RAW_LOG, "RBR sensor online\n");
-    bm_printf(0, "RBR sensor online\n");
+    bm_printf(0, "RBR sensor online");
     printf("RBR sensor online\n");
   }
   _sensorDropDebounceCount = 0;
@@ -118,7 +118,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
       bm_fprintf(0, RBR_RAW_LOG, "Detected temp & pressure sensor, saving config\n");
-      bm_printf(0, "Detected temp & pressure sensor, saving config\n");
+      bm_printf(0, "Detected temp & pressure sensor, saving config");
       printf("Detected temp & pressure sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
     }
@@ -129,7 +129,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE));
       bm_fprintf(0, RBR_RAW_LOG, "Detected pressure sensor, saving config\n");
-      bm_printf(0, "Detected pressure sensor, saving config\n");
+      bm_printf(0, "Detected pressure sensor, saving config");
       printf("Detected pressure sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
     }
@@ -140,14 +140,14 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::TEMPERATURE));
       bm_fprintf(0, RBR_RAW_LOG, "Detected temp sensor, saving config\n");
-      bm_printf(0, "Detected temp sensor, saving config\n");
+      bm_printf(0, "Detected temp sensor, saving config");
       printf("Detected temp sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
     }
     _type = BmRbrDataMsg::SensorType::TEMPERATURE;
   } else {
     bm_fprintf(0, RBR_RAW_LOG, "Invalid outputformat: %s\n", s);
-    bm_printf(0, "Invalid outputformat: %s\n", s);
+    bm_printf(0, "Invalid outputformat: %s", s);
     printf("Invalid outputformat: %s\n", s);
   }
 }

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -15,13 +15,19 @@
 
 extern cfg::Configuration *systemConfigurationPartition;
 
+// Preventing typos. These strings are used several times.
+static constexpr char PRESSURE[] = "pressure";
+static constexpr char TEMPERATURE[] = "temperature";
+
 /*!
 * @brief Initialize the RBR sensor driver.
 * @param type The sensor type.
+* @param min_probe_period_ms How often to check the sensor type in milliseconds.
 */
-void RbrSensor::init(BmRbrDataMsg::SensorType_t type) {
+void RbrSensor::init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms) {
   _type = type;
   _stored_type = type;
+  _minProbePeriodMs = min_probe_period_ms;
   for (int i = 0; i < NUM_PARSERS; i++) {
     if (_parsers[i]) {
       _parsers[i]->init();
@@ -48,213 +54,203 @@ void RbrSensor::init(BmRbrDataMsg::SensorType_t type) {
 }
 
 /*!
-* @brief Probe the sensor type.
-* @param timeout_ms The timeout in milliseconds.
-* @return True if the sensor type was successfully probed, false otherwise.
+* @brief Probe the sensor type if enough time has passed.
 */
-bool RbrSensor::probeType(uint32_t timeout_ms) {
-  uint32_t start = uptimeGetMs();
-  PLUART::write((uint8_t *)typeCommand, strlen(typeCommand));
+void RbrSensor::maybeProbeType(void) {
+  if (uptimeGetMs() - _lastProbeTime >= _minProbePeriodMs) {
+    PLUART::write((uint8_t *)typeCommand, strlen(typeCommand));
+    _lastProbeTime = uptimeGetMs();
+    _awaitingProbeResponse = true;
+  }
+}
+
+/*!
+ * @brief Handle a line of output from the sensor payload.
+ * @param d The sensor data to be filled in.
+ * @return True if sensor data was successfully read and parsed.
+ */
+bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
   bool success = false;
-  do {
-    if (PLUART::lineAvailable()) {
-      PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
-      if (BmRbrSensorUtil::validSensorOutputformat(_payload_buffer, strlen(_payload_buffer))) {
-        if (strstr(_payload_buffer, "pressure") != NULL &&
-            strstr(_payload_buffer, "temperature") != NULL) {
-          if (_stored_type != BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
-            systemConfigurationPartition->setConfig(
-                "rbrCodaType", strlen("rbrCodaType"),
-                static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
-            bm_fprintf(0, RBR_RAW_LOG, "Detected temp/pressure sensor, saving config\n");
-            bm_printf(0, "Detected temp/pressure sensor, saving config\n");
-            printf("Detected temp/pressure sensor, saving config.\n");
-            systemConfigurationPartition->saveConfig(); // reboot
-          }
-          _type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
-          success = true;
-          break;
-        } else if (strstr(_payload_buffer, "pressure") != NULL) {
-          if (_stored_type != BmRbrDataMsg::SensorType::PRESSURE) {
-            systemConfigurationPartition->setConfig(
-                "rbrCodaType", strlen("rbrCodaType"),
-                static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE));
-            bm_fprintf(0, RBR_RAW_LOG, "Detected pressure sensor, saving config\n");
-            bm_printf(0, "Detected pressure sensor, saving config\n");
-            printf("Detected pressure sensor, saving config.\n");
-            systemConfigurationPartition->saveConfig(); // reboot
-          }
-          _type = BmRbrDataMsg::SensorType::PRESSURE;
-          success = true;
-          break;
-        } else if (strstr(_payload_buffer, "temperature") != NULL) {
-          if (_stored_type != BmRbrDataMsg::SensorType::TEMPERATURE) {
-            systemConfigurationPartition->setConfig(
-                "rbrCodaType", strlen("rbrCodaType"),
-                static_cast<uint32_t>(BmRbrDataMsg::SensorType::TEMPERATURE));
-            bm_fprintf(0, RBR_RAW_LOG, "Detected temp sensor, saving config\n");
-            bm_printf(0, "Detected temp sensor, saving config\n");
-            printf("Detected temp sensor, saving config.\n");
-            systemConfigurationPartition->saveConfig(); // reboot
-          }
-          _type = BmRbrDataMsg::SensorType::TEMPERATURE;
-          success = true;
-          break;
-        } else {
-          bm_fprintf(0, RBR_RAW_LOG, "Invalid outputformat: %s\n", _payload_buffer);
-          bm_printf(0, "Invalid outputformat: %s\n", _payload_buffer);
-          printf("Invalid outputformat: %s\n", _payload_buffer);
-        }
-      } else {
-        bm_fprintf(0, RBR_RAW_LOG, "Invalid outputformat: %s\n", _payload_buffer);
-        bm_printf(0, "Invalid outputformat: %s\n", _payload_buffer);
-        printf("Invalid outputformat: %s\n", _payload_buffer);
-      }
+  if (PLUART::lineAvailable()) {
+    uint16_t read_len = PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
+    BmRbrSensorUtil::preprocessLine(_payload_buffer, read_len);
+    if (BmRbrSensorUtil::validSensorOutputformat(_payload_buffer, read_len)) {
+      handleOutputformat(_payload_buffer, read_len);
+    } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
+      success = handleDataString(_payload_buffer, read_len, d);
+    } else {
+      bm_fprintf(0, RBR_RAW_LOG, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
+      bm_printf(0, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
+      printf("Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
     }
-    vTaskDelay(pdMS_TO_TICKS(100));
-  } while (uptimeGetMs() - start < timeout_ms);
-  if (!success) {
-    if (++_sensorDropDebounceCount == SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
+  }
+
+  // If we are awaiting a probe response, check for a timeout.
+  if (_awaitingProbeResponse && uptimeGetMs() - _lastProbeTime >= PROBE_TYPE_TIMEOUT_MS) {
+    _awaitingProbeResponse = false;
+    _sensorDropDebounceCount++;
+    if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
       _type = BmRbrDataMsg::SensorType::UNKNOWN;
       bm_fprintf(0, RBR_RAW_LOG, "RBR sensor was lost\n");
       bm_printf(0, "RBR sensor was lost\n");
       printf("RBR sensor was lost\n");
     }
-  } else {
-    if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
-      bm_fprintf(0, RBR_RAW_LOG, "RBR sensor online\n");
-      bm_printf(0, "RBR sensor online\n");
-      printf("RBR sensor online\n");
-    }
-    _sensorDropDebounceCount = 0;
   }
+
   return success;
 }
 
-/*!
-  * @brief Get the sensor data from the payload.
-  * @param d The sensor data to be filled in.
-  * @return True if the sensor data was successfully read and parsed.
-*/
-bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
-  bool rval = false;
-  do {
-    // Read a line if it is available
-    if (PLUART::lineAvailable()) {
-      uint16_t read_len = PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
+void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
+  // If the sensor was previously lost, print a message that it is back online.
+  if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
+    bm_fprintf(0, RBR_RAW_LOG, "RBR sensor online\n");
+    bm_printf(0, "RBR sensor online\n");
+    printf("RBR sensor online\n");
+  }
+  _sensorDropDebounceCount = 0;
+  _awaitingProbeResponse = false;
 
-      // Get the RTC if available
-      RTCTimeAndDate_t time_and_date = {};
-      rtcGet(&time_and_date);
-      char rtcTimeBuffer[32] = {};
-      rtcPrint(rtcTimeBuffer, NULL);
-      if (_sensorBmLogEnable) {
-        bm_fprintf(0, RBR_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
-                   rtcTimeBuffer, read_len, _payload_buffer);
-      }
-      bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
-                read_len, _payload_buffer);
-      printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
-             read_len, _payload_buffer);
-
-      BmRbrSensorUtil::preprocessLine(_payload_buffer, read_len);
-
-      if (!BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
-        bm_fprintf(0, RBR_RAW_LOG, "Invalid sensor data string: %.*s\n", read_len,
-                   _payload_buffer);
-        bm_printf(0, "Invalid sensor data string: %.*s\n", read_len, _payload_buffer);
-        printf("Invalid sensor data string: %.*s\n", read_len, _payload_buffer);
-        break;
-      }
-
-      // Now when we get a line of text data, our LineParser turns it into numeric values.
-      if (_parsers[_type] && _parsers[_type]->parseLine(_payload_buffer, read_len)) {
-        switch (_type) {
-        case BmRbrDataMsg::SensorType::TEMPERATURE: {
-          Value timeValue = _parsers[_type]->getValue(0);
-          Value tempValue = _parsers[_type]->getValue(1);
-          if (timeValue.type != TYPE_UINT64 || tempValue.type != TYPE_DOUBLE) {
-            printf("Parsed invalid values: time: %d, temp: %d\n", timeValue.type,
-                   tempValue.type);
-            break;
-          }
-          if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::TEMPERATURE,
-                                                tempValue.data.double_val)) {
-            printf("Invalid temperature value: %lf\n", tempValue.data.double_val);
-            break;
-          }
-          d.sensor_type = BmRbrDataMsg::SensorType::TEMPERATURE;
-          d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-          d.header.reading_uptime_millis = uptimeGetMs();
-          d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
-          d.temperature_deg_c = tempValue.data.double_val;
-          d.pressure_deci_bar = NAN;
-          rval = true;
-          break;
-        }
-        case BmRbrDataMsg::SensorType::PRESSURE: {
-          Value timeValue = _parsers[_type]->getValue(0);
-          Value pressureValue = _parsers[_type]->getValue(1);
-          if (timeValue.type != TYPE_UINT64 || pressureValue.type != TYPE_DOUBLE) {
-            printf("Parsed invalid types: time: %d, pressure: %d\n", timeValue.type,
-                   pressureValue.type);
-            break;
-          }
-          if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::PRESSURE,
-                                                pressureValue.data.double_val)) {
-            printf("Invalid pressure value: %lf\n", pressureValue.data.double_val);
-            break;
-          }
-          d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE;
-          d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-          d.header.reading_uptime_millis = uptimeGetMs();
-          d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
-          d.temperature_deg_c = NAN;
-          d.pressure_deci_bar = pressureValue.data.double_val;
-          rval = true;
-          break;
-        }
-        case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
-          Value timeValue = _parsers[_type]->getValue(0);
-          Value tempValue = _parsers[_type]->getValue(1);
-          Value pressureValue = _parsers[_type]->getValue(2);
-          if (timeValue.type != TYPE_UINT64 || tempValue.type != TYPE_DOUBLE ||
-              pressureValue.type != TYPE_DOUBLE) {
-            printf("Parsed invalid types: time: %d, temp: %d, pressure: %d\n", timeValue.type,
-                   tempValue.type, pressureValue.type);
-            break;
-          }
-          if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::TEMPERATURE,
-                                                tempValue.data.double_val)) {
-            printf("Invalid temperature value: %lf\n", tempValue.data.double_val);
-            break;
-          }
-          if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::PRESSURE,
-                                                pressureValue.data.double_val)) {
-            printf("Invalid pressure value: %lf\n", pressureValue.data.double_val);
-            break;
-          }
-          d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
-          d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-          d.header.reading_uptime_millis = uptimeGetMs();
-          d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
-          d.temperature_deg_c = tempValue.data.double_val;
-          d.pressure_deci_bar = pressureValue.data.double_val;
-          rval = true;
-          break;
-        }
-        default: {
-          printf("Invalid rbr sensor type: %d\n", _type);
-          break;
-        }
-        }
-      } else {
-        printf("Error parsing line!\n");
-        break;
-      }
+  // Check whether the sensor type has changed.
+  // If so, save the new type and reboot.
+  if (strnstr(s, PRESSURE, read_len) != NULL && strnstr(s, TEMPERATURE, read_len) != NULL) {
+    if (_stored_type != BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE) {
+      systemConfigurationPartition->setConfig(
+          CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
+          static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
+      bm_fprintf(0, RBR_RAW_LOG, "Detected temp & pressure sensor, saving config\n");
+      bm_printf(0, "Detected temp & pressure sensor, saving config\n");
+      printf("Detected temp & pressure sensor, saving config.\n");
+      systemConfigurationPartition->saveConfig(); // reboot
     }
-  } while (0);
-  return rval;
+    _type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
+  } else if (strnstr(s, PRESSURE, read_len) != NULL) {
+    if (_stored_type != BmRbrDataMsg::SensorType::PRESSURE) {
+      systemConfigurationPartition->setConfig(
+          CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
+          static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE));
+      bm_fprintf(0, RBR_RAW_LOG, "Detected pressure sensor, saving config\n");
+      bm_printf(0, "Detected pressure sensor, saving config\n");
+      printf("Detected pressure sensor, saving config.\n");
+      systemConfigurationPartition->saveConfig(); // reboot
+    }
+    _type = BmRbrDataMsg::SensorType::PRESSURE;
+  } else if (strnstr(s, TEMPERATURE, read_len) != NULL) {
+    if (_stored_type != BmRbrDataMsg::SensorType::TEMPERATURE) {
+      systemConfigurationPartition->setConfig(
+          CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
+          static_cast<uint32_t>(BmRbrDataMsg::SensorType::TEMPERATURE));
+      bm_fprintf(0, RBR_RAW_LOG, "Detected temp sensor, saving config\n");
+      bm_printf(0, "Detected temp sensor, saving config\n");
+      printf("Detected temp sensor, saving config.\n");
+      systemConfigurationPartition->saveConfig(); // reboot
+    }
+    _type = BmRbrDataMsg::SensorType::TEMPERATURE;
+  } else {
+    bm_fprintf(0, RBR_RAW_LOG, "Invalid outputformat: %s\n", s);
+    bm_printf(0, "Invalid outputformat: %s\n", s);
+    printf("Invalid outputformat: %s\n", s);
+  }
+}
+
+bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::Data &d) {
+  bool success = false;
+  RTCTimeAndDate_t time_and_date = {};
+  rtcGet(&time_and_date);
+  char rtcTimeBuffer[32] = {};
+  rtcPrint(rtcTimeBuffer, NULL);
+  if (_sensorBmLogEnable) {
+    bm_fprintf(0, RBR_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
+               rtcTimeBuffer, read_len, s);
+  }
+  bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
+            read_len, s);
+  printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
+         read_len, s);
+
+  // Use LineParser to turn string data into numeric values.
+  if (_parsers[_type] && _parsers[_type]->parseLine(s, read_len)) {
+    switch (_type) {
+    case BmRbrDataMsg::SensorType::TEMPERATURE: {
+      Value timeValue = _parsers[_type]->getValue(0);
+      Value tempValue = _parsers[_type]->getValue(1);
+      if (timeValue.type != TYPE_UINT64 || tempValue.type != TYPE_DOUBLE) {
+        printf("Parsed invalid values: time: %d, temp: %d\n", timeValue.type, tempValue.type);
+        break;
+      }
+      if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::TEMPERATURE,
+                                            tempValue.data.double_val)) {
+        printf("Invalid temperature value: %lf\n", tempValue.data.double_val);
+        break;
+      }
+      d.sensor_type = BmRbrDataMsg::SensorType::TEMPERATURE;
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      d.header.reading_uptime_millis = uptimeGetMs();
+      d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
+      d.temperature_deg_c = tempValue.data.double_val;
+      d.pressure_deci_bar = NAN;
+      success = true;
+      break;
+    }
+    case BmRbrDataMsg::SensorType::PRESSURE: {
+      Value timeValue = _parsers[_type]->getValue(0);
+      Value pressureValue = _parsers[_type]->getValue(1);
+      if (timeValue.type != TYPE_UINT64 || pressureValue.type != TYPE_DOUBLE) {
+        printf("Parsed invalid types: time: %d, pressure: %d\n", timeValue.type,
+               pressureValue.type);
+        break;
+      }
+      if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::PRESSURE,
+                                            pressureValue.data.double_val)) {
+        printf("Invalid pressure value: %lf\n", pressureValue.data.double_val);
+        break;
+      }
+      d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE;
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      d.header.reading_uptime_millis = uptimeGetMs();
+      d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
+      d.temperature_deg_c = NAN;
+      d.pressure_deci_bar = pressureValue.data.double_val;
+      success = true;
+      break;
+    }
+    case BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE: {
+      Value timeValue = _parsers[_type]->getValue(0);
+      Value tempValue = _parsers[_type]->getValue(1);
+      Value pressureValue = _parsers[_type]->getValue(2);
+      if (timeValue.type != TYPE_UINT64 || tempValue.type != TYPE_DOUBLE ||
+          pressureValue.type != TYPE_DOUBLE) {
+        printf("Parsed invalid types: time: %d, temp: %d, pressure: %d\n", timeValue.type,
+               tempValue.type, pressureValue.type);
+        break;
+      }
+      if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::TEMPERATURE,
+                                            tempValue.data.double_val)) {
+        printf("Invalid temperature value: %lf\n", tempValue.data.double_val);
+        break;
+      }
+      if (!BmRbrSensorUtil::validSensorData(BmRbrSensorUtil::PRESSURE,
+                                            pressureValue.data.double_val)) {
+        printf("Invalid pressure value: %lf\n", pressureValue.data.double_val);
+        break;
+      }
+      d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      d.header.reading_uptime_millis = uptimeGetMs();
+      d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
+      d.temperature_deg_c = tempValue.data.double_val;
+      d.pressure_deci_bar = pressureValue.data.double_val;
+      success = true;
+      break;
+    }
+    default: {
+      printf("Invalid rbr sensor type: %d\n", _type);
+      break;
+    }
+    }
+  } else {
+    printf("Error parsing line!\n");
+  }
+  return success;
 }
 
 /*!

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
@@ -8,15 +8,21 @@ public:
   RbrSensor()
       : _type(BmRbrDataMsg::SensorType_t::UNKNOWN),
         _stored_type(BmRbrDataMsg::SensorType_t::UNKNOWN), _sensorDropDebounceCount(0),
-        _sensorBmLogEnable(false), _parserTwoArguments(",", 256, parserValueTypeOne, 2),
+        _sensorBmLogEnable(false), _minProbePeriodMs(0), _lastProbeTime(0),
+        _awaitingProbeResponse(false), _parserTwoArguments(",", 256, parserValueTypeOne, 2),
         _parserThreeArguments(",", 256, parserValueTypeTwo, 3){};
-  void init(BmRbrDataMsg::SensorType_t type);
-  bool probeType(uint32_t timeout_ms = 1000);
+  void init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms);
+  void maybeProbeType(void);
   bool getData(BmRbrDataMsg::Data &d);
   void flush(void);
 
+private:
+  void handleOutputformat(const char *s, size_t read_len);
+  bool handleDataString(const char *s, size_t read_len, BmRbrDataMsg::Data &d);
+
 public:
   static constexpr char RBR_RAW_LOG[] = "rbr_raw.log";
+  static constexpr char CFG_RBR_TYPE[] = "rbrCodaType";
 
 private:
   static constexpr uint32_t BAUD_RATE = 9600;
@@ -25,6 +31,7 @@ private:
   static constexpr ValueType parserValueTypeTwo[] = {TYPE_UINT64, TYPE_DOUBLE, TYPE_DOUBLE};
   static constexpr char typeCommand[] = "outputformat channelslist\n";
   static constexpr uint8_t SENSOR_DROP_DEBOUNCE_MAX_COUNT = 3;
+  static constexpr uint32_t PROBE_TYPE_TIMEOUT_MS = 1000;
   static constexpr uint8_t NUM_PARSERS = 4;
   static constexpr char sensor_bm_log_enable[] = "sensorBmLogEnable";
 
@@ -33,6 +40,9 @@ private:
   BmRbrDataMsg::SensorType_t _stored_type;
   uint8_t _sensorDropDebounceCount = 0;
   uint32_t _sensorBmLogEnable = 0;
+  uint32_t _minProbePeriodMs = 0;
+  uint64_t _lastProbeTime = 0;
+  bool _awaitingProbeResponse = false;
   OrderedSeparatorLineParser _parserTwoArguments;
   OrderedSeparatorLineParser _parserThreeArguments;
   OrderedSeparatorLineParser *_parsers[NUM_PARSERS] = {

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
@@ -11,21 +11,21 @@ static bool validSpecialChar(char c);
 /*!
     * @brief Check if the sensor data string is valid
     * @param[in] s The sensor data string
-    * @param[in] strlen The length of the sensor data string
+    * @param[in] len The length of the sensor data string
     * @return True if the sensor data string is valid, false otherwise
     */
-bool validSensorDataString(const char *s, size_t strlen) {
+bool validSensorDataString(const char *s, size_t len) {
   configASSERT(s);
   bool rval = false;
   do {
     // 78 determined by 1.5 the maximum length of the longest sensor data string
     // coming from the RBRcoda3 T.ODO sensor
     // https://rbr-global.com/wp-content/uploads/2023/12/RBR-Sensors-RUG-0003296revN.pdf
-    if (strlen == 0 || strlen > 78) {
+    if (len == 0 || len > 78) {
       break;
     }
     bool invalid = false;
-    for (size_t i = 0; i < strlen; i++) {
+    for (size_t i = 0; i < len; i++) {
       if ((!isdigit(s[i]) && !isspace(s[i]) && !validSpecialChar(s[i]))) {
         invalid = true;
         break;
@@ -60,26 +60,27 @@ bool validSensorData(DataType_e type, double val) {
 /*!
     * @brief Check if the sensor output format configuration is valid
     * @param[in] s The sensor output format
-    * @param[in] strlen The length of the sensor output format
+    * @param[in] len The length of the sensor output format
     * @return True if the sensor output format is valid, false otherwise
     * @note See outputformat channelslist in https://rbr-global.com/wp-content/uploads/2023/12/RBR-Sensors-RUG-0003296revN.pdf
 */
-bool validSensorOutputformat(const char *s, size_t strlen) {
+bool validSensorOutputformat(const char *s, size_t len) {
   configASSERT(s);
-  bool rval = false;
+  bool valid = false;
   do {
-    if (strlen == 0) {
+    if (len == 0) {
       break;
     }
-    if (strstr(s, "outputformat channelslist =") == NULL) {
+    if (strnstr(s, "outputformat channelslist =", len) == NULL) {
       break;
     }
-    if (strstr(s, "pressure(dbar)") == NULL && strstr(s, "temperature(C)") == NULL) {
+    if (strnstr(s, "pressure(dbar)", len) == NULL &&
+        strnstr(s, "temperature(C)", len) == NULL) {
       break;
     }
-    rval = true;
+    valid = true;
   } while (0);
-  return rval;
+  return valid;
 }
 
 void preprocessLine(char *str, uint16_t &len) {
@@ -88,7 +89,7 @@ void preprocessLine(char *str, uint16_t &len) {
   if (!len) {
     return;
   }
-  char *readyString = strstr(str, readystr);
+  char *readyString = strnstr(str, readystr, len);
   if (readyString) {
     char *endReady = readyString + strlen(readystr);
     if (endReady < str + len) {

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
@@ -71,11 +71,10 @@ bool validSensorOutputformat(const char *s, size_t len) {
     if (len == 0) {
       break;
     }
-    if (strnstr(s, "outputformat channelslist =", len) == NULL) {
+    if (strstr(s, "outputformat channelslist =") == NULL) {
       break;
     }
-    if (strnstr(s, "pressure(dbar)", len) == NULL &&
-        strnstr(s, "temperature(C)", len) == NULL) {
+    if (strstr(s, "pressure(dbar)") == NULL && strstr(s, "temperature(C)") == NULL) {
       break;
     }
     valid = true;
@@ -89,7 +88,7 @@ void preprocessLine(char *str, uint16_t &len) {
   if (!len) {
     return;
   }
-  char *readyString = strnstr(str, readystr, len);
+  char *readyString = strstr(str, readystr);
   if (readyString) {
     char *endReady = readyString + strlen(readystr);
     if (endReady < str + len) {

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.h
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.h
@@ -8,8 +8,8 @@ typedef enum DataType {
   PRESSURE,
 } DataType_e;
 
-bool validSensorDataString(const char *s, size_t strlen);
+bool validSensorDataString(const char *s, size_t len);
 bool validSensorData(DataType_e type, double val);
-bool validSensorOutputformat(const char *s, size_t strlen);
+bool validSensorOutputformat(const char *s, size_t len);
 void preprocessLine(char *str, uint16_t &len);
 } // namespace BmRbrSensorUtil

--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -65,7 +65,7 @@ void loop(void) {
 static bool BmRbrWatchdogHandler(void *arg) {
   (void)arg;
   bm_fprintf(0, RbrSensor::RBR_RAW_LOG, "DEBUG - attempting FTL recovery\n");
-  bm_printf(0, "DEBUG - attempting FTL recovery\n");
+  bm_printf(0, "DEBUG - attempting FTL recovery");
   printf("DEBUG - attempting FTL recovery\n");
   IOWrite(&BB_PL_BUCK_EN, 1);
   vTaskDelay(pdMS_TO_TICKS(500)); // Wait for Vbus to stabilize


### PR DESCRIPTION
We noticed in some logs that we would sometimes drop an RBR sensor reading when it lined up with our periodic checking of the RBR type. In order to ensure we keep all valid sensor readings, this change reads from the RBR sensor in exactly one place in the code (rather than two different places previously). It correctly handles either a sensor reading or a command response no matter when they arrive.

The bulk of the changes are in `rbr_sensor.cpp`:

- The function `probeType` is renamed `maybeProbeType` to encapsulate the timing and only writes the command, without reading a response. It also sets a flag to indicate we are now awaiting a response.
- The boolean return value from `getData` still represents whether it received and successfully parsed a sensor reading, but command responses are also handled within that function.
- The two types of lines we expect to receive from the sensor are each extracted into their own handler functions: `handleOutputformat` and `handleDataString`.
- Logic marking a sensor being online with a known type is at the top of `handleOutputFormat` including resetting the "awaiting probe response" flag.
- The handling of a timeout awaiting a probe response is moved to `getData`, including marking a sensor lost.