### PR TITLE
Enable Writing Files W/ bm_fprintf Without TimeStamp

### DIFF
--- a/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
@@ -135,7 +135,7 @@ void loop(void) {
             current_tx_data.mean, current_tx_data.stdev, pressure_tx_data.sample_count,
             pressure_tx_data.min, pressure_tx_data.max, pressure_tx_data.mean,
             pressure_tx_data.stdev);
-    bm_fprintf(0, "bmdk_sensor_agg.log", "%s\n", stats_print_buffer);
+    bm_fprintf(0, "bmdk_sensor_agg.log", USE_TIMESTAMP, "%s\n", stats_print_buffer);
     bm_printf(0, "[sensor-agg] | %s", stats_print_buffer);
     printf("[sensor-agg] | %s\n", stats_print_buffer);
     // Update variables tracking start time of agg period in ticks and RTC.

--- a/src/apps/bm_devkit/nortek/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/nortek/user_code/user_code.cpp
@@ -258,10 +258,10 @@ void setup(void) {
 
   //Print Headers into log file. will happen every time the mote power cycles, but that's fine.
   //This doesn't seem to be working. For some reason not being written.
-  bm_fprintf(0,"nortek_averages.log",
+  bm_fprintf(0,"nortek_averages.log", USE_TIMESTAMP,
           "HEADERS,uptime,rtcTimeBuffer,v_b1_x_mean,v_b1_x_stdev,v_b2_y_mean,v_b2_y_stdev,v_b3_z_mean,v_b3_z_stdev,heading_mean,heading_stdev,pitch_mean,pitch_stdev,roll_mean,roll_stdev,pressure_mean,pressure_stdev,temperature_mean,temperature_stdev,speed_mean,speed_stdev,direction_mean,direction_stdev"
       );
-  bm_fprintf(0,"nortek.log",
+  bm_fprintf(0,"nortek.log", USE_TIMESTAMP,
           "HEADERS,uptime,rtcTimeBuffer,month,day,year,hour,minute,second,error_code,status_code,v_b1_x,v_b2_y,v_b3_z,amp_b1_x,amp_b2_y,amp_b3_z,batt_v,sound_speed,heading,pitch,roll,pressure,temperature,an_in_1,an_in_2,speed,direction"
       );
 }
@@ -312,7 +312,7 @@ void loop(void) {
     uint16_t read_len = PLUART::readLine(payload_buffer, sizeof(payload_buffer));
 
     rtcPrint(rtcTimeBuffer, NULL);
-    bm_fprintf(0, "nortek_raw.log", "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
+    bm_fprintf(0, "nortek_raw.log", USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     bm_printf(0, "[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     printf("[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
 
@@ -340,11 +340,11 @@ void loop(void) {
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         this_uptime, rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
-      bm_printf(0,
+      bm_printf(0, 
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         this_uptime, rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
-      bm_fprintf(0,"nortek.log",
+      bm_fprintf(0,"nortek.log", USE_TIMESTAMP,
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         uptimeGetMs(), rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
@@ -399,16 +399,16 @@ void loop(void) {
           v_b1_x_stdev,v_b2_y_stdev,v_b3_z_stdev,heading_stdev,pitch_stdev,roll_stdev,pressure_stdev,temperature_stdev,speed_stdev,direction_stdev
       );
 
-      bm_printf(0,
+      bm_printf(0, 
           "MEANS |  v_x %.4f, v_y %.4f, v_z %.4f, heading %.4f, pitch %.4f, roll %.4f, pressure %.4f, temperature %.4f, speed %.4f, direction %.4f\n\n",
           v_b1_x_mean,v_b2_y_mean,v_b3_z_mean,heading_mean,pitch_mean,roll_mean,pressure_mean,temperature_mean,speed_mean,direction_mean
       );
-      bm_printf(0,
+      bm_printf(0, 
           "STDEVS |  v_x %.4f, v_y %.4f, v_z %.4f, heading %.4f, pitch %.4f, roll %.4f, pressure %.4f, temperature %.4f, speed %.4f, direction %.4f\n\n",
           v_b1_x_stdev,v_b2_y_stdev,v_b3_z_stdev,heading_stdev,pitch_stdev,roll_stdev,pressure_stdev,temperature_stdev,speed_stdev,direction_stdev
       );
 
-      bm_fprintf(0,"nortek_averages.log",
+      bm_fprintf(0,"nortek_averages.log", USE_TIMESTAMP,
           "DATA, %llu, %s,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",
           uptimeGetMs(), rtcTimeBuffer, v_b1_x_mean, v_b1_x_stdev, v_b2_y_mean, v_b2_y_stdev, v_b3_z_mean, v_b3_z_stdev, heading_mean, heading_stdev, pitch_mean, pitch_stdev, roll_mean, roll_stdev, pressure_mean, pressure_stdev, temperature_mean, temperature_stdev, speed_mean, speed_stdev, direction_mean, direction_stdev
       );

--- a/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
@@ -132,11 +132,11 @@ void loop(void) {
     char rtcTimeBuffer[32];
     rtcPrint(rtcTimeBuffer, &time_and_date);
 
-    bm_fprintf(0, "payload_data_agg.log",
+    bm_fprintf(0, "payload_data_agg.log", USE_TIMESTAMP,
                "tick: %llu, rtc: %s, n: %u, min: %.4f, max: %.4f, mean: %.4f, "
                "std: %.4f\n",
                uptimeGetMs(), rtcTimeBuffer, n_samples, min, max, mean, stdev);
-    bm_printf(0,
+    bm_printf(0, 
               "[rbr-agg] | tick: %llu, rtc: %s, n: %u, min: %.4f, max: %.4f, "
               "mean: %.4f, std: %.4f",
               uptimeGetMs(), rtcTimeBuffer, n_samples, min, max, mean, stdev);
@@ -231,7 +231,7 @@ void loop(void) {
     rtcGet(&time_and_date);
     char rtcTimeBuffer[32] = {};
     rtcPrint(rtcTimeBuffer, NULL);
-    bm_fprintf(0, "rbr_raw.log", "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
+    bm_fprintf(0, "rbr_raw.log", USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
                rtcTimeBuffer, read_len, payload_buffer);
     bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
               read_len, payload_buffer);

--- a/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
@@ -144,7 +144,7 @@ void loop(void) {
     rtcPrint(rtcTimeBuffer, &time_and_date);
 
     // Print the payload data to a file, to the bm_printf console, and to the printf console.
-    bm_fprintf(0, "payload_data.log", "tick: %llu, rtc: %s, line: %.*s\n",
+    bm_fprintf(0, "payload_data.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, line: %.*s\n",
                uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     bm_printf(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(),
               rtcTimeBuffer, read_len, payload_buffer);

--- a/src/apps/bm_soft_module/user_code/user_code.cpp
+++ b/src/apps/bm_soft_module/user_code/user_code.cpp
@@ -54,7 +54,7 @@ static void getConfigs() {
     printf("TSYS serial number: %" PRIu32 "\n", serial_number);
   } else {
     printf("No TSYS serial number found\n");
-    bm_fprintf(0, soft_log, "No TSYS serial number found\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "No TSYS serial number found\n");
     bm_printf(0, "No TSYS serial number found");
   }
 
@@ -64,7 +64,7 @@ static void getConfigs() {
     printf("Calibration temperature: %" PRId32 "\n", calTempC);
   } else {
     printf("No calibration temperature found\n");
-    bm_fprintf(0, soft_log, "No calibration temperature found\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "No calibration temperature found\n");
     bm_printf(0, "No calibration temperature found");
   }
 
@@ -73,7 +73,7 @@ static void getConfigs() {
     printf("Calibration time: %" PRIu32 "\n", cal_time_epoch);
   } else {
     printf("No calibration time found\n");
-    bm_fprintf(0, soft_log, "No calibration time found\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "No calibration time found\n");
     bm_printf(0, "No calibration time found");
   }
 
@@ -83,7 +83,7 @@ static void getConfigs() {
     printf("Calibration offset (milliDegC): %" PRId32 "\n", calOffsetMilliC);
   } else {
     printf("No calibration offset (milliDegC) found\n");
-    bm_fprintf(0, soft_log, "No calibration offset (milliDegC) found\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "No calibration offset (milliDegC) found\n");
     bm_printf(0, "No calibration offset (milliDegC) found");
   }
   calibrationOffsetDegC = static_cast<float>(calOffsetMilliC) * 1e-3f;
@@ -129,7 +129,7 @@ void loop(void) {
     bm_printf(0, "soft | tick: %llu, rtc: %s, temp: %f", uptimeGetMs(), rtcTimeBuffer,
               temperature);
     if (sensorBmLogEnable) {
-      bm_fprintf(0, soft_log, "soft | tick: %llu, rtc: %s, temp: %f\n", uptimeGetMs(),
+      bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | tick: %llu, rtc: %s, temp: %f\n", uptimeGetMs(),
                  rtcTimeBuffer, temperature);
     }
     static BmSoftDataMsg::Data d;
@@ -151,7 +151,7 @@ void loop(void) {
   }
   case TSYS01::TSYS01_RESULT_COMMS: {
     printf("soft | tick: %llu, rtc: %s, COMMS ERROR\n", uptimeGetMs(), rtcTimeBuffer);
-    bm_fprintf(0, soft_log, "soft | tick: %llu, rtc: %s,  COMMS ERROR\n", uptimeGetMs(),
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | tick: %llu, rtc: %s,  COMMS ERROR\n", uptimeGetMs(),
                rtcTimeBuffer);
     bm_printf(0, "soft | tick: %llu, rtc: %s,  COMMS ERROR", uptimeGetMs(), rtcTimeBuffer);
     break;
@@ -159,7 +159,7 @@ void loop(void) {
   case TSYS01::TSYS01_RESULT_INVALID: {
     printf("soft | tick: %llu, rtc: %s, INVALID temp: %f\n", uptimeGetMs(), rtcTimeBuffer,
            temperature);
-    bm_fprintf(0, soft_log, "soft | tick: %llu, rtc: %s, INVALID temp: %f\n", uptimeGetMs(),
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | tick: %llu, rtc: %s, INVALID temp: %f\n", uptimeGetMs(),
                rtcTimeBuffer, temperature);
     bm_printf(0, "soft | tick: %llu, rtc: %s, INVALID temp: %f", uptimeGetMs(), rtcTimeBuffer,
               temperature);
@@ -168,7 +168,7 @@ void loop(void) {
   }
   default: {
     printf("soft | tick: %llu, rtc: %s, UNKNOWN ERROR\n", uptimeGetMs(), rtcTimeBuffer);
-    bm_fprintf(0, soft_log, "soft | tick: %llu, rtc: %s,  UNKNOWN ERROR\n", uptimeGetMs(),
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | tick: %llu, rtc: %s,  UNKNOWN ERROR\n", uptimeGetMs(),
                rtcTimeBuffer);
     bm_printf(0, "soft | tick: %llu, rtc: %s,  UNKNOWN ERROR", uptimeGetMs(), rtcTimeBuffer);
     break;
@@ -203,11 +203,11 @@ static bool BmSoftWatchdogHandler(void *arg) {
   (void)arg;
   printf("Resetting BM soft\n");
   if (BmSoftStartAndValidate()) {
-    bm_fprintf(0, soft_log, "soft | Watchdog: Reset Bm Soft\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | Watchdog: Reset Bm Soft\n");
     bm_printf(0, "soft | Watchdog: Reset Bm Soft");
     printf("soft | Watchdog: Reset Bm Soft\n");
   } else {
-    bm_fprintf(0, soft_log, "soft | Watchdog: Failed to reset Bm Soft\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "soft | Watchdog: Failed to reset Bm Soft\n");
     bm_printf(0, "soft | Watchdog: Failed to reset Bm Soft");
     printf("soft | Watchdog: Failed to reset Bm Soft\n");
   }
@@ -226,7 +226,7 @@ static void BmSoftInitalize(void) {
   while (!BmSoftStartAndValidate()) {
     if (!failed_init) {
       printf("Failed to start BM soft\n");
-      bm_fprintf(0, soft_log, "Failed to start BM soft\n");
+      bm_fprintf(0, soft_log, USE_TIMESTAMP, "Failed to start BM soft\n");
       bm_printf(0, "Failed to start BM soft");
       failed_init = true;
     }
@@ -234,7 +234,7 @@ static void BmSoftInitalize(void) {
   }
   if (failed_init) {
     printf("Successfully recovered & started BM soft\n");
-    bm_fprintf(0, soft_log, "Successfully recovered & started BM soft\n");
+    bm_fprintf(0, soft_log, USE_TIMESTAMP, "Successfully recovered & started BM soft\n");
     bm_printf(0, "Successfully recovered & started BM soft");
   }
 }

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -346,7 +346,7 @@ void loop(void) {
                   current_tx_data[i].max, current_tx_data[i].mean, current_tx_data[i].stdev);
     }
     printf("DEBUG - wrote %d chars to buffer.", buffer_offset);
-    bm_fprintf(0, "aanderaa_agg.log", "%s\n", stats_print_buffer);
+    bm_fprintf(0, "aanderaa_agg.log", USE_TIMESTAMP, "%s\n", stats_print_buffer);
     bm_printf(0, "[aanderaa-agg] | %s", stats_print_buffer);
     printf("[aanderaa-agg] | %s\n", stats_print_buffer);
     // Update variables tracking start time of agg period in ticks and RTC.
@@ -426,7 +426,7 @@ void loop(void) {
     char rtcTimeBuffer[32] = {};
     rtcPrint(rtcTimeBuffer, NULL);
     if (sensorBmLogEnable) {
-      bm_fprintf(0, AANDERAA_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
+      bm_fprintf(0, AANDERAA_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
                  rtcTimeBuffer, read_len, payload_buffer);
     }
     bm_printf(0, "[aanderaa] | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -81,7 +81,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
     } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
       success = handleDataString(_payload_buffer, read_len, d);
     } else {
-      bm_fprintf(0, RBR_RAW_LOG, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
+      bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
       bm_printf(0, "Invalid line from sensor: %.*s", read_len, _payload_buffer);
       printf("Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
     }
@@ -93,7 +93,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
     _sensorDropDebounceCount++;
     if (_sensorDropDebounceCount == SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
       _type = BmRbrDataMsg::SensorType::UNKNOWN;
-      bm_fprintf(0, RBR_RAW_LOG, "RBR sensor was lost\n");
+      bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "RBR sensor was lost\n");
       bm_printf(0, "RBR sensor was lost");
       printf("RBR sensor was lost\n");
     }
@@ -105,7 +105,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
 void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
   // If the sensor was previously lost, print a message that it is back online.
   if (_sensorDropDebounceCount >= SENSOR_DROP_DEBOUNCE_MAX_COUNT) {
-    bm_fprintf(0, RBR_RAW_LOG, "RBR sensor online\n");
+    bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "RBR sensor online\n");
     bm_printf(0, "RBR sensor online");
     printf("RBR sensor online\n");
   }
@@ -119,7 +119,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
       systemConfigurationPartition->setConfig(
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
-      bm_fprintf(0, RBR_RAW_LOG, "Detected temp & pressure sensor, saving config\n");
+      bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "Detected temp & pressure sensor, saving config\n");
       bm_printf(0, "Detected temp & pressure sensor, saving config");
       printf("Detected temp & pressure sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
@@ -130,7 +130,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
       systemConfigurationPartition->setConfig(
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE));
-      bm_fprintf(0, RBR_RAW_LOG, "Detected pressure sensor, saving config\n");
+      bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "Detected pressure sensor, saving config\n");
       bm_printf(0, "Detected pressure sensor, saving config");
       printf("Detected pressure sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
@@ -141,14 +141,14 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
       systemConfigurationPartition->setConfig(
           CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::TEMPERATURE));
-      bm_fprintf(0, RBR_RAW_LOG, "Detected temp sensor, saving config\n");
+      bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "Detected temp sensor, saving config\n");
       bm_printf(0, "Detected temp sensor, saving config");
       printf("Detected temp sensor, saving config.\n");
       systemConfigurationPartition->saveConfig(); // reboot
     }
     _type = BmRbrDataMsg::SensorType::TEMPERATURE;
   } else {
-    bm_fprintf(0, RBR_RAW_LOG, "Invalid outputformat: %s\n", s);
+    bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid outputformat: %s\n", s);
     bm_printf(0, "Invalid outputformat: %s", s);
     printf("Invalid outputformat: %s\n", s);
   }
@@ -161,7 +161,7 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
   char rtcTimeBuffer[32] = {};
   rtcPrint(rtcTimeBuffer, NULL);
   if (_sensorBmLogEnable) {
-    bm_fprintf(0, RBR_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
+    bm_fprintf(0, RBR_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
                rtcTimeBuffer, read_len, s);
   }
   bm_printf(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,

--- a/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/user_code.cpp
@@ -73,7 +73,7 @@ void loop(void) {
 
 static bool BmRbrWatchdogHandler(void *arg) {
   (void)arg;
-  bm_fprintf(0, RbrSensor::RBR_RAW_LOG, "DEBUG - attempting FTL recovery\n");
+  bm_fprintf(0, RbrSensor::RBR_RAW_LOG, USE_TIMESTAMP, "DEBUG - attempting FTL recovery\n");
   bm_printf(0, "DEBUG - attempting FTL recovery");
   printf("DEBUG - attempting FTL recovery\n");
   IOWrite(&BB_PL_BUCK_EN, 1);

--- a/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
@@ -253,10 +253,10 @@ void setup(void) {
 
   //Print Headers into log file. will happen every time the mote power cycles, but that's fine.
   //This doesn't seem to be working. For some reason not being written.
-  bm_fprintf(0,"nortek_averages.log",
+  bm_fprintf(0,"nortek_averages.log", USE_TIMESTAMP,
           "HEADERS,uptime,rtcTimeBuffer,v_b1_x_mean,v_b1_x_stdev,v_b2_y_mean,v_b2_y_stdev,v_b3_z_mean,v_b3_z_stdev,heading_mean,heading_stdev,pitch_mean,pitch_stdev,roll_mean,roll_stdev,pressure_mean,pressure_stdev,temperature_mean,temperature_stdev,speed_mean,speed_stdev,direction_mean,direction_stdev"
       );
-  bm_fprintf(0,"nortek.log",
+  bm_fprintf(0,"nortek.log", USE_TIMESTAMP,
           "HEADERS,uptime,rtcTimeBuffer,month,day,year,hour,minute,second,error_code,status_code,v_b1_x,v_b2_y,v_b3_z,amp_b1_x,amp_b2_y,amp_b3_z,batt_v,sound_speed,heading,pitch,roll,pressure,temperature,an_in_1,an_in_2,speed,direction"
       );
 }
@@ -307,7 +307,7 @@ void loop(void) {
     uint16_t read_len = PLUART::readLine(payload_buffer, sizeof(payload_buffer));
 
     rtcPrint(rtcTimeBuffer, NULL);
-    bm_fprintf(0, "nortek_raw.log", "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
+    bm_fprintf(0, "nortek_raw.log", USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     bm_printf(0, "[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     printf("[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
 
@@ -335,11 +335,11 @@ void loop(void) {
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         this_uptime, rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
-      bm_printf(0,
+      bm_printf(0, 
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         this_uptime, rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
-      bm_fprintf(0,"nortek.log",
+      bm_fprintf(0,"nortek.log", USE_TIMESTAMP,
         "DATA, %" PRIu64 ", %s, %u, %u, %u, %u, %u, %u, %u, %u, %.4f, %.4f, %.4f, %u, %u, %u, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %u, %u, %.4f, %.4f\n",
         uptimeGetMs(), rtcTimeBuffer,nortekData.month, nortekData.day, nortekData.year, nortekData.hour, nortekData.minute, nortekData.second, nortekData.error_code, nortekData.status_code, nortekData.v_b1_x, nortekData.v_b2_y, nortekData.v_b3_z, nortekData.amp_b1_x, nortekData.amp_b2_y, nortekData.amp_b3_z, nortekData.batt_v, nortekData.sound_speed, nortekData.heading, nortekData.pitch, nortekData.roll, nortekData.pressure, nortekData.temperature, nortekData.an_in_1, nortekData.an_in_2, nortekData.speed, nortekData.direction
       );
@@ -394,16 +394,16 @@ void loop(void) {
           v_b1_x_stdev,v_b2_y_stdev,v_b3_z_stdev,heading_stdev,pitch_stdev,roll_stdev,pressure_stdev,temperature_stdev,speed_stdev,direction_stdev
       );
 
-      bm_printf(0,
+      bm_printf(0, 
           "MEANS |  v_x %.4f, v_y %.4f, v_z %.4f, heading %.4f, pitch %.4f, roll %.4f, pressure %.4f, temperature %.4f, speed %.4f, direction %.4f\n\n",
           v_b1_x_mean,v_b2_y_mean,v_b3_z_mean,heading_mean,pitch_mean,roll_mean,pressure_mean,temperature_mean,speed_mean,direction_mean
       );
-      bm_printf(0,
+      bm_printf(0, 
           "STDEVS |  v_x %.4f, v_y %.4f, v_z %.4f, heading %.4f, pitch %.4f, roll %.4f, pressure %.4f, temperature %.4f, speed %.4f, direction %.4f\n\n",
           v_b1_x_stdev,v_b2_y_stdev,v_b3_z_stdev,heading_stdev,pitch_stdev,roll_stdev,pressure_stdev,temperature_stdev,speed_stdev,direction_stdev
       );
 
-      bm_fprintf(0,"nortek_averages.log",
+      bm_fprintf(0,"nortek_averages.log", USE_TIMESTAMP,
           "DATA, %llu, %s,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f\n",
           uptimeGetMs(), rtcTimeBuffer, v_b1_x_mean, v_b1_x_stdev, v_b2_y_mean, v_b2_y_stdev, v_b3_z_mean, v_b3_z_stdev, heading_mean, heading_stdev, pitch_mean, pitch_stdev, roll_mean, roll_stdev, pressure_mean, pressure_stdev, temperature_mean, temperature_stdev, speed_mean, speed_stdev, direction_mean, direction_stdev
       );

--- a/src/apps/bristleback_apps/seapoint_turbidity/user_code/seapoint_turbidity_sensor.cpp
+++ b/src/apps/bristleback_apps/seapoint_turbidity/user_code/seapoint_turbidity_sensor.cpp
@@ -69,7 +69,7 @@ bool SeapointTurbiditySensor::getData(BmSeapointTurbidityDataMsg::Data &d) {
     rtcPrint(rtc_time_str, NULL);
 
     if (_sensorBmLogEnable) {
-      bm_fprintf(0, SEAPOINT_TURBIDITY_RAW_LOG, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
+      bm_fprintf(0, SEAPOINT_TURBIDITY_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
                  uptimeGetMs(), rtc_time_str, read_len, _payload_buffer);
     }
     bm_printf(0, "turbidity | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),

--- a/src/apps/bristleback_apps/serial_payload_example/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_payload_example/user_code/user_code.cpp
@@ -69,7 +69,7 @@ void loop(void) {
     rtcPrint(rtcTimeBuffer, &time_and_date);
 
     // Print the payload data to a file, to the bm_printf console, and to the printf console.
-    bm_fprintf(0, "payload_data.log", "tick: %llu, rtc: %s, line: %.*s\n",
+    bm_fprintf(0, "payload_data.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, line: %.*s\n",
                uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
     bm_printf(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(),
               rtcTimeBuffer, read_len, payload_buffer);

--- a/src/lib/bcmp/bm/bm_printf.cpp
+++ b/src/lib/bcmp/bm/bm_printf.cpp
@@ -19,7 +19,8 @@ static constexpr uint8_t fappendType = 1;
   \param[in] file_name - (optional) file name to print to (this will append to file")
   \param[in] *format - normal printf format string
 */
-bm_printf_err_t bm_fprintf(uint64_t target_node_id, const char* file_name, const char* format, ...) {
+bm_printf_err_t bm_fprintf(uint64_t target_node_id, const char* file_name,
+                           bool print_time, const char* format, ...) {
   bm_printf_err_t rval = BM_PRINTF_OK;
   bm_print_publication_t* printf_pub = NULL;
   va_list va;
@@ -55,6 +56,7 @@ bm_printf_err_t bm_fprintf(uint64_t target_node_id, const char* file_name, const
     printf_pub->target_node_id = target_node_id;
     printf_pub->fname_len = fname_len;
     printf_pub->data_len = data_len;
+    printf_pub->print_time = print_time;
 
     if (file_name) {
       memcpy(printf_pub->fnameAndData, file_name, fname_len);

--- a/src/lib/bcmp/bm/bm_printf.h
+++ b/src/lib/bcmp/bm/bm_printf.h
@@ -6,6 +6,9 @@
 #include "bm_util.h"
 #include "bm_pubsub.h"
 
+#define USE_TIMESTAMP 1
+#define NO_TIMESTAMP 0
+
 typedef enum {
   BM_PRINTF_OK,
   BM_PRINTF_STR_ZERO_LEN,
@@ -15,7 +18,8 @@ typedef enum {
   BM_PRINTF_TX_ERR,
 } bm_printf_err_t;
 
-bm_printf_err_t bm_fprintf(uint64_t target_node_id, const char* file_name, const char* format, ...);
+bm_printf_err_t bm_fprintf(uint64_t target_node_id, const char* file_name,
+                           bool print_time, const char* format, ...);
 bm_printf_err_t bm_file_append(uint64_t target_node_id, const char* file_name, const uint8_t *buff, uint16_t len);
 
-#define bm_printf(target_node_id, format, ...) bm_fprintf(target_node_id, NULL, format, ##__VA_ARGS__)
+#define bm_printf(target_node_id, format, ...) bm_fprintf(target_node_id, NULL, USE_TIMESTAMP, format, ##__VA_ARGS__)

--- a/src/lib/common/sensorWatchdog.cpp
+++ b/src/lib/common/sensorWatchdog.cpp
@@ -103,7 +103,7 @@ static void _sensorWatchdogHandler(void *arg) {
   configASSERT(arg);
   sensor_watchdog_t *curr = reinterpret_cast<sensor_watchdog_t *>(arg);
   if (curr->_logHandle) {
-    bm_fprintf(0, curr->_logHandle, "[%s] | tick: %" PRIu64 " SensorWatchdog Expired!\n",
+    bm_fprintf(0, curr->_logHandle, USE_TIMESTAMP, "[%s] | tick: %" PRIu64 " SensorWatchdog Expired!\n",
                curr->_id, uptimeGetMs());
   }
   printf("[%s] | tick: %" PRIu64 " SensorWatchdog Expired!\n", curr->_id, uptimeGetMs());
@@ -117,7 +117,7 @@ static void _sensorWatchdogHandler(void *arg) {
     } else {
       configASSERT(xTimerStop(curr->_timerHandle, 0) == pdTRUE);
       if (curr->_logHandle) {
-        bm_fprintf(0, curr->_logHandle,
+        bm_fprintf(0, curr->_logHandle, USE_TIMESTAMP,
                    "[%s] | tick: %" PRIu64 " SensorWatchdog max trigger: %" PRIu32
                    " reached!\n",
                    curr->_id, uptimeGetMs(), curr->_max_triggers);

--- a/src/lib/debug/debug_spotter.cpp
+++ b/src/lib/debug/debug_spotter.cpp
@@ -95,7 +95,7 @@ static BaseType_t cmd_spotter_fn(char *writeBuffer, size_t writeBufferLen,
       }
       size_t dataLen = strnlen(dataStr, 128);
       bm_printf_err_t res;
-      res = bm_fprintf(0, just_filename, "%.*s\n", dataLen + 1,
+      res = bm_fprintf(0, just_filename, USE_TIMESTAMP, "%.*s\n", dataLen + 1,
                        dataStr); // add one for the \n
       if (res != BM_PRINTF_OK) {
         printf("bm_fprintf err: %d\n", res);

--- a/src/lib/sensor_sampler/htuSampler.cpp
+++ b/src/lib/sensor_sampler/htuSampler.cpp
@@ -56,7 +56,7 @@ static bool htuSample() {
     rtcPrint(rtcTimeBuffer, &time_and_date);
     printf("hum_temp | tick: %llu, rtc: %s, hum: %f, temp: %f\n", uptimeGetMs(), rtcTimeBuffer,
            _humTempData.humidity, _humTempData.temperature);
-    bm_fprintf(0, "hum_temp.log", "tick: %llu, rtc: %s, hum: %f, temp: %f\n", uptimeGetMs(),
+    bm_fprintf(0, "hum_temp.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, hum: %f, temp: %f\n", uptimeGetMs(),
                rtcTimeBuffer, _humTempData.humidity, _humTempData.temperature);
     bm_printf(0, "hum_temp | tick: %llu, rtc: %s, hum: %f, temp: %f", uptimeGetMs(),
               rtcTimeBuffer, _humTempData.humidity, _humTempData.temperature);

--- a/src/lib/sensor_sampler/loadCellSampler.cpp
+++ b/src/lib/sensor_sampler/loadCellSampler.cpp
@@ -69,9 +69,9 @@ static bool loadCellSample() {
       _loadCell->getInternalOffsetCal();
 
       // prints to SD card file
-      bm_fprintf(0, "loadcell.log", "tick: %llu, rtc: %s, reading: %" PRId32 "\n",
+      bm_fprintf(0, "loadcell.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, reading: %" PRId32 "\n",
                  uptimeGetMicroSeconds() / 1000, rtcTimeBuffer, reading);
-      bm_fprintf(0, "loadcell.log", "tick: %llu, rtc: %s, weight: %f\n",
+      bm_fprintf(0, "loadcell.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, weight: %f\n",
                  uptimeGetMicroSeconds() / 1000, rtcTimeBuffer, weight);
 
       // prints to Spotter console

--- a/src/lib/sensor_sampler/powerSampler.cpp
+++ b/src/lib/sensor_sampler/powerSampler.cpp
@@ -54,7 +54,7 @@ static bool powerSample() {
       rtcPrint(rtcTimeBuffer, &time_and_date);
       printf("power | tick: %llu, rtc: %s, addr: %u, voltage: %f, current: %f\n", uptimeGetMs(),
              rtcTimeBuffer, _powerData.address, _powerData.voltage, _powerData.current);
-      bm_fprintf(0, "power.log", "tick: %llu, rtc: %s, addr: %lu, voltage: %f, current: %f\n",
+      bm_fprintf(0, "power.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, addr: %lu, voltage: %f, current: %f\n",
                  uptimeGetMs(), rtcTimeBuffer, _powerData.address, _powerData.voltage,
                  _powerData.current);
       bm_printf(0, "power | tick: %llu, rtc: %s, addr: %u, voltage: %f, current: %f",
@@ -69,7 +69,7 @@ static bool powerSample() {
     } else {
       printf("ERR Failed to sample power monitor %u!", dev_num);
       bm_printf(0, "ERR Failed to sample power monitor %u!", dev_num);
-      bm_fprintf(0, "power.log", "ERR Failed to sample power monitor %u!", dev_num);
+      bm_fprintf(0, "power.log", USE_TIMESTAMP, "ERR Failed to sample power monitor %u!", dev_num);
     }
     rval &= success;
   }

--- a/src/lib/sensor_sampler/pressureSampler.cpp
+++ b/src/lib/sensor_sampler/pressureSampler.cpp
@@ -46,7 +46,7 @@ static bool baroSample() {
     rtcPrint(rtcTimeBuffer, &time_and_date);
     printf("pressure | tick: %llu, rtc: %s, temp: %f, pressure: %f\n", uptimeGetMs(),
            rtcTimeBuffer, _pressureData.temperature, _pressureData.pressure);
-    bm_fprintf(0, "pressure.log", "tick: %llu, rtc: %s, temp: %f, pressure: %f\n",
+    bm_fprintf(0, "pressure.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, temp: %f, pressure: %f\n",
                uptimeGetMs(), rtcTimeBuffer, _pressureData.temperature, _pressureData.pressure);
     bm_printf(0, "pressure | tick: %llu, rtc: %s, temp: %f, pressure: %f", uptimeGetMs(),
               rtcTimeBuffer, _pressureData.temperature, _pressureData.pressure);


### PR DESCRIPTION
Allows logs files to be written without timestamp information at beginning of log files

The spotter FW will also support backwards compatability of the `bm_print_publication_t` message.

resolves #154

The following was done to test this branch:


1. Change line 57 in `powerSampler.cpp` to not utilize time stamps:
```
      bm_fprintf(0, "power.log", NO_TIMESTAMP, "tick: %llu, rtc: %s, addr: %lu, voltage: %f, current: %f\n",
                 uptimeGetMs(), rtcTimeBuffer, _powerData.address, _powerData.voltage,
                 _powerData.current);
```
2. Flash serial payload example on BM mote and updated changes to spotter fw on spotter
3. Let the network run for some time and `cat` the log file that is written
4. Repeat steps 1 through 3 with:
    a. `USE_TIMESTAMP` in place of line 57
    b.  Version 1 of the `bm_print_publication_t` message (revert to an older commit and flash)

The following are the results:
- `NO_TIMESTAMP` parameter:
![Screenshot 2024-08-28 at 11 01 39 AM](https://github.com/user-attachments/assets/3856d8c2-030b-4847-ba8f-c2ee495dcea9)

-  `USE_TIMESTAMP` parameter:
![Screenshot 2024-08-28 at 11 01 14 AM](https://github.com/user-attachments/assets/6fb08661-cb28-4d2f-ad9c-c64234e78c86)

- Version 1 of `bm_print_publication_t`
    - `printf` statements:
![Screenshot 2024-08-28 at 11 07 42 AM](https://github.com/user-attachments/assets/ce4df005-5d31-4f8a-b6de-da5930310333)
    
    - `cat` logfile:
![Screenshot 2024-08-28 at 11 07 33 AM](https://github.com/user-attachments/assets/0dc9c7e0-f649-44b2-937b-5d686d754d74)


