### PR TITLE
only set ms from rtc if we have rtc

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -157,6 +157,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
 bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::Data &d) {
   bool success = false;
   RTCTimeAndDate_t time_and_date = {};
+  bool rtc_is_set = isRTCSet();
   rtcGet(&time_and_date);
   char rtcTimeBuffer[32] = {};
   rtcPrint(rtcTimeBuffer, NULL);
@@ -185,7 +186,11 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::TEMPERATURE;
-      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      if (rtc_is_set) {
+        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      } else {
+        d.header.reading_time_utc_ms = 0;
+      }
       d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = tempValue.data.double_val;
@@ -207,8 +212,11 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE;
-      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-      d.header.reading_uptime_millis = uptimeGetMs();
+      if (rtc_is_set) {
+        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      } else {
+        d.header.reading_time_utc_ms = 0;
+      }      d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = NAN;
       d.pressure_deci_bar = pressureValue.data.double_val;
@@ -236,7 +244,11 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
-      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      if (rtc_is_set) {
+        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      } else {
+        d.header.reading_time_utc_ms = 0;
+      }
       d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = tempValue.data.double_val;

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -157,7 +157,6 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
 bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::Data &d) {
   bool success = false;
   RTCTimeAndDate_t time_and_date = {};
-  bool rtc_is_set = isRTCSet();
   rtcGet(&time_and_date);
   char rtcTimeBuffer[32] = {};
   rtcPrint(rtcTimeBuffer, NULL);
@@ -186,11 +185,7 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::TEMPERATURE;
-      if (rtc_is_set) {
-        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-      } else {
-        d.header.reading_time_utc_ms = 0;
-      }
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
       d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = tempValue.data.double_val;
@@ -212,11 +207,8 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE;
-      if (rtc_is_set) {
-        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-      } else {
-        d.header.reading_time_utc_ms = 0;
-      }      d.header.reading_uptime_millis = uptimeGetMs();
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+      d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = NAN;
       d.pressure_deci_bar = pressureValue.data.double_val;
@@ -244,11 +236,7 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
         break;
       }
       d.sensor_type = BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE;
-      if (rtc_is_set) {
-        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-      } else {
-        d.header.reading_time_utc_ms = 0;
-      }
+      d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
       d.header.reading_uptime_millis = uptimeGetMs();
       d.header.sensor_reading_time_ms = timeValue.data.uint64_val;
       d.temperature_deg_c = tempValue.data.double_val;

--- a/src/lib/drivers/stm32_rtc.c
+++ b/src/lib/drivers/stm32_rtc.c
@@ -165,7 +165,11 @@ BaseType_t rtcSet(const RTCTimeAndDate_t *timeAndDate) {
 
 uint64_t rtcGetMicroSeconds(RTCTimeAndDate_t *timeAndDate){
   int i;
-  uint64_t microseconds;
+  uint64_t microseconds = 0;
+
+  if (timeAndDate->year == 0) {
+    return microseconds;
+  }
 
   // microseconds from 1970 till 1 jan 00:00:00 of the given year
   microseconds = (timeAndDate->year - 1970) * (SECS_PER_DAY * 365);

--- a/src/lib/drivers/stm32_rtc.c
+++ b/src/lib/drivers/stm32_rtc.c
@@ -167,7 +167,7 @@ uint64_t rtcGetMicroSeconds(RTCTimeAndDate_t *timeAndDate){
   int i;
   uint64_t microseconds = 0;
 
-  if (timeAndDate->year == 0) {
+  if (!isRTCSet()) {
     return microseconds;
   }
 


### PR DESCRIPTION
If we didn't have RTC fixed, the RBR sens ind lines would have an unset default value for the UTC ms column.
```
Before FIX
ac84979e1f96729f,1,RBR.D,27348,6593470336.000,26.500,nan,10.131
ac84979e1f96729f,1,RBR.D,27848,6593470336.000,27.000,nan,10.131
ac84979e1f96729f,1,RBR.D,28348,6593470336.000,27.500,nan,10.130
ac84979e1f96729f,1,RBR.D,28848,6593470336.000,28.000,nan,10.131
ac84979e1f96729f,1,RBR.D,29348,6593470336.000,28.500,nan,10.131
ac84979e1f96729f,1,RBR.D,29848,6593470336.000,29.000,nan,10.131
ac84979e1f96729f,1,RBR.D,30348,6593470336.000,29.500,nan,10.131
ac84979e1f96729f,1,RBR.D,30848,6593470336.000,30.000,nan,10.131
AFTER FIX
ac84979e1f96729f,1,RBR.D,1016,0.000,0.000,nan,10.130
ac84979e1f96729f,1,RBR.D,1338,0.000,0.500,nan,10.130
ac84979e1f96729f,1,RBR.D,1838,0.000,1.000,nan,10.131
ac84979e1f96729f,1,RBR.D,2338,0.000,1.500,nan,10.131
ac84979e1f96729f,1,RBR.D,2838,0.000,2.000,nan,10.131
ac84979e1f96729f,1,RBR.D,3338,0.000,2.500,nan,10.131
ac84979e1f96729f,1,RBR.D,3838,0.000,3.000,nan,10.131
```
https://app.shortcut.com/sofar/story/203386/on-the-mote-rbr-code-check-if-rtc-valid-before-stamping-data