### PR TITLE
Fix config check for Raw Pressure Processor Init code

### DIFF
--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -161,7 +161,7 @@ raw_pressure_config_s getRawPressureConfigs(cfg::Configuration &syscfg) {
     save_config = true;
   }
   cfg.rbrCodaReadingPeriodMs = RbrCodaSensor::DEFAULT_RBR_CODA_READING_PERIOD_MS;
-  if (syscfg.getConfig(AppConfig::RBR_CODA_READING_PERIOD_MS,
+  if (!syscfg.getConfig(AppConfig::RBR_CODA_READING_PERIOD_MS,
                                 strlen(AppConfig::RBR_CODA_READING_PERIOD_MS),
                                 cfg.rbrCodaReadingPeriodMs)) {
     bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -369,7 +369,7 @@ static void defaultTask(void *parameters) {
   bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
 
 
-  #ifdef RAW_PRESSURE_ENABLE
+#ifdef RAW_PRESSURE_ENABLE
   raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
   rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS,
                             raw_pressure_cfg.maxRawReports,

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -368,6 +368,16 @@ static void defaultTask(void *parameters) {
   debugDfuInit(&dfu_partition);
   bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
 
+
+  #ifdef RAW_PRESSURE_ENABLE
+  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
+  rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS,
+                            raw_pressure_cfg.maxRawReports,
+                            raw_pressure_cfg.rawDepthThresholdUbar,
+                            &debug_configuration_user,
+                            raw_pressure_cfg.rbrCodaReadingPeriodMs);
+#endif // RAW_PRESSURE_ENABLE
+
   printf("Using bridge power controller.\n");
   IOWrite(&BOOST_EN, 1);
   power_config_s pwrcfg = getPowerConfigs(debug_configuration_system);
@@ -401,15 +411,6 @@ static void defaultTask(void *parameters) {
 #ifdef USE_MICROPYTHON
   micropython_freertos_init(&usbCLI);
 #endif
-
-#ifdef RAW_PRESSURE_ENABLE
-  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
-  rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS,
-                            raw_pressure_cfg.maxRawReports,
-                            raw_pressure_cfg.rawDepthThresholdUbar,
-                            &debug_configuration_user, 
-                            raw_pressure_cfg.rbrCodaReadingPeriodMs);
-#endif // RAW_PRESSURE_ENABLE
 
   // // Re-enable low power mode
   lpmPeripheralInactive(LPM_BOOT);

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -368,16 +368,6 @@ static void defaultTask(void *parameters) {
   debugDfuInit(&dfu_partition);
   bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
 
-
-#ifdef RAW_PRESSURE_ENABLE
-  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
-  rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS,
-                            raw_pressure_cfg.maxRawReports,
-                            raw_pressure_cfg.rawDepthThresholdUbar,
-                            &debug_configuration_user,
-                            raw_pressure_cfg.rbrCodaReadingPeriodMs);
-#endif // RAW_PRESSURE_ENABLE
-
   printf("Using bridge power controller.\n");
   IOWrite(&BOOST_EN, 1);
   power_config_s pwrcfg = getPowerConfigs(debug_configuration_system);
@@ -411,6 +401,15 @@ static void defaultTask(void *parameters) {
 #ifdef USE_MICROPYTHON
   micropython_freertos_init(&usbCLI);
 #endif
+
+#ifdef RAW_PRESSURE_ENABLE
+  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
+  rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS,
+                            raw_pressure_cfg.maxRawReports,
+                            raw_pressure_cfg.rawDepthThresholdUbar,
+                            &debug_configuration_user,
+                            raw_pressure_cfg.rbrCodaReadingPeriodMs);
+#endif // RAW_PRESSURE_ENABLE
 
   // // Re-enable low power mode
   lpmPeripheralInactive(LPM_BOOT);


### PR DESCRIPTION
Move up the raw pressure processor init code so that it get/sets configs before NCP code can begin to process incoming packets.

See comment below for actual fix + explanation