### PR TITLE
fix: drop rbr readings that arrive after timer fires

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -235,10 +235,11 @@ void BridgePowerController::_update(void) {
         } else { // Subsampling disabled
           stateLogPrintTarget("Sample", currentCycleS + sampleTimeRemainingS);
 #ifdef RAW_PRESSURE_ENABLE
-      if(!rbrPressureProcessorIsStarted()) {
-        rbrPressureProcessorStart();
-        printf("Started rbrPressureProcessor\n");
-      }
+          if (!rbrPressureProcessorIsStarted()) {
+            rbrPressureProcessorStart();
+            bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                           "Started rbrPressureProcessor\n");
+          }
 #endif // RAW_PRESSURE_ENABLE
           powerBusAndSetSignal(true);
           time_to_sleep_ms = MAX(sampleTimeRemainingS * 1000, MIN_TASK_SLEEP_MS);
@@ -298,7 +299,7 @@ void BridgePowerController::_update(void) {
 #ifndef CI_TEST
   uint32_t taskNotifyValue = 0;
   xTaskNotifyWait(pdFALSE, UINT32_MAX, &taskNotifyValue, pdMS_TO_TICKS(time_to_sleep_ms));
-#else // CI_TEST
+#else  // CI_TEST
   vTaskDelay(time_to_sleep_ms); // FIXME fix this in test.
 #endif // CI_TEST
 }


### PR DESCRIPTION
One task catches RBR pressure readings and enqueues them. Another task reads from the queue and adds the readings to the difference signal buffer. When the "end of sample" timer fires, we already don't enqueue any more readings. However, the question is how we should deal with the ones that might be sitting in the queue, not yet processed.

After discussion, we agreed that it's better to drop these on the floor rather than add them to the beginning of the next sample, since the difference signal buffer may already have been cleared.

The tradeoff here is that we may drop valid readings at the tail end of a sample before calculating the difference signal and sending messages to Spotter. That's acceptable.