### PR TITLE
fix: print the bridge network config in a single pass

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -56,6 +56,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
+    ${SRC_DIR}/lib/common/network_config_logger.cpp
     ${SRC_DIR}/lib/common/nvmPartition.cpp
     ${SRC_DIR}/lib/common/pcap.c
     ${SRC_DIR}/lib/common/reset_reason.c

--- a/src/lib/common/network_config_logger.cpp
+++ b/src/lib/common/network_config_logger.cpp
@@ -1,0 +1,44 @@
+#include "network_config_logger.h"
+#include "FreeRTOS.h"
+#include "bridgeLog.h"
+#include "cbor.h"
+
+static char *log_buffer = NULL;
+static size_t log_buffer_size = 0;
+static constexpr size_t log_buffer_max_size = 2048;
+
+static CborError print_stream_handler(void *out, const char *fmt, ...) {
+  configASSERT(log_buffer != NULL);
+  (void)out;
+
+  va_list args;
+  va_start(args, fmt);
+  int n = vsnprintf(nullptr, log_buffer_max_size - log_buffer_size, fmt, args);
+  if (n > 0) {
+    vsnprintf(&log_buffer[log_buffer_size], log_buffer_max_size - log_buffer_size, fmt, args);
+    log_buffer_size += n;
+  }
+  va_end(args);
+
+  return n < 0 ? CborErrorIO : CborNoError;
+}
+
+void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buffer_size) {
+  configASSERT(cbor_buffer != NULL);
+  configASSERT(log_buffer == NULL);
+  log_buffer = static_cast<char *>(pvPortMalloc(log_buffer_max_size));
+  configASSERT(log_buffer);
+  log_buffer_size = 0;
+  CborParser parser;
+  CborValue it;
+  CborError err = cbor_parser_init(cbor_buffer, cbor_buffer_size, 0, &parser, &it);
+  if (err == CborNoError) {
+    cbor_value_to_pretty_stream(print_stream_handler, NULL, &it, CborPrettyDefaultFlags);
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Bridge network config: %.*s\n", log_buffer_size, log_buffer);
+  }
+  if (log_buffer) {
+    vPortFree(log_buffer);
+    log_buffer = NULL;
+  }
+}

--- a/src/lib/common/network_config_logger.h
+++ b/src/lib/common/network_config_logger.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_bufsize);

--- a/src/lib/common/topology_sampler.cpp
+++ b/src/lib/common/topology_sampler.cpp
@@ -24,6 +24,7 @@
 #include "config_cbor_map_srv_request_msg.h"
 #include "crc.h"
 #include "device_info.h"
+#include "network_config_logger.h"
 #include "sensorController.h"
 #include "sm_config_crc_list.h"
 #include "stm32_rtc.h"
@@ -84,9 +85,6 @@ static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bu
 
 static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t app_name_len);
 
-static CborError cborStreamFunct(void *token, const char *fmt, ...);
-
-static void log_cbor_network_configurations(uint8_t *cbor_buf, size_t cbor_buf_size);
 static void log_network_crc_info(uint32_t network_crc32, SMConfigCRCList &sm_config_crc_list);
 
 static void topology_sample_cb(networkTopology_t *networkTopology) {
@@ -829,31 +827,6 @@ static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t 
       }
     }
   }
-}
-
-static CborError cborStreamFunct(void *token, const char *fmt, ...) {
-  (void)token;
-  va_list args;
-  va_start(args, fmt);
-  vBridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, fmt, args);
-  va_end(args);
-  return CborNoError;
-}
-
-static void log_cbor_network_configurations(uint8_t *cbor_buf, size_t cbor_buf_size) {
-  configASSERT(cbor_buf);
-  CborError err = CborNoError;
-  bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge network config: \n");
-  do {
-    CborParser parser;
-    CborValue it;
-    err = cbor_parser_init(cbor_buf, cbor_buf_size, 0, &parser, &it);
-    if (err != CborNoError) {
-      break;
-    }
-    cbor_value_to_pretty_stream(cborStreamFunct, NULL, &it, CborPrettyDefaultFlags);
-  } while (0);
-  bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "\n");
 }
 
 static void log_network_crc_info(uint32_t network_crc32, SMConfigCRCList &sm_config_crc_list) {


### PR DESCRIPTION
Previously the internal cbor stream handler would build a whole publish packet for every character or two!

This resulted in spotter console logs having the bridge network config being slowly printed a little at a time while other lines interrupt it.

Example spotter console log line with a couple nodes attached:

2024-07-19T07:42:38.207Z [BRIDGE_CFG] [INFO] Bridge network config: [[3126851968281441696, "bridge-dbg", 1499363141, 3152952663, {"sampleIntervalMs": 300000, "sampleDurationMs": 240000, "subsampleIntervalMs": 60000, "subsampleDurationMs": 30000, "subsampleEnabled": 0, "bridgePowerControllerEnabled": 0, "alignmentInterval5Min": 1, "ticksSamplingEnabled": 0, "samplesPerReport": 2, "transmitAggregations": 1, "currentReadingPeriodMs": 60000, "softReadingPeriodMs": 500, "rbrCodaReadingPeriodMs": 500, "turbidityReadingPeriodMs": 1000}], [10047966341406729948, "serial_bridge-dbg", 1499363141, 1985325339, {"sensorsPollIntervalMs": 10000, "sensorsCheckIntervalS": 60, "currentAggPeriodMin": 0.f, "nSkipReadings": 0, "readingIntervalMs": 60000, "payloadWdToS": 70, "plUartBaudRate": 9600, "dfu_confirm": 0, "rbrCodaType": 2}], [816502619147696319, "rbr_coda_example-dbg", 553272471, 3352688053, {"sensorsPollIntervalMs": 60000, "rbrCodaType": 2}]]

Notice that currentAggPeriodMin is `0.f` which is annoying to parse in production tooling but we've determined that fixing it isn't worth the effort. It's the way tinycbor does "pretty" output. There are json output functions too, but we'd have to convert most numbers to strings, especially node IDs to prevent them from being rounded, because all json numbers are floating point under the hood.