### PR TITLE
Experiment/user defined abstractions config

### DIFF
--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -392,7 +392,7 @@ static void defaultTask(void *parameters) {
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
-  bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
+  bcl_init(&dfu_partition, &debug_configuration_system);
 
   sensorConfig_t sensorConfig = {.sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
                                  .sensorsPollIntervalMs = sys_cfg_sensorsPollIntervalMs};

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -136,6 +136,7 @@ SerialHandle_t usbPcap = {
     .postTxCb = NULL,
 };
 
+// TODO - make a getter API for this
 cfg::Configuration *userConfigurationPartition = NULL;
 cfg::Configuration *sysConfigurationPartition = NULL;
 

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -137,6 +137,7 @@ SerialHandle_t usbPcap = {
 };
 
 cfg::Configuration *userConfigurationPartition = NULL;
+cfg::Configuration *sysConfigurationPartition = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
@@ -383,6 +384,7 @@ static void defaultTask(void *parameters) {
   debug_configuration_system.getConfig("sensorsCheckIntervalS", strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
+  sysConfigurationPartition = &debug_configuration_system;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   debugConfigurationInit(&debug_configuration_user, &debug_configuration_hardware,

--- a/src/apps/bm_devkit/hello_world/CMakeLists.txt
+++ b/src/apps/bm_devkit/hello_world/CMakeLists.txt
@@ -76,6 +76,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -244,6 +244,9 @@ static bool bcmp_dfu_tx(bcmp_message_type_t type, uint8_t *buff, uint16_t len) {
 BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *user_cfg, Configuration *sys_cfg,
                 DeviceCfg device) {
 
+  (void) user_cfg;
+  (void) sys_cfg;
+
   CTX.queue = bm_queue_create(bcmp_evt_queue_len, sizeof(BcmpQueueItem));
 
   device_init(device);
@@ -256,7 +259,7 @@ BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *user_cfg, Configurat
   bcmp_process_info_init();
 
   bm_dfu_init(bcmp_dfu_tx, dfu_partition, sys_cfg);
-  bcmp_config_init(user_cfg, sys_cfg);
+  bcmp_config_init();
   bcmp_resource_discovery_init();
 
   return bm_task_create(bcmp_thread, "BCMP", 1024, NULL, BCMP_TASK_PRIORITY, NULL);

--- a/src/lib/bcmp/bcmp.cpp
+++ b/src/lib/bcmp/bcmp.cpp
@@ -241,11 +241,8 @@ static bool bcmp_dfu_tx(bcmp_message_type_t type, uint8_t *buff, uint16_t len) {
   \param *netif lwip network interface to use
   \return none
 */
-BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *user_cfg, Configuration *sys_cfg,
+BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *sys_cfg,
                 DeviceCfg device) {
-
-  (void) user_cfg;
-  (void) sys_cfg;
 
   CTX.queue = bm_queue_create(bcmp_evt_queue_len, sizeof(BcmpQueueItem));
 

--- a/src/lib/bcmp/bcmp.h
+++ b/src/lib/bcmp/bcmp.h
@@ -22,8 +22,7 @@ using namespace cfg;
 
 static constexpr uint32_t DEFAULT_MESSAGE_TIMEOUT_MS = 24;
 
-BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *user_cfg, Configuration *sys_cfg,
-                DeviceCfg device);
+BmErr bcmp_init(NvmPartition *dfu_partition, Configuration *sys_cfg, DeviceCfg device);
 BmErr bcmp_tx(const void *dst, BcmpMessageType type, uint8_t *data, uint16_t size,
               uint32_t seq_num = 0, BmErr (*reply_cb)(uint8_t *payload) = NULL);
 BmErr bcmp_ll_forward(BcmpHeader *header, void *data, uint32_t size, uint8_t ingress_port);

--- a/src/lib/bcmp/bcmp_cli.cpp
+++ b/src/lib/bcmp/bcmp_cli.cpp
@@ -19,6 +19,7 @@
 #include "bcmp_topology.h"
 #include "bm_pubsub.h"
 #include "bm_util.h"
+#include "messages.h"
 
 #include "debug.h"
 
@@ -145,11 +146,11 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           break;
         }
         uint64_t node_id = strtoull(node_id_str, NULL, 16);
-        bm_common_config_partition_e partition;
+        BmConfigPartition partition;
         if (strncmp("u", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_USER;
+          partition = BM_CFG_PARTITION_USER;
         } else if (strncmp("s", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_SYSTEM;
+          partition = BM_CFG_PARTITION_SYSTEM;
         } else {
           printf("Invalid arguments\n");
           break;
@@ -181,11 +182,11 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           break;
         }
         uint64_t node_id = strtoull(node_id_str, NULL, 16);
-        bm_common_config_partition_e partition;
+        BmConfigPartition partition;
         if (strncmp("u", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_USER;
+          partition = BM_CFG_PARTITION_USER;
         } else if (strncmp("s", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_SYSTEM;
+          partition = BM_CFG_PARTITION_SYSTEM;
         } else {
           printf("Invalid arguments\n");
           break;
@@ -297,11 +298,11 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           break;
         }
         uint64_t node_id = strtoull(node_id_str, NULL, 16);
-        bm_common_config_partition_e partition;
+        BmConfigPartition partition;
         if (strncmp("u", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_USER;
+          partition = BM_CFG_PARTITION_USER;
         } else if (strncmp("s", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_SYSTEM;
+          partition = BM_CFG_PARTITION_SYSTEM;
         } else {
           printf("Invalid arguments\n");
           break;
@@ -324,11 +325,11 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           break;
         }
         uint64_t node_id = strtoull(node_id_str, NULL, 16);
-        bm_common_config_partition_e partition;
+        BmConfigPartition partition;
         if (strncmp("u", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_USER;
+          partition = BM_CFG_PARTITION_USER;
         } else if (strncmp("s", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_SYSTEM;
+          partition = BM_CFG_PARTITION_SYSTEM;
         } else {
           printf("Invalid arguments\n");
           break;
@@ -354,11 +355,11 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           break;
         }
         uint64_t node_id = strtoull(node_id_str, NULL, 16);
-        bm_common_config_partition_e partition;
+        BmConfigPartition partition;
         if (strncmp("u", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_USER;
+          partition = BM_CFG_PARTITION_USER;
         } else if (strncmp("s", part_str, part_str_len) == 0) {
-          partition = BM_COMMON_CFG_PARTITION_SYSTEM;
+          partition = BM_CFG_PARTITION_SYSTEM;
         } else {
           printf("Invalid arguments\n");
           break;

--- a/src/lib/bcmp/bcmp_config.cpp
+++ b/src/lib/bcmp/bcmp_config.cpp
@@ -1,4 +1,5 @@
 #include "bcmp_config.h"
+#include "bm_configs_generic.h"
 #include "FreeRTOS.h"
 #include "bcmp.h"
 #include "bm_util.h"
@@ -7,17 +8,14 @@ extern "C" {
 #include "packet.h"
 }
 
-static Configuration *USR_CFG;
-static Configuration *SYS_CFG;
-
-bool bcmp_config_get(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_get(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, BmErr &err,
                      BmErr (*reply_cb)(uint8_t *)) {
   configASSERT(key);
   bool rval = false;
   err = BmEINVAL;
-  size_t msg_size = sizeof(bm_common_config_get_t) + key_len;
-  bm_common_config_get_t *get_msg = (bm_common_config_get_t *)bm_malloc(msg_size);
+  size_t msg_size = sizeof(BmConfigGet) + key_len;
+  BmConfigGet *get_msg = (BmConfigGet *)bm_malloc(msg_size);
   configASSERT(get_msg);
   do {
     get_msg->header.target_node_id = target_node_id;
@@ -34,19 +32,19 @@ bool bcmp_config_get(uint64_t target_node_id, bm_common_config_partition_e parti
       rval = true;
     }
   } while (0);
-  vPortFree(get_msg);
+  bm_free(get_msg);
   return rval;
 }
 
-bool bcmp_config_set(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_set(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, size_t value_size, void *val, BmErr &err,
                      BmErr (*reply_cb)(uint8_t *)) {
   configASSERT(key);
   configASSERT(key);
   bool rval = false;
   err = BmEINVAL;
-  size_t msg_len = sizeof(bm_common_config_set_t) + key_len + value_size;
-  bm_common_config_set_t *set_msg = (bm_common_config_set_t *)bm_malloc(msg_len);
+  size_t msg_len = sizeof(BmConfigSet) + key_len + value_size;
+  BmConfigSet *set_msg = (BmConfigSet *)bm_malloc(msg_len);
   configASSERT(set_msg);
   do {
     set_msg->header.target_node_id = target_node_id;
@@ -65,65 +63,65 @@ bool bcmp_config_set(uint64_t target_node_id, bm_common_config_partition_e parti
       rval = true;
     }
   } while (0);
-  vPortFree(set_msg);
+  bm_free(set_msg);
   return rval;
 }
 
-bool bcmp_config_commit(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_commit(uint64_t target_node_id, BmConfigPartition partition,
                         BmErr &err) {
   bool rval = false;
   err = BmEINVAL;
-  bm_common_config_commit_t *commit_msg =
-      (bm_common_config_commit_t *)bm_malloc(sizeof(bm_common_config_commit_t));
+  BmConfigCommit *commit_msg =
+      (BmConfigCommit *)bm_malloc(sizeof(BmConfigCommit));
   configASSERT(commit_msg);
   commit_msg->header.target_node_id = target_node_id;
   commit_msg->header.source_node_id = node_id();
   commit_msg->partition = partition;
   err = bcmp_tx(&multicast_ll_addr, BcmpConfigCommitMessage, (uint8_t *)commit_msg,
-                sizeof(bm_common_config_commit_t));
+                sizeof(BmConfigCommit));
   if (err == BmOK) {
     rval = true;
   }
-  vPortFree(commit_msg);
+  bm_free(commit_msg);
   return rval;
 }
 
-bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_status_request(uint64_t target_node_id, BmConfigPartition partition,
                                 BmErr &err, BmErr (*reply_cb)(uint8_t *)) {
   bool rval = false;
   err = BmEINVAL;
-  bm_common_config_status_request_t *status_req_msg =
-      (bm_common_config_status_request_t *)pvPortMalloc(
-          sizeof(bm_common_config_status_request_t));
+  BmConfigStatusRequest *status_req_msg =
+      (BmConfigStatusRequest *)bm_malloc(
+          sizeof(BmConfigStatusRequest));
   configASSERT(status_req_msg);
   status_req_msg->header.target_node_id = target_node_id;
   status_req_msg->header.source_node_id = node_id();
   status_req_msg->partition = partition;
   err = bcmp_tx(&multicast_ll_addr, BcmpConfigStatusRequestMessage, (uint8_t *)status_req_msg,
-                sizeof(bm_common_config_status_request_t), 0, reply_cb);
+                sizeof(BmConfigStatusRequest), 0, reply_cb);
   if (err == BmOK) {
     rval = true;
   }
-  vPortFree(status_req_msg);
+  bm_free(status_req_msg);
   return rval;
 }
 
 bool bcmp_config_status_response(uint64_t target_node_id,
-                                 bm_common_config_partition_e partition, bool commited,
-                                 uint8_t num_keys, const ConfigKey_t *keys, BmErr &err,
+                                 BmConfigPartition partition, bool commited,
+                                 uint8_t num_keys, const GenericConfigKey *keys, BmErr &err,
                                  uint16_t seq_num) {
   bool rval = false;
   err = BmEINVAL;
-  size_t msg_size = sizeof(bm_common_config_status_response_t);
+  size_t msg_size = sizeof(BmConfigStatusResponse);
   for (int i = 0; i < num_keys; i++) {
-    msg_size += sizeof(bm_common_config_status_key_data_t);
+    msg_size += sizeof(BmConfigStatusKeyData);
     msg_size += keys[i].keyLen;
   }
   if (msg_size > BCMP_MAX_PAYLOAD_SIZE_BYTES) {
     return false;
   }
-  bm_common_config_status_response_t *status_resp_msg =
-      (bm_common_config_status_response_t *)pvPortMalloc(msg_size);
+  BmConfigStatusResponse *status_resp_msg =
+      (BmConfigStatusResponse *)bm_malloc(msg_size);
   configASSERT(status_resp_msg);
   do {
     status_resp_msg->header.target_node_id = target_node_id;
@@ -131,12 +129,12 @@ bool bcmp_config_status_response(uint64_t target_node_id,
     status_resp_msg->committed = commited;
     status_resp_msg->partition = partition;
     status_resp_msg->num_keys = num_keys;
-    bm_common_config_status_key_data_t *key_data =
-        (bm_common_config_status_key_data_t *)status_resp_msg->keyData;
+    BmConfigStatusKeyData *key_data =
+        (BmConfigStatusKeyData *)status_resp_msg->keyData;
     for (int i = 0; i < num_keys; i++) {
       key_data->key_length = keys[i].keyLen;
       memcpy(key_data->key, keys[i].keyBuffer, keys[i].keyLen);
-      key_data += sizeof(bm_common_config_status_key_data_t);
+      key_data += sizeof(BmConfigStatusKeyData);
       key_data += keys[i].keyLen;
     }
     err = bcmp_tx(&multicast_ll_addr, BcmpConfigStatusResponseMessage,
@@ -145,44 +143,23 @@ bool bcmp_config_status_response(uint64_t target_node_id,
       rval = true;
     }
   } while (0);
-  vPortFree(status_resp_msg);
+  bm_free(status_resp_msg);
   return rval;
 }
 
-static void bcmp_config_process_commit_msg(bm_common_config_commit_t *msg) {
+static void bcmp_config_process_commit_msg(BmConfigCommit *msg) {
   configASSERT(msg);
-  switch (msg->partition) {
-  case BM_COMMON_CFG_PARTITION_USER: {
-    USR_CFG->saveConfig(); // Reboot!
-    break;
-  }
-  case BM_COMMON_CFG_PARTITION_SYSTEM: {
-    SYS_CFG->saveConfig(); // Reboot!
-    break;
-  }
-  default:
-    printf("Invalid partition\n");
-    break;
-  }
+  bcmp_commit_config((BmConfigPartition)msg->partition);
 }
 
-static void bcmp_config_process_status_request_msg(bm_common_config_status_request_t *msg,
+static void bcmp_config_process_status_request_msg(BmConfigStatusRequest *msg,
                                                    uint16_t seq_num) {
   configASSERT(msg);
   BmErr err;
   do {
-    Configuration *cfg;
-    if (msg->partition == BM_COMMON_CFG_PARTITION_USER) {
-      cfg = USR_CFG;
-    } else if (msg->partition == BM_COMMON_CFG_PARTITION_SYSTEM) {
-      cfg = SYS_CFG;
-    } else {
-      printf("Invalid configuration\n");
-      break;
-    }
     uint8_t num_keys;
-    const ConfigKey_t *keys = cfg->getStoredKeys(num_keys);
-    bcmp_config_status_response(msg->header.source_node_id, msg->partition, cfg->needsCommit(),
+    const GenericConfigKey *keys =bcmp_config_get_stored_keys(num_keys, msg->partition);
+    bcmp_config_status_response(msg->header.source_node_id, msg->partition, bcmp_config_needs_commit(msg->partition),
                                 num_keys, keys, err, seq_num);
     if (err != BmOK) {
       printf("Error processing config status request.\n");
@@ -191,12 +168,12 @@ static void bcmp_config_process_status_request_msg(bm_common_config_status_reque
 }
 
 static bool bcmp_config_send_value(uint64_t target_node_id,
-                                   bm_common_config_partition_e partition, uint32_t data_length,
+                                   BmConfigPartition partition, uint32_t data_length,
                                    void *data, BmErr &err, uint16_t seq_num) {
   bool rval = false;
   err = BmEINVAL;
-  size_t msg_len = data_length + sizeof(bm_common_config_value_t);
-  bm_common_config_value_t *value_msg = (bm_common_config_value_t *)pvPortMalloc(msg_len);
+  size_t msg_len = data_length + sizeof(BmConfigValue);
+  BmConfigValue *value_msg = (BmConfigValue *)bm_malloc(msg_len);
   configASSERT(value_msg);
   do {
     value_msg->header.target_node_id = target_node_id;
@@ -210,49 +187,33 @@ static bool bcmp_config_send_value(uint64_t target_node_id,
       rval = true;
     }
   } while (0);
-  vPortFree(value_msg);
+  bm_free(value_msg);
   return rval;
 }
 
-static void bcmp_config_process_config_get_msg(bm_common_config_get_t *msg, uint16_t seq_num) {
+static void bcmp_config_process_config_get_msg(BmConfigGet *msg, uint16_t seq_num) {
   configASSERT(msg);
   do {
-    Configuration *cfg;
-    if (msg->partition == BM_COMMON_CFG_PARTITION_USER) {
-      cfg = USR_CFG;
-    } else if (msg->partition == BM_COMMON_CFG_PARTITION_SYSTEM) {
-      cfg = SYS_CFG;
-    } else {
-      break;
-    }
     size_t buffer_len = cfg::MAX_CONFIG_BUFFER_SIZE_BYTES;
-    uint8_t *buffer = (uint8_t *)pvPortMalloc(buffer_len);
+    uint8_t *buffer = (uint8_t *)bm_malloc(buffer_len);
     configASSERT(buffer);
-    if (cfg->getConfigCbor(msg->key, msg->key_length, buffer, buffer_len)) {
+    if (bcmp_get_config(msg->key, msg->key_length, buffer, buffer_len, msg->partition)) {
       BmErr err;
       bcmp_config_send_value(msg->header.source_node_id, msg->partition, buffer_len, buffer,
                              err, seq_num);
     }
-    vPortFree(buffer);
+    bm_free(buffer);
   } while (0);
 }
 
-static void bcmp_config_process_config_set_msg(bm_common_config_set_t *msg, uint16_t seq_num) {
+static void bcmp_config_process_config_set_msg(BmConfigSet *msg, uint16_t seq_num) {
   configASSERT(msg);
   do {
-    Configuration *cfg;
-    if (msg->partition == BM_COMMON_CFG_PARTITION_USER) {
-      cfg = USR_CFG;
-    } else if (msg->partition == BM_COMMON_CFG_PARTITION_SYSTEM) {
-      cfg = SYS_CFG;
-    } else {
-      break;
-    }
     if (msg->data_length > cfg::MAX_CONFIG_BUFFER_SIZE_BYTES || msg->data_length == 0) {
       break;
     }
-    if (cfg->setConfigCbor((const char *)msg->keyAndData, msg->key_length,
-                           &msg->keyAndData[msg->key_length], msg->data_length)) {
+    if (bcmp_set_config((const char *)msg->keyAndData, msg->key_length,
+                        &msg->keyAndData[msg->key_length], msg->data_length, msg->partition)) {
       BmErr err;
       bcmp_config_send_value(msg->header.source_node_id, msg->partition, msg->data_length,
                              &msg->keyAndData[msg->key_length], err, seq_num);
@@ -260,7 +221,7 @@ static void bcmp_config_process_config_set_msg(bm_common_config_set_t *msg, uint
   } while (0);
 }
 
-static void bcmp_process_value_message(bm_common_config_value_t *msg) {
+static void bcmp_process_value_message(BmConfigValue *msg) {
   CborValue it;
   CborParser parser;
   do {
@@ -301,7 +262,7 @@ static void bcmp_process_value_message(bm_common_config_value_t *msg) {
     }
     case cfg::ConfigDataTypes_e::STR: {
       size_t buffer_len = cfg::MAX_CONFIG_BUFFER_SIZE_BYTES;
-      char *buffer = (char *)pvPortMalloc(buffer_len);
+      char *buffer = (char *)bm_malloc(buffer_len);
       configASSERT(buffer);
       do {
         if (cbor_value_copy_text_string(&it, buffer, &buffer_len, NULL) != CborNoError) {
@@ -313,12 +274,12 @@ static void bcmp_process_value_message(bm_common_config_value_t *msg) {
         buffer[buffer_len] = '\0';
         printf("Node Id: %016" PRIx64 " Value:%s\n", msg->header.source_node_id, buffer);
       } while (0);
-      vPortFree(buffer);
+      bm_free(buffer);
       break;
     }
     case cfg::ConfigDataTypes_e::BYTES: {
       size_t buffer_len = cfg::MAX_CONFIG_BUFFER_SIZE_BYTES;
-      uint8_t *buffer = (uint8_t *)pvPortMalloc(buffer_len);
+      uint8_t *buffer = (uint8_t *)bm_malloc(buffer_len);
       configASSERT(buffer);
       do {
         if (cbor_value_copy_byte_string(&it, buffer, &buffer_len, NULL) != CborNoError) {
@@ -333,13 +294,13 @@ static void bcmp_process_value_message(bm_common_config_value_t *msg) {
         }
         printf("\n");
       } while (0);
-      vPortFree(buffer);
+      bm_free(buffer);
       break;
     }
     case cfg::ConfigDataTypes_e::ARRAY: {
       printf("Node Id: %016" PRIx64 " Value: Array\n", msg->header.source_node_id);
       size_t buffer_len = cfg::MAX_CONFIG_BUFFER_SIZE_BYTES;
-      uint8_t *buffer = static_cast<uint8_t *>(pvPortMalloc(buffer_len));
+      uint8_t *buffer = static_cast<uint8_t *>(bm_malloc(buffer_len));
       configASSERT(buffer);
       for (size_t i = 0; i < buffer_len; i++) {
         printf(" %02x", buffer[i]);
@@ -348,20 +309,20 @@ static void bcmp_process_value_message(bm_common_config_value_t *msg) {
         }
       }
       printf("\n");
-      vPortFree(buffer);
+      bm_free(buffer);
       break;
     }
     }
   } while (0);
 }
 
-bool bcmp_config_del_key(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_del_key(uint64_t target_node_id, BmConfigPartition partition,
                          size_t key_len, const char *key, BmErr (*reply_cb)(uint8_t *)) {
   configASSERT(key);
   bool rval = false;
-  size_t msg_size = sizeof(bm_common_config_delete_key_request_t) + key_len;
-  bm_common_config_delete_key_request_t *del_msg =
-      (bm_common_config_delete_key_request_t *)pvPortMalloc(msg_size);
+  size_t msg_size = sizeof(BmConfigDeleteKeyRequest) + key_len;
+  BmConfigDeleteKeyRequest *del_msg =
+      (BmConfigDeleteKeyRequest *)bm_malloc(msg_size);
   configASSERT(del_msg);
   del_msg->header.target_node_id = target_node_id;
   del_msg->header.source_node_id = node_id();
@@ -372,19 +333,19 @@ bool bcmp_config_del_key(uint64_t target_node_id, bm_common_config_partition_e p
               msg_size, 0, reply_cb) == BmOK) {
     rval = true;
   }
-  vPortFree(del_msg);
+  bm_free(del_msg);
   return rval;
 }
 
 static bool bcmp_config_send_del_key_response(uint64_t target_node_id,
-                                              bm_common_config_partition_e partition,
+                                              BmConfigPartition partition,
                                               size_t key_len, const char *key, bool success,
                                               uint16_t seq_num) {
   configASSERT(key);
   bool rval = false;
-  size_t msg_size = sizeof(bm_common_config_delete_key_response_t) + key_len;
-  bm_common_config_delete_key_response_t *del_resp =
-      (bm_common_config_delete_key_response_t *)pvPortMalloc(msg_size);
+  size_t msg_size = sizeof(BmConfigDeleteKeyResponse) + key_len;
+  BmConfigDeleteKeyResponse *del_resp =
+      (BmConfigDeleteKeyResponse *)bm_malloc(msg_size);
   configASSERT(del_resp);
   del_resp->header.target_node_id = target_node_id;
   del_resp->header.source_node_id = node_id();
@@ -396,23 +357,15 @@ static bool bcmp_config_send_del_key_response(uint64_t target_node_id,
               msg_size, seq_num) == BmOK) {
     rval = true;
   }
-  vPortFree(del_resp);
+  bm_free(del_resp);
   return rval;
 }
 
-static void bcmp_process_del_request_message(bm_common_config_delete_key_request_t *msg,
+static void bcmp_process_del_request_message(BmConfigDeleteKeyRequest *msg,
                                              uint16_t seq_num) {
   configASSERT(msg);
   do {
-    Configuration *cfg;
-    if (msg->partition == BM_COMMON_CFG_PARTITION_USER) {
-      cfg = USR_CFG;
-    } else if (msg->partition == BM_COMMON_CFG_PARTITION_SYSTEM) {
-      cfg = SYS_CFG;
-    } else {
-      break;
-    }
-    bool success = cfg->removeKey(msg->key, msg->key_length);
+    bool success = bcmp_remove_key(msg->key, msg->key_length, msg->partition);
     if (!bcmp_config_send_del_key_response(msg->header.source_node_id, msg->partition,
                                            msg->key_length, msg->key, success, seq_num)) {
       printf("Failed to send del key resp\n");
@@ -420,14 +373,14 @@ static void bcmp_process_del_request_message(bm_common_config_delete_key_request
   } while (0);
 }
 
-static void bcmp_process_del_response_message(bm_common_config_delete_key_response_t *msg) {
+static void bcmp_process_del_response_message(BmConfigDeleteKeyResponse *msg) {
   configASSERT(msg);
-  char *keyprintbuf = (char *)pvPortMalloc(msg->key_length + 1);
+  char *keyprintbuf = (char *)bm_malloc(msg->key_length + 1);
   memcpy(keyprintbuf, msg->key, msg->key_length);
   keyprintbuf[msg->key_length] = '\0';
   printf("Node Id: %016" PRIx64 " Key Delete Response - Key: %s, Partition: %d, Success %d\n",
          msg->header.source_node_id, keyprintbuf, msg->partition, msg->success);
-  vPortFree(keyprintbuf);
+  bm_free(keyprintbuf);
 }
 
 /*!
@@ -436,7 +389,7 @@ static void bcmp_process_del_response_message(bm_common_config_delete_key_respon
 static BmErr bcmp_process_config_message(BcmpProcessData data) {
   BmErr err = BmEINVAL;
   bool should_forward = false;
-  bm_common_config_header_t *msg_header = (bm_common_config_header_t *)data.payload;
+  BmConfigHeader *msg_header = (BmConfigHeader *)data.payload;
 
   if (msg_header->target_node_id != node_id()) {
     should_forward = true;
@@ -444,58 +397,58 @@ static BmErr bcmp_process_config_message(BcmpProcessData data) {
     err = BmOK;
     switch (data.header->type) {
     case BcmpConfigGetMessage: {
-      bcmp_config_process_config_get_msg((bm_common_config_get_t *)(data.payload),
+      bcmp_config_process_config_get_msg((BmConfigGet *)(data.payload),
                                          data.header->seq_num);
       break;
     }
     case BcmpConfigSetMessage: {
-      bcmp_config_process_config_set_msg((bm_common_config_set_t *)data.payload,
+      bcmp_config_process_config_set_msg((BmConfigSet *)data.payload,
                                          data.header->seq_num);
       break;
     }
     case BcmpConfigCommitMessage: {
-      bcmp_config_process_commit_msg((bm_common_config_commit_t *)data.payload);
+      bcmp_config_process_commit_msg((BmConfigCommit *)data.payload);
 
       break;
     }
     case BcmpConfigStatusRequestMessage: {
-      bcmp_config_process_status_request_msg((bm_common_config_status_request_t *)data.payload,
+      bcmp_config_process_status_request_msg((BmConfigStatusRequest *)data.payload,
                                              data.header->seq_num);
       break;
     }
     case BcmpConfigStatusResponseMessage: {
-      bm_common_config_status_response_t *msg =
-          (bm_common_config_status_response_t *)data.payload;
+      BmConfigStatusResponse *msg =
+          (BmConfigStatusResponse *)data.payload;
       printf("Response msg -- Node Id: %016" PRIx64 ", Partition: %d, Commit Status: %d\n",
              msg->header.source_node_id, msg->partition, msg->committed);
       printf("Num Keys: %d\n", msg->num_keys);
-      bm_common_config_status_key_data_t *key =
-          (bm_common_config_status_key_data_t *)msg->keyData;
+      BmConfigStatusKeyData *key =
+          (BmConfigStatusKeyData *)msg->keyData;
       for (int i = 0; i < msg->num_keys; i++) {
-        char *keybuf = (char *)pvPortMalloc(key->key_length + 1);
+        char *keybuf = (char *)bm_malloc(key->key_length + 1);
         configASSERT(keybuf);
         memcpy(keybuf, key->key, key->key_length);
         keybuf[key->key_length] = '\0';
         printf("%s\n", keybuf);
-        key += key->key_length + sizeof(bm_common_config_status_key_data_t);
-        vPortFree(keybuf);
+        key += key->key_length + sizeof(BmConfigStatusKeyData);
+        bm_free(keybuf);
       }
       break;
     }
     case BcmpConfigValueMessage: {
-      bm_common_config_value_t *msg = (bm_common_config_value_t *)data.payload;
+      BmConfigValue *msg = (BmConfigValue *)data.payload;
       bcmp_process_value_message(msg);
       break;
     }
     case BcmpConfigDeleteRequestMessage: {
-      bm_common_config_delete_key_request_t *msg =
-          (bm_common_config_delete_key_request_t *)data.payload;
+      BmConfigDeleteKeyRequest *msg =
+          (BmConfigDeleteKeyRequest *)data.payload;
       bcmp_process_del_request_message(msg, data.header->seq_num);
       break;
     }
     case BcmpConfigDeleteResponseMessage: {
-      bm_common_config_delete_key_response_t *msg =
-          (bm_common_config_delete_key_response_t *)data.payload;
+      BmConfigDeleteKeyResponse *msg =
+          (BmConfigDeleteKeyResponse *)data.payload;
       bcmp_process_del_response_message(msg);
       break;
     }
@@ -512,8 +465,8 @@ static BmErr bcmp_process_config_message(BcmpProcessData data) {
   return err;
 }
 
-BmErr bcmp_config_init(Configuration *user_cfg, Configuration *sys_cfg) {
-  BmErr err = BmEINVAL;
+BmErr bcmp_config_init(void) {
+  BmErr err = BmOK;
   BcmpPacketCfg config_get = {
       false,
       true,
@@ -554,12 +507,6 @@ BmErr bcmp_config_init(Configuration *user_cfg, Configuration *sys_cfg) {
       false,
       bcmp_process_config_message,
   };
-
-  if (user_cfg && sys_cfg) {
-    err = BmOK;
-    USR_CFG = user_cfg;
-    SYS_CFG = sys_cfg;
-  }
 
   bm_err_check(err, packet_add(&config_get, BcmpConfigGetMessage));
   bm_err_check(err, packet_add(&config_set, BcmpConfigSetMessage));

--- a/src/lib/bcmp/bcmp_config.h
+++ b/src/lib/bcmp/bcmp_config.h
@@ -1,25 +1,24 @@
 #pragma once
 
-#include "bm_common_structs.h"
-#include "configuration.h"
+#include "messages.h"
+#include "bm_configs_generic.h"
 #include "util.h"
 #include <stdint.h>
 
-using namespace cfg;
-
-BmErr bcmp_config_init(Configuration *user_cfg, Configuration *sys_cfg);
-bool bcmp_config_get(uint64_t target_node_id, bm_common_config_partition_e partition,
+BmErr bcmp_config_init(void);
+bool bcmp_config_get(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, BmErr &err,
                      BmErr (*reply_cb)(uint8_t *) = NULL);
-bool bcmp_config_set(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_set(uint64_t target_node_id, BmConfigPartition partition,
                      size_t key_len, const char *key, size_t value_size, void *val, BmErr &err,
                      BmErr (*reply_cb)(uint8_t *) = NULL);
-bool bcmp_config_commit(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_commit(uint64_t target_node_id, BmConfigPartition partition,
                         BmErr &err);
-bool bcmp_config_status_request(uint64_t target_node_id, bm_common_config_partition_e partition,
+bool bcmp_config_status_request(uint64_t target_node_id, BmConfigPartition partition,
                                 BmErr &err, BmErr (*reply_cb)(uint8_t *) = NULL);
 bool bcmp_config_status_response(uint64_t target_node_id,
-                                 bm_common_config_partition_e partition, bool commited,
-                                 BmErr &err);
-bool bcmp_config_del_key(uint64_t target_node_id, bm_common_config_partition_e partition,
+                                 BmConfigPartition partition, bool commited,
+                                 uint8_t num_keys, const GenericConfigKey *keys, BmErr &err,
+                                 uint16_t seq_num);
+bool bcmp_config_del_key(uint64_t target_node_id, BmConfigPartition partition,
                          size_t key_len, const char *key, BmErr (*reply_cb)(uint8_t *) = NULL);

--- a/src/lib/bcmp/bm/bristlemouth.cpp
+++ b/src/lib/bcmp/bm/bristlemouth.cpp
@@ -37,8 +37,7 @@ void bm_link_change_cb(uint8_t port, bool state) {
   bcmp_link_change(port, state);
 }
 
-void bcl_init(NvmPartition *dfu_partition, cfg::Configuration *usr_cfg,
-              cfg::Configuration *sys_cfg) {
+void bcl_init(NvmPartition *dfu_partition, cfg::Configuration *sys_cfg) {
   err_t mld6_err;
   // int         rval;
   ip6_addr_t multicast_glob_addr;
@@ -101,7 +100,7 @@ void bcl_init(NvmPartition *dfu_partition, cfg::Configuration *usr_cfg,
       .sn = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'},
   };
 
-  bcmp_init(dfu_partition, usr_cfg, sys_cfg, device);
+  bcmp_init(dfu_partition, sys_cfg, device);
   bcmp_cli_init();
 
   bm_middleware_init(&netif, BM_MIDDLEWARE_PORT);

--- a/src/lib/bcmp/bm/bristlemouth.h
+++ b/src/lib/bcmp/bm/bristlemouth.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 
-void bcl_init(NvmPartition * dfu_partition, cfg::Configuration* usr_cfg, cfg::Configuration* sys_cfg);
+void bcl_init(NvmPartition * dfu_partition, cfg::Configuration* sys_cfg);
 const char *bcl_get_ip_str(uint8_t ip);
 
 #ifdef __cplusplus

--- a/src/lib/sys/bm_config_wrapper.cpp
+++ b/src/lib/sys/bm_config_wrapper.cpp
@@ -1,0 +1,90 @@
+#include "configuration.h"
+#include "bm_configs_generic.h"
+
+using namespace cfg;
+
+extern cfg::Configuration *userConfigurationPartition;
+extern cfg::Configuration *sysConfigurationPartition;
+
+const GenericConfigKey *bcmp_config_get_stored_keys(uint8_t &num_stored_keys, BmConfigPartition partition) {
+  Configuration *cfg;
+  if (partition == BM_CFG_PARTITION_USER) {
+    cfg = userConfigurationPartition;
+  } else if (partition == BM_CFG_PARTITION_SYSTEM) {
+    cfg = sysConfigurationPartition;
+  } else {
+    printf("Invalid configuration\n");
+    return NULL;
+  }
+  return (const GenericConfigKey *)cfg->getStoredKeys(num_stored_keys);
+}
+
+bool bcmp_remove_key(const char *key, size_t key_len, BmConfigPartition partition) {
+  Configuration *cfg;
+  if (partition == BM_CFG_PARTITION_USER) {
+    cfg = userConfigurationPartition;
+  } else if (partition == BM_CFG_PARTITION_SYSTEM) {
+    cfg = sysConfigurationPartition;
+  } else {
+    return false;
+  }
+  return cfg->removeKey(key, key_len);
+}
+
+bool bcmp_config_needs_commit(BmConfigPartition partition) {
+  switch (partition) {
+    case BM_CFG_PARTITION_USER: {
+      return userConfigurationPartition->needsCommit();
+    }
+    case BM_CFG_PARTITION_SYSTEM: {
+      return userConfigurationPartition->needsCommit();
+    }
+    default: {
+      printf("Invalid partition\n");
+      return false;
+    }
+  }
+}
+
+bool bcmp_commit_config(BmConfigPartition partition) {
+  switch (partition) {
+  case BM_CFG_PARTITION_USER: {
+    userConfigurationPartition->saveConfig(); // Reboot!
+    return true;
+  }
+  case BM_CFG_PARTITION_SYSTEM: {
+    sysConfigurationPartition->saveConfig(); // Reboot!
+    return true;
+  }
+  default:
+    printf("Invalid partition\n");
+    return false;
+  }
+}
+
+bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value,
+                     size_t value_len, BmConfigPartition partition) {
+  Configuration *cfg;
+  if (partition == BM_CFG_PARTITION_USER) {
+    cfg = userConfigurationPartition;
+  } else if (partition == BM_CFG_PARTITION_SYSTEM) {
+    cfg = sysConfigurationPartition;
+  } else {
+    return false;
+  }
+  return cfg->setConfigCbor((const char *)key, key_len,
+                       value, value_len);
+}
+
+bool bcmp_get_config(const char *key, size_t key_len, uint8_t *value,
+                     size_t &value_len, BmConfigPartition partition) {
+  Configuration *cfg;
+  if (partition == BM_CFG_PARTITION_USER) {
+    cfg = userConfigurationPartition;
+  } else if (partition == BM_CFG_PARTITION_SYSTEM) {
+    cfg = sysConfigurationPartition;
+  } else {
+    return false;
+  }
+  return cfg->getConfigCbor(key, key_len, value, value_len);
+}

--- a/src/lib/sys/configuration.cpp
+++ b/src/lib/sys/configuration.cpp
@@ -42,7 +42,7 @@ bool Configuration::loadAndVerifyNvmConfig(void) {
 
 /*!
  * @brief Get the the entire cbor encoded Configuration CRC.
- * @note This differs from the ConfigPartition_t header.crc32, 
+ * @note This differs from the ConfigPartition_t header.crc32,
  * which is strictly used for partition validation.
  * @return The CRC32 of the entire cbor encoded Configuration.
  */


### PR DESCRIPTION
In this I am moving all of the `configuration.h/.cpp` specific stuff from `bcmp_config.h/.cpp` into a new file called `bm_config_wrapper.cpp`. I am also removing the init pass-through of the `cfg::usr_cfg` object since we don't need/want to pass it through anymore. I also updated the config struct/enum types to use the new ones defined in `bm_core/messages.h`(which were added in https://github.com/bristlemouth/bm_core/pull/7).


# Testing:
## Mote info:
<img width="465" alt="Screenshot 2024-10-03 at 10 54 14 AM" src="https://github.com/user-attachments/assets/1120ea58-8a2f-4a3f-b420-3c6014569df1">

## Testing sys partition
### Set config on mote from Spotter
<img width="704" alt="Screenshot 2024-10-03 at 10 48 36 AM" src="https://github.com/user-attachments/assets/1737ca1a-37de-41cc-9749-7b95582eacdf">

### Commit config on mote from Spotter
<img width="565" alt="Screenshot 2024-10-03 at 10 48 46 AM" src="https://github.com/user-attachments/assets/63b3dd0f-9af6-42a2-9622-1e1395cad1e7">

### Get config from mote to Spotter
<img width="702" alt="Screenshot 2024-10-03 at 10 48 59 AM" src="https://github.com/user-attachments/assets/a436ea9c-97f5-4265-a015-d75bd0bc21d2">

### Get config status from mote to Spotter
<img width="877" alt="Screenshot 2024-10-03 at 10 49 08 AM" src="https://github.com/user-attachments/assets/f780e8a1-cade-4ff8-a542-7a61981964ff">

### Delete config on mote from Spotter and commit it
<img width="1152" alt="Screenshot 2024-10-03 at 10 49 37 AM" src="https://github.com/user-attachments/assets/70c60c2f-c067-41da-8b5c-22c72d9dde46">

### Get config status from mote after deletion
<img width="888" alt="Screenshot 2024-10-03 at 10 49 52 AM" src="https://github.com/user-attachments/assets/79699847-cb5d-4de0-82d4-021b36693db2">


## Testing usr partition
### Set config on mote from Spotter
<img width="695" alt="Screenshot 2024-10-03 at 10 50 25 AM" src="https://github.com/user-attachments/assets/c0f39d9f-dc9f-4865-84d1-8c1842ca324c">

### Commit config on mote from Spotter
<img width="235" alt="Screenshot 2024-10-03 at 10 50 32 AM" src="https://github.com/user-attachments/assets/40a0a94c-082d-4929-86a3-96a2f6fe942d">

### Get config from mote to Spotter
<img width="705" alt="Screenshot 2024-10-03 at 10 50 57 AM" src="https://github.com/user-attachments/assets/ca2f4dbe-4c30-48e9-aad1-ba615ba0c120">

### Get config status from mote to Spotter
<img width="878" alt="Screenshot 2024-10-03 at 10 51 09 AM" src="https://github.com/user-attachments/assets/a5195168-f19f-4fa4-9b7f-2468ff170059">

### Delete config on mote from Spotter
<img width="982" alt="Screenshot 2024-10-03 at 10 51 25 AM" src="https://github.com/user-attachments/assets/633538e8-e024-46d4-bfb5-4531c5813c48">

### Commit deletion
<img width="251" alt="Screenshot 2024-10-03 at 10 51 37 AM" src="https://github.com/user-attachments/assets/aeff88b0-aeed-4d39-b6b5-e4e4f5e48e73">

### Get config status from mote after deletion
<img width="865" alt="Screenshot 2024-10-03 at 10 51 51 AM" src="https://github.com/user-attachments/assets/e6a0bb0a-0bc2-455d-b5dc-9b6fb7e463b2">
