### PR TITLE
add the rs232 apps to the release build

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -90,6 +90,8 @@ class AutoBuilder:
             cmd += ["-DCMAKE_APP_TYPE=bristleback"]
         elif config["args"]["bsp"] == "bm_mote_v1.0":
             cmd += ["-DCMAKE_APP_TYPE=BMDK"]
+        elif config["args"]["bsp"] == "bm_mote_rs232":
+            cmd += ["-DCMAKE_APP_TYPE=rs232_expander"]
 
         if config["name"].startswith("aanderaa"):
             cmd += ["-DCMAKE_AANDERAA_TYPE=4830"]

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -38,24 +38,6 @@
     build_type: Release
   sign: true
 
-- name: aanderaa_debug
-  description: Aanderaa Current Meter - Debug
-  type: build_fw
-  args:
-    app: aanderaa
-    bsp: bm_mote_bristleback_v1_0
-    build_type: Debug
-  sign: true
-
-- name: aanderaa_release
-  description: Aanderaa Current Meter - Release
-  type: build_fw
-  args:
-    app: aanderaa
-    bsp: bm_mote_bristleback_v1_0
-    build_type: Release
-  sign: true
-
 - name: hello_world_debug
   description: Hello World - Debug
   type: build_fw
@@ -71,24 +53,6 @@
   args:
     app: bm_soft_module
     bsp: bm_mote_spi_v1_0
-    build_type: Release
-  sign: true
-
-- name: bm_rbr_release
-  description: BM RBR - Release
-  type: build_fw
-  args:
-    app: bm_rbr
-    bsp: bm_mote_bristleback_v1_0
-    build_type: Release
-  sign: true
-
-- name: seapoint_turbidity_release
-  description: BM Seapoint Turbidity - Release
-  type: build_fw
-  args:
-    app: seapoint_turbidity
-    bsp: bm_mote_bristleback_v1_0
     build_type: Release
   sign: true
 
@@ -126,15 +90,6 @@
     app: seapoint_turbidity
     bsp: bm_mote_rs232
     build_type: Release
-  sign: true
-
-  - name: aanderaa_debug
-  description: Aanderaa Current Meter - Debug
-  type: build_fw
-  args:
-    app: aanderaa
-    bsp: bm_mote_rs232
-    build_type: Debug
   sign: true
 
 - name: aanderaa_release

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -109,3 +109,39 @@
     bsp: bm_mote_v1.0
     build_type: Debug
   sign: false
+
+- name: bm_rbr_release
+  description: BM RBR - Release
+  type: build_fw
+  args:
+    app: bm_rbr
+    bsp: bm_mote_rs232
+    build_type: Release
+  sign: true
+
+- name: seapoint_turbidity_release
+  description: BM Seapoint Turbidity - Release
+  type: build_fw
+  args:
+    app: seapoint_turbidity
+    bsp: bm_mote_rs232
+    build_type: Release
+  sign: true
+
+  - name: aanderaa_debug
+  description: Aanderaa Current Meter - Debug
+  type: build_fw
+  args:
+    app: aanderaa
+    bsp: bm_mote_rs232
+    build_type: Debug
+  sign: true
+
+- name: aanderaa_release
+  description: Aanderaa Current Meter - Release
+  type: build_fw
+  args:
+    app: aanderaa
+    bsp: bm_mote_rs232
+    build_type: Release
+  sign: true


### PR DESCRIPTION
I forgot to add the new rs232 apps to the release build. Should I also remove the bristleback bsp version of these apps from the `default.yml`?