### PR TITLE
Experiment/user defined abstractions

### DIFF
--- a/src/apps/bm_devkit/hello_world/CMakeLists.txt
+++ b/src/apps/bm_devkit/hello_world/CMakeLists.txt
@@ -104,6 +104,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c

--- a/src/lib/bcmp/bcmp_time.cpp
+++ b/src/lib/bcmp/bcmp_time.cpp
@@ -83,13 +83,13 @@ static void bcmp_time_send_response(uint64_t target_node_id, uint64_t utc_us) {
 */
 static void bcmp_time_process_time_request_msg(const BcmpSystemTimeRequest *msg) {
   do {
-    RTCTimeAndDate_t time;
+    RtcTimeAndDate time;
     // TODO: make this an abstraction
-    if (rtcGet(&time) != pdPASS) {
+    if (bm_rtc_get(&time) != pdPASS) {
       printf("Failed to get time.\n");
       break;
     }
-    bcmp_time_send_response(msg->header.source_node_id, rtcGetMicroSeconds(&time));
+    bcmp_time_send_response(msg->header.source_node_id, bm_rtc_get_micro_seconds(&time));
   } while (0);
 }
 
@@ -101,15 +101,15 @@ static void bcmp_time_process_time_request_msg(const BcmpSystemTimeRequest *msg)
   @param[in] msg The system time set message to process.
 */
 static void bcmp_time_process_time_set_msg(const BcmpSystemTimeSet *msg) {
-  utcDateTime_t datetime;
+  UtcDateTime datetime;
   // TODO: make this an abstraction
-  dateTimeFromUtc(msg->utc_time_us, &datetime);
-  RTCTimeAndDate_t time = {// TODO: Consolidate the time functions into util.h
+  date_time_from_utc(msg->utc_time_us, &datetime);
+  RtcTimeAndDate time = {// TODO: Consolidate the time functions into util.h
                            .year = datetime.year,       .month = datetime.month,
                            .day = datetime.day,         .hour = datetime.hour,
                            .minute = datetime.min,      .second = datetime.sec,
                            .ms = (datetime.usec / 1000)};
-  if (rtcSet(&time) == pdPASS) {
+  if (bm_rtc_set(&time) == pdPASS) {
     bcmp_time_send_response(msg->header.source_node_id, msg->utc_time_us);
   } else {
     printf("Failed to set time.\n");
@@ -149,9 +149,9 @@ static BmErr bcmp_time_process_time_message(BcmpProcessData data) {
         break;
       }
       BcmpSystemTimeResponse *resp = (BcmpSystemTimeResponse *)data.payload;
-      utcDateTime_t datetime;
+      UtcDateTime datetime;
       // TODO - make this an abstraction
-      dateTimeFromUtc(resp->utc_time_us, &datetime);
+      date_time_from_utc(resp->utc_time_us, &datetime);
       printf("Response time node ID: %016" PRIx64 " to %d/%d/%d %02d:%02d:%02d.%03" PRIu32 "\n",
              resp->header.source_node_id, datetime.year, datetime.month, datetime.day,
              datetime.hour, datetime.min, datetime.sec, datetime.usec);

--- a/src/lib/bcmp/bcmp_time.cpp
+++ b/src/lib/bcmp/bcmp_time.cpp
@@ -5,6 +5,7 @@
 #include "stm32_rtc.h"
 
 extern "C" {
+#include "bm_rtc.h"
 #include "packet.h"
 }
 

--- a/src/lib/bcmp/bcmp_time.cpp
+++ b/src/lib/bcmp/bcmp_time.cpp
@@ -86,7 +86,7 @@ static void bcmp_time_process_time_request_msg(const BcmpSystemTimeRequest *msg)
   do {
     RtcTimeAndDate time;
     // TODO: make this an abstraction
-    if (bm_rtc_get(&time) != pdPASS) {
+    if (bm_rtc_get(&time) != BmOK) {
       printf("Failed to get time.\n");
       break;
     }
@@ -110,7 +110,7 @@ static void bcmp_time_process_time_set_msg(const BcmpSystemTimeSet *msg) {
                            .day = datetime.day,         .hour = datetime.hour,
                            .minute = datetime.min,      .second = datetime.sec,
                            .ms = (datetime.usec / 1000)};
-  if (bm_rtc_set(&time) == pdPASS) {
+  if (bm_rtc_set(&time) == BmOK) {
     bcmp_time_send_response(msg->header.source_node_id, msg->utc_time_us);
   } else {
     printf("Failed to set time.\n");

--- a/src/lib/bcmp/bm/bm_util.c
+++ b/src/lib/bcmp/bm/bm_util.c
@@ -1,4 +1,26 @@
 #include "bm_util.h"
 
-const ip6_addr_t multicast_global_addr = {{0x3FF,0x0,0x0,0x1000000}, 0};
-const ip6_addr_t multicast_ll_addr = {{0x2FF,0x0,0x0,0x1000000}, 0};
+#include "bm_rtc.h"
+#include "stm32_rtc.h"
+
+BmErr bm_rtc_set(const RtcTimeAndDate *time_and_date) {
+  BmErr err = BmOK;
+  if (rtcSet((RTCTimeAndDate_t)time_and_date) != pdPASS) {
+    err = BmEINVAL;
+  }
+  return err;
+}
+BmErr bm_rtc_get(RtcTimeAndDate *time_and_date) {
+  BmErr err = BmOK;
+  if (rtcGet((RTCTimeAndDate_t)time_and_date) != pdPASS) {
+    err = BmEINVAL;
+  }
+  return err;
+}
+
+uint64_t bm_rtc_get_micro_seconds(RtcTimeAndDate *time_and_date) {
+  return rtcGetMicroSeconds((RTCTimeAndDate_t)time_and_date);
+}
+
+// const ip6_addr_t multicast_global_addr = {{0x3FF,0x0,0x0,0x1000000}, 0};
+// const ip6_addr_t multicast_ll_addr = {{0x2FF,0x0,0x0,0x1000000}, 0};

--- a/src/lib/bcmp/bm/bm_util.c
+++ b/src/lib/bcmp/bm/bm_util.c
@@ -5,21 +5,21 @@
 
 BmErr bm_rtc_set(const RtcTimeAndDate *time_and_date) {
   BmErr err = BmOK;
-  if (rtcSet((RTCTimeAndDate_t)time_and_date) != pdPASS) {
+  if (rtcSet((const RTCTimeAndDate_t *)time_and_date) != pdPASS) {
     err = BmEINVAL;
   }
   return err;
 }
 BmErr bm_rtc_get(RtcTimeAndDate *time_and_date) {
   BmErr err = BmOK;
-  if (rtcGet((RTCTimeAndDate_t)time_and_date) != pdPASS) {
+  if (rtcGet((RTCTimeAndDate_t *)time_and_date) != pdPASS) {
     err = BmEINVAL;
   }
   return err;
 }
 
 uint64_t bm_rtc_get_micro_seconds(RtcTimeAndDate *time_and_date) {
-  return rtcGetMicroSeconds((RTCTimeAndDate_t)time_and_date);
+  return rtcGetMicroSeconds((RTCTimeAndDate_t *)time_and_date);
 }
 
 // const ip6_addr_t multicast_global_addr = {{0x3FF,0x0,0x0,0x1000000}, 0};

--- a/src/lib/bcmp/bm/bm_util.c
+++ b/src/lib/bcmp/bm/bm_util.c
@@ -1,26 +1,4 @@
 #include "bm_util.h"
 
-#include "bm_rtc.h"
-#include "stm32_rtc.h"
-
-BmErr bm_rtc_set(const RtcTimeAndDate *time_and_date) {
-  BmErr err = BmOK;
-  if (rtcSet((const RTCTimeAndDate_t *)time_and_date) != pdPASS) {
-    err = BmEINVAL;
-  }
-  return err;
-}
-BmErr bm_rtc_get(RtcTimeAndDate *time_and_date) {
-  BmErr err = BmOK;
-  if (rtcGet((RTCTimeAndDate_t *)time_and_date) != pdPASS) {
-    err = BmEINVAL;
-  }
-  return err;
-}
-
-uint64_t bm_rtc_get_micro_seconds(RtcTimeAndDate *time_and_date) {
-  return rtcGetMicroSeconds((RTCTimeAndDate_t *)time_and_date);
-}
-
 // const ip6_addr_t multicast_global_addr = {{0x3FF,0x0,0x0,0x1000000}, 0};
 // const ip6_addr_t multicast_ll_addr = {{0x2FF,0x0,0x0,0x1000000}, 0};

--- a/src/lib/bcmp/bm/bm_util.h
+++ b/src/lib/bcmp/bm/bm_util.h
@@ -9,8 +9,8 @@ extern "C" {
 #endif
 #include "util.h"
 
-extern const ip6_addr_t multicast_global_addr;
-extern const ip6_addr_t multicast_ll_addr;
+// extern const ip6_addr_t multicast_global_addr;
+// extern const ip6_addr_t multicast_ll_addr;
 
 //TODO: make this endian agnostic and platform agnostic
 /*!
@@ -19,15 +19,15 @@ extern const ip6_addr_t multicast_ll_addr;
   \param *ip address to extract node id from
   \return node id
 */
-static inline uint64_t ip_to_nodeid(void *ip) {
-  uint32_t high_word = ((uint32_t *)(ip))[2];
-  uint32_t low_word = ((uint32_t *)(ip))[3];
-  if (is_little_endian()) {
-    swap_32bit(&high_word);
-    swap_32bit(&low_word);
-  }
-  return (uint64_t)high_word << 32 | (uint64_t)low_word;
-}
+// static inline uint64_t ip_to_nodeid(void *ip) {
+//   uint32_t high_word = ((uint32_t *)(ip))[2];
+//   uint32_t low_word = ((uint32_t *)(ip))[3];
+//   if (is_little_endian()) {
+//     swap_32bit(&high_word);
+//     swap_32bit(&low_word);
+//   }
+//   return (uint64_t)high_word << 32 | (uint64_t)low_word;
+// }
 
 #ifdef __cplusplus
 }

--- a/src/lib/common/stress.c
+++ b/src/lib/common/stress.c
@@ -161,7 +161,7 @@ void stress_test_init(struct netif* netif, uint16_t port) {
   \return 0 if OK nonzero otherwise (see udp_send for error codes)
 */
 int32_t stress_test_tx(struct pbuf *pbuf) {
-  return safe_udp_sendto_if(_ctx.pcb, pbuf, &multicast_global_addr, _ctx.port, _ctx.netif);
+  return safe_udp_sendto_if(_ctx.pcb, pbuf, (const ip_addr_t *)&multicast_global_addr, _ctx.port, _ctx.netif);
 }
 
 /*!

--- a/src/lib/drivers/bm_rtc_wrapper.c
+++ b/src/lib/drivers/bm_rtc_wrapper.c
@@ -1,0 +1,21 @@
+#include "bm_rtc.h"
+#include "stm32_rtc.h"
+
+BmErr bm_rtc_set(const RtcTimeAndDate *time_and_date) {
+  BmErr err = BmOK;
+  if (rtcSet((const RTCTimeAndDate_t *)time_and_date) != pdPASS) {
+    err = BmEINVAL;
+  }
+  return err;
+}
+BmErr bm_rtc_get(RtcTimeAndDate *time_and_date) {
+  BmErr err = BmOK;
+  if (rtcGet((RTCTimeAndDate_t *)time_and_date) != pdPASS) {
+    err = BmEINVAL;
+  }
+  return err;
+}
+
+uint64_t bm_rtc_get_micro_seconds(RtcTimeAndDate *time_and_date) {
+  return rtcGetMicroSeconds((RTCTimeAndDate_t *)time_and_date);
+}

--- a/src/lib/middleware/middleware.cpp
+++ b/src/lib/middleware/middleware.cpp
@@ -76,7 +76,7 @@ int32_t middleware_net_tx(struct pbuf *pbuf) {
   // Don't try to transmit if the payload is too big
   if(pbuf->len <= MAX_PAYLOAD_LEN){
     // TODO - Do we always send global multicast or link local?
-    rval = safe_udp_sendto_if(_ctx.pcb, pbuf, &multicast_global_addr, _ctx.port, _ctx.netif);
+    rval = safe_udp_sendto_if(_ctx.pcb, pbuf, (const ip_addr_t *)&multicast_global_addr, _ctx.port, _ctx.netif);
   }
 
   return rval;


### PR DESCRIPTION
Uses the bm_rtc.h header file from https://github.com/bristlemouth/bm_core/pull/7 to create a bm_rtc_wrapper.c file where now bcmp_time can call the "generic" functions.

Also updates bm_core to where the bm_util.h/.c contents have been moved to `bm_common`.

- DONE - ~Blocked by https://github.com/bristlemouth/bm_core/pull/7, so we can point the commit to the right version of bm_core (i am pointing it to my branch for testing)~

~TODO -Code is ready for review but I need to gather some testing results to show the behavior has stayed the same.~
## Tests:

### Setting the time on the Mote from the bridge:
<img width="596" alt="Screenshot 2024-10-03 at 10 04 54 AM" src="https://github.com/user-attachments/assets/c03051b9-b111-4894-aab3-3c181d1605a6">

### The time on the mote afterwards:
<img width="207" alt="Screenshot 2024-10-03 at 10 05 01 AM" src="https://github.com/user-attachments/assets/d43129bf-6e47-42fb-9ccd-831118e9a66f">

### getting the time from the mote on the bridge:
<img width="512" alt="Screenshot 2024-10-03 at 10 09 17 AM" src="https://github.com/user-attachments/assets/1d00c6e3-8a08-40b8-8b4c-faf7d1901781">

### Setting the time on the bridge from the mote:
<img width="546" alt="Screenshot 2024-10-03 at 10 05 49 AM" src="https://github.com/user-attachments/assets/6ab2801b-2191-4b6e-98cb-62ed016647cd">

### The time on the bridge afterwards:
<img width="189" alt="Screenshot 2024-10-03 at 10 05 56 AM" src="https://github.com/user-attachments/assets/f913f186-3492-42d3-8ef8-f6104022ed3a">

### Getting the time from the bridge on the mote:
<img width="487" alt="Screenshot 2024-10-03 at 10 06 10 AM" src="https://github.com/user-attachments/assets/a29c4bb8-44c9-4a0b-97d3-0269b0b8d4ac">

