### PR TITLE
Pulls Out Many ADIN Related Items

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -1,6 +1,7 @@
 #include "bridgePowerController.h"
 #include "FreeRTOS.h"
 #include "app_pub_sub.h"
+#include "app_util.h"
 #include "bm_l2.h"
 #include "bm_serial.h"
 #include "bridgeLog.h"
@@ -9,7 +10,6 @@
 #include "stm32_rtc.h"
 #include "task.h"
 #include "task_priorities.h"
-#include "app_util.h"
 #include <cinttypes>
 #include <stdio.h>
 #ifdef RAW_PRESSURE_ENABLE
@@ -312,13 +312,12 @@ void BridgePowerController::powerControllerRun(void *arg) {
 
 bool BridgePowerController::getAdinDevice() {
   bool rval = false;
-  for (uint32_t port = 0; port < bm_l2_get_num_ports(); port++) {
+  for (uint32_t device = 0; device < bm_l2_get_num_devices(); device++) {
     adin2111_DeviceHandle_t adin_handle;
-    bm_netdev_type_t dev_type = BM_NETDEV_TYPE_NONE;
     uint32_t start_port_idx;
-    if (bm_l2_get_device_handle(port, reinterpret_cast<void **>(&adin_handle), &dev_type,
+    if (bm_l2_get_device_handle(device, reinterpret_cast<void **>(&adin_handle),
                                 &start_port_idx) &&
-        (dev_type == BM_NETDEV_TYPE_ADIN2111)) {
+        (adin_handle != NULL)) {
       _adin_handle = adin_handle;
       rval = true;
       break;

--- a/src/lib/bcmp/bm/bm_l2.h
+++ b/src/lib/bcmp/bm/bm_l2.h
@@ -12,33 +12,35 @@ extern "C" {
 
 /* We store the egress port for the RX device and the ingress port of the TX device
    in bytes 5 (index 4) and 6 (index 5) of the SRC IPv6 address. */
-#define EGRESS_PORT_IDX 4
-#define INGRESS_PORT_IDX 5
-/* Define for actual netdev instance count here, as some of the later code currently iterates devices
-   using BM_NETDEV_MAX_DEVICES (which specifies the number of enum entries, not the actual number of devices).
-   If you added a new enum entry, but didn't change the instance array, the current code would crash. */
-#define BM_NETDEV_COUNT (2)
+#define egress_port_idx 4
+#define ingress_port_idx 5
 
-typedef enum {
-  BM_NETDEV_TYPE_NONE,
-  BM_NETDEV_TYPE_ADIN2111,
-  BM_NETDEV_TYPE_MAX
-} bm_netdev_type_t;
+typedef void (*BmL2ModuleLinkChangeCb)(uint8_t port, bool state);
+typedef void (*BmL2DeviceLinkChangeCb)(void *device_handle, uint8_t port, bool state);
+typedef BmErr (*BmL2TxCb)(void *device_handle, uint8_t *buff, uint16_t size, uint8_t port_mask,
+                          uint8_t port_offset);
+typedef BmErr (*BmL2RxCb)(void *device_handle, uint8_t *payload, uint16_t size,
+                          uint8_t port_mask);
+typedef BmErr (*BmL2InitCb)(void *device_handle, BmL2RxCb rx_cb,
+                            BmL2DeviceLinkChangeCb link_change_cb, uint8_t port_mask);
+typedef BmErr (*BmL2PowerDownCb)(const void *devHandle, bool on, uint8_t port_mask);
 
-typedef struct bm_netdev_config_s {
-  bm_netdev_type_t type;
-  void *config;
-} bm_netdev_config_t;
-
-typedef void (*bm_l2_link_change_cb_t)(uint8_t port, bool state);
+typedef struct {
+  void *device_handle;
+  uint8_t port_mask;
+  uint8_t num_ports;
+  BmL2InitCb init_cb;
+  BmL2PowerDownCb power_cb;
+  BmL2TxCb tx_cb;
+} BmNetDevCfg;
 
 BmErr bm_l2_link_output(void *buf, uint32_t length);
-BmErr bm_l2_init(bm_l2_link_change_cb_t link_change_cb);
+BmErr bm_l2_init(BmL2ModuleLinkChangeCb cb, const BmNetDevCfg *cfg, uint8_t count);
 void bm_l2_netif_set_power(void *dev, bool on);
 
-bool bm_l2_get_device_handle(uint8_t dev_idx, void **device_handle, bm_netdev_type_t *type,
-                             uint32_t *start_port_idx);
+bool bm_l2_get_device_handle(uint8_t dev_idx, void **device_handle, uint32_t *start_port_idx);
 uint8_t bm_l2_get_num_ports(void);
+uint8_t bm_l2_get_num_devices(void);
 bool bm_l2_get_port_state(uint8_t port);
 
 #ifdef __cplusplus

--- a/src/lib/bcmp/bm/bristlemouth.cpp
+++ b/src/lib/bcmp/bm/bristlemouth.cpp
@@ -19,6 +19,9 @@ extern "C" {
 #include "middleware.h"
 #include "task_priorities.h"
 
+#include "bm_config.h"
+#include "eth_adin2111.h"
+
 #ifdef STRESS_TEST_ENABLE
 #include "stress.h"
 #endif
@@ -56,7 +59,30 @@ void bcl_init(void) {
   printf("Starting up BCL\n");
   device_init(device);
 
-  bm_l2_init(bm_link_change_cb);
+  // TODO: this is specific configuration to the netif driver.
+  // this should be placed elsewhere based on the users chosen 10BASE-T1L
+  // chipset selection
+  static adin2111_DeviceStruct_t adin_device;
+  static const BmNetDevCfg bm_netdev_config[] = {
+      {
+          &adin_device,
+          ADIN_PORT_MASK_ALL,
+          ADIN2111_PORT_NUM,
+          adin2111_hw_init,
+          adin2111_power_cb,
+          adin2111_tx,
+      },
+      {
+          NULL,
+          0,
+          0,
+          NULL,
+          NULL,
+          NULL,
+      },
+  };
+
+  bm_l2_init(bm_link_change_cb, bm_netdev_config, array_size(bm_netdev_config));
 
   bm_ip_init();
 

--- a/src/lib/common/stress.c
+++ b/src/lib/common/stress.c
@@ -262,12 +262,12 @@ void stress_print_stats() {
   _ctx.last_bytes_received = _ctx.total_bytes_received;
   _ctx.last_bytes_ticks = xTaskGetTickCount();
 
-  for (uint32_t port = 0; port < bm_l2_get_num_ports(); port++) {
+  //TODO this will have to be updated when more devices are supported
+  for (uint32_t device = 0; device < bm_l2_get_num_devices(); device++) {
     adin2111_DeviceHandle_t adin_handle;
-    bm_netdev_type_t dev_type = BM_NETDEV_TYPE_NONE;
     uint32_t start_port_idx;
-    if (!bm_l2_get_device_handle(port, (void **)&adin_handle, &dev_type, &start_port_idx) ||
-        (dev_type != BM_NETDEV_TYPE_ADIN2111)) {
+    if (!bm_l2_get_device_handle(device, (void **)&adin_handle, &start_port_idx) ||
+        (adin_handle != NULL)) {
 
       // Not an ADIN interface, skip it
       continue;

--- a/src/lib/drivers/adin2111/include/eth_adin2111.h
+++ b/src/lib/drivers/adin2111/include/eth_adin2111.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "adin2111.h"
+#include "bm_l2.h"
 #include "lwip/netif.h"
 #include "util.h"
 #include <stdbool.h>
@@ -22,24 +23,19 @@ typedef struct {
   uint16_t frame_check_rx_err_cnt;
 } adin_port_stats_t;
 
-typedef BmErr (*adin_rx_callback_t)(void *device_handle, uint8_t *payload, uint16_t payload_len,
-                                    uint8_t port_mask);
-typedef void (*adin_link_change_callback_t)(void *device_handle, uint8_t port, bool state);
 typedef void (*adin2111_port_stats_callback_t)(adin2111_DeviceHandle_t device_handle,
                                                adin2111_Port_e port, adin_port_stats_t *stats,
                                                void *args);
 
-adi_eth_Result_e adin2111_hw_init(adin2111_DeviceHandle_t hDevice,
-                                  adin_rx_callback_t rx_callback,
-                                  adin_link_change_callback_t link_change_callback,
-                                  uint8_t enabled_port_mask);
-err_t adin2111_tx(adin2111_DeviceHandle_t hDevice, uint8_t *buf, uint16_t buf_len,
-                  uint8_t port_mask, uint8_t port_offset);
+BmErr adin2111_hw_init(void *device, BmL2RxCb rx_callback,
+                       BmL2DeviceLinkChangeCb link_change_callback, uint8_t enabled_port_mask);
+BmErr adin2111_tx(void *device, uint8_t *buf, uint16_t buf_len, uint8_t port_mask,
+                  uint8_t port_offset);
 int adin2111_hw_start(adin2111_DeviceHandle_t dev, uint8_t port_mask);
 int adin2111_hw_stop(adin2111_DeviceHandle_t dev, uint8_t port_mask);
 bool adin2111_get_port_stats(adin2111_DeviceHandle_t dev, adin2111_Port_e port,
                              adin2111_port_stats_callback_t cb, void *args);
-int adin2111_power_cb(const void *devHandle, bool on, uint8_t port_mask);
+BmErr adin2111_power_cb(const void *devHandle, bool on, uint8_t port_mask);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allows the l2 layer to standalone without ADIN related code
Adds new API to get number of configured devices and replaces items that utilized the get_port API
Formatting changes