### PR TITLE
Prevent Watchdog From Tripping At First Aligned Interval Reading In Power Controller

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -362,6 +362,10 @@ uint32_t BridgePowerController::getCurrentTimeS() {
 uint32_t BridgePowerController::_alignNextInterval(uint32_t nowEpochS,
                                                    uint32_t lastIntervalStartS,
                                                    uint32_t sampleIntervalS) {
+  if (!lastIntervalStartS) {
+    // Prevent many loops from occurring and tripping watchdog
+    lastIntervalStartS = nowEpochS - (nowEpochS % sampleIntervalS);
+  }
   uint32_t alignedEpoch = lastIntervalStartS + sampleIntervalS;
   while (alignedEpoch < nowEpochS) {
     // If the aligned epoch is in the past, the timebase must have just jumped forward.


### PR DESCRIPTION
Well it looks like out time is up (pun intended).
The epoch time had gotten too large that when we started to align interval start times for the power controller starting from 0 in variable `lastIntervalStartS`, we began tripping the wdt.
This probably should get released ASAP, because there is a potential that many units in the field would be experiencing cyclic WDT resets on boot (I saw we have an upcoming release in our iteration).
