### PR TITLE
Adds Load Cell Configuration Parameters

### DIFF
--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -22,16 +22,19 @@
 #include "bristlemouth.h"
 #include "bsp.h"
 #include "cli.h"
+#include "config_cbor_map_service.h"
+#include "debug_bm_service.h"
 #include "debug_configuration.h"
 #include "debug_dfu.h"
 #include "debug_gpio.h"
 #include "debug_memfault.h"
 #include "debug_nvm_cli.h"
+#include "debug_pluart_cli.h"
 #include "debug_rtc.h"
 #include "debug_spotter.h"
 #include "debug_sys.h"
-#include "debug_pluart_cli.h"
 #include "debug_w25.h"
+#include "echo_service.h"
 #include "external_flash_partitions.h"
 #include "gpdma.h"
 #include "gpioISR.h"
@@ -48,15 +51,12 @@
 #include "serial_console.h"
 #include "stm32_rtc.h"
 #include "stress.h"
+#include "sys_info_service.h"
 #include "timer_callback_handler.h"
 #include "usb.h"
 #include "util.h"
 #include "w25.h"
 #include "watchdog.h"
-#include "debug_bm_service.h"
-#include "echo_service.h"
-#include "sys_info_service.h"
-#include "config_cbor_map_service.h"
 
 /* USER FILE INCLUDES */
 #include "user_code.h"
@@ -137,13 +137,12 @@ SerialHandle_t usbPcap = {
 };
 
 cfg::Configuration *userConfigurationPartition = NULL;
+cfg::Configuration *systemConfigurationPartition = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
 
-extern "C" void USART3_IRQHandler(void) {
-  serialGenericUartIRQHandler(&usart3);
-}
+extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }
 
 // Only needed if we want the debug commands too
 // extern MS5803 debugPressure;
@@ -383,6 +382,7 @@ static void defaultTask(void *parameters) {
   debug_configuration_system.getConfig("sensorsCheckIntervalS", strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
+  systemConfigurationPartition = &debug_configuration_system;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   debugConfigurationInit(&debug_configuration_user, &debug_configuration_hardware,

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -21,19 +21,22 @@
 #include "bristlemouth.h"
 #include "bsp.h"
 #include "cli.h"
+#include "config_cbor_map_service.h"
+#include "debug_bm_service.h"
 #include "debug_configuration.h"
 #include "debug_dfu.h"
 #include "debug_gpio.h"
 #include "debug_memfault.h"
 #include "debug_nvm_cli.h"
+#include "debug_pluart_cli.h"
 #include "debug_rtc.h"
 #include "debug_spotter.h"
 #include "debug_sys.h"
-#include "debug_pluart_cli.h"
 #include "debug_w25.h"
 #include "external_flash_partitions.h"
 #include "gpdma.h"
 #include "gpioISR.h"
+#include "loadCellSampler.h"
 #include "memfault_platform_core.h"
 #include "ms5803.h"
 #include "nvmPartition.h"
@@ -42,20 +45,18 @@
 #include "printf.h"
 #include "ram_partitions.h"
 #include "sensorSampler.h"
+#include "sensorWatchdog.h"
 #include "sensors.h"
 #include "serial.h"
 #include "serial_console.h"
 #include "stm32_rtc.h"
 #include "stress.h"
+#include "sys_info_service.h"
 #include "timer_callback_handler.h"
 #include "usb.h"
 #include "util.h"
 #include "w25.h"
 #include "watchdog.h"
-#include "debug_bm_service.h"
-#include "sys_info_service.h"
-#include "sensorWatchdog.h"
-#include "config_cbor_map_service.h"
 /* USER FILE INCLUDES */
 #include "user_code.h"
 /* USER FILE INCLUDES END */
@@ -137,9 +138,7 @@ cfg::Configuration *systemConfigurationPartition = NULL;
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
 
-extern "C" void USART3_IRQHandler(void) {
-  serialGenericUartIRQHandler(&usart3);
-}
+extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }
 
 // Only needed if we want the debug commands too
 // extern INA::INA232 *debugIna;
@@ -171,13 +170,12 @@ extern "C" int main(void) {
   // Enable hardfault on divide-by-zero
   SCB->CCR |= 0x10;
 
-  BaseType_t rval =
-      xTaskCreate(defaultTask, "Default",
-                  // TODO - verify stack size
-                  128 * 4, NULL,
-                  // Start with very high priority during boot then downgrade
-                  // once done initializing everything
-                  2, NULL);
+  BaseType_t rval = xTaskCreate(defaultTask, "Default",
+                                // TODO - verify stack size
+                                128 * 4, NULL,
+                                // Start with very high priority during boot then downgrade
+                                // once done initializing everything
+                                2, NULL);
   configASSERT(rval == pdTRUE);
 
   // Start FreeRTOS scheduler
@@ -202,9 +200,8 @@ bool start_stress(const void *pinHandle, uint8_t value, void *args) {
   return false;
 }
 
-void handle_sensor_subscriptions(uint64_t node_id, const char *topic,
-                                 uint16_t topic_len, const uint8_t *data,
-                                 uint16_t data_len, uint8_t type,
+void handle_sensor_subscriptions(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                 const uint8_t *data, uint16_t data_len, uint8_t type,
                                  uint8_t version) {
   (void)node_id;
   (void)version;
@@ -212,8 +209,7 @@ void handle_sensor_subscriptions(uint64_t node_id, const char *topic,
   if (strncmp("button", topic, topic_len) == 0) {
     if (strncmp("on", reinterpret_cast<const char *>(data), data_len) == 0) {
       IOWrite(&LED_GREEN, BB_LED_ON);
-    } else if (strncmp("off", reinterpret_cast<const char *>(data), data_len) ==
-               0) {
+    } else if (strncmp("off", reinterpret_cast<const char *>(data), data_len) == 0) {
       IOWrite(&LED_GREEN, BB_LED_OFF);
     } else {
       // Not handled
@@ -224,9 +220,9 @@ void handle_sensor_subscriptions(uint64_t node_id, const char *topic,
   }
 }
 
-void handle_bm_subscriptions(uint64_t node_id, const char *topic,
-                             uint16_t topic_len, const uint8_t *data,
-                             uint16_t data_len, uint8_t type, uint8_t version) {
+void handle_bm_subscriptions(uint64_t node_id, const char *topic, uint16_t topic_len,
+                             const uint8_t *data, uint16_t data_len, uint8_t type,
+                             uint8_t version) {
   (void)node_id;
   if (strncmp(APP_PUB_SUB_UTC_TOPIC, topic, topic_len) == 0) {
     if (type == APP_PUB_SUB_UTC_TYPE && version == APP_PUB_SUB_UTC_VERSION) {
@@ -246,9 +242,8 @@ void handle_bm_subscriptions(uint64_t node_id, const char *topic,
       };
 
       if (rtcSet(&rtc_time) == pdPASS) {
-        printf("Set RTC to %04u-%02u-%02uT%02u:%02u:%02u.%03u\n", rtc_time.year,
-               rtc_time.month, rtc_time.day, rtc_time.hour, rtc_time.minute,
-               rtc_time.second, rtc_time.ms);
+        printf("Set RTC to %04u-%02u-%02uT%02u:%02u:%02u.%03u\n", rtc_time.year, rtc_time.month,
+               rtc_time.day, rtc_time.hour, rtc_time.minute, rtc_time.second, rtc_time.ms);
       } else {
         printf("\n Failed to set RTC.\n");
       }
@@ -264,28 +259,20 @@ void handle_bm_subscriptions(uint64_t node_id, const char *topic,
 // TODO - move this to some debug file
 // Defines lost if GPIOs for Debug CLI
 static const DebugGpio_t debugGpioPins[] = {
-    {"adin_cs", &ADIN_CS, GPIO_OUT},
-    {"adin_int", &ADIN_INT, GPIO_IN},
-    {"adin_pwr", &ADIN_PWR, GPIO_OUT},
-    {"adin_rst", &ADIN_RST, GPIO_OUT},
-    {"bb_3v3_en", &BB_3V3_EN, GPIO_OUT},
-    {"gpio1", &GPIO1, GPIO_OUT},
-    {"led_green", &LED_GREEN, GPIO_OUT},
-    {"led_blue", &LED_BLUE, GPIO_OUT},
-    {"led_red", &LED_RED, GPIO_OUT},
-    {"bb_pl_buck_en", &BB_PL_BUCK_EN, GPIO_OUT},
-    {"bb_vbus_en", &BB_VBUS_EN, GPIO_OUT},
-    {"flash_cs", &FLASH_CS, GPIO_OUT},
-    {"boot_led", &BOOT_LED, GPIO_IN},
-    {"vusb_detect", &VUSB_DETECT, GPIO_IN},
+    {"adin_cs", &ADIN_CS, GPIO_OUT},       {"adin_int", &ADIN_INT, GPIO_IN},
+    {"adin_pwr", &ADIN_PWR, GPIO_OUT},     {"adin_rst", &ADIN_RST, GPIO_OUT},
+    {"bb_3v3_en", &BB_3V3_EN, GPIO_OUT},   {"gpio1", &GPIO1, GPIO_OUT},
+    {"led_green", &LED_GREEN, GPIO_OUT},   {"led_blue", &LED_BLUE, GPIO_OUT},
+    {"led_red", &LED_RED, GPIO_OUT},       {"bb_pl_buck_en", &BB_PL_BUCK_EN, GPIO_OUT},
+    {"bb_vbus_en", &BB_VBUS_EN, GPIO_OUT}, {"flash_cs", &FLASH_CS, GPIO_OUT},
+    {"boot_led", &BOOT_LED, GPIO_IN},      {"vusb_detect", &VUSB_DETECT, GPIO_IN},
 };
 
 /* USER CODE EXECUTED HERE */
 static void user_task(void *parameters);
 
 void user_code_start() {
-  BaseType_t rval =
-      xTaskCreate(user_task, "USER", 4096, NULL, USER_TASK_PRIORITY, NULL);
+  BaseType_t rval = xTaskCreate(user_task, "USER", 4096, NULL, USER_TASK_PRIORITY, NULL);
   configASSERT(rval == pdPASS);
 }
 
@@ -339,7 +326,6 @@ static void defaultTask(void *parameters) {
 
   gpioISRStartTask();
 
-
   memfault_platform_start();
 
   pca9535StartIRQTask();
@@ -359,36 +345,29 @@ static void defaultTask(void *parameters) {
   NvmPartition debug_user_partition(debugW25, user_configuration);
   NvmPartition debug_hardware_partition(debugW25, hardware_configuration);
   NvmPartition debug_system_partition(debugW25, system_configuration);
-  cfg::Configuration debug_configuration_user(
-      debug_user_partition, ram_user_configuration, RAM_USER_CONFIG_SIZE_BYTES);
+  cfg::Configuration debug_configuration_user(debug_user_partition, ram_user_configuration,
+                                              RAM_USER_CONFIG_SIZE_BYTES);
   cfg::Configuration debug_configuration_hardware(
-      debug_hardware_partition, ram_hardware_configuration,
-      RAM_HARDWARE_CONFIG_SIZE_BYTES);
-  cfg::Configuration debug_configuration_system(debug_system_partition,
-                                                ram_system_configuration,
-                                                RAM_SYSTEM_CONFIG_SIZE_BYTES);
-  debug_configuration_system.getConfig("sensorsPollIntervalMs",
-                                       strlen("sensorsPollIntervalMs"),
+      debug_hardware_partition, ram_hardware_configuration, RAM_HARDWARE_CONFIG_SIZE_BYTES);
+  cfg::Configuration debug_configuration_system(
+      debug_system_partition, ram_system_configuration, RAM_SYSTEM_CONFIG_SIZE_BYTES);
+  debug_configuration_system.getConfig("sensorsPollIntervalMs", strlen("sensorsPollIntervalMs"),
                                        sys_cfg_sensorsPollIntervalMs);
-  debug_configuration_system.getConfig("sensorsCheckIntervalS",
-                                       strlen("sensorsCheckIntervalS"),
+  debug_configuration_system.getConfig("sensorsCheckIntervalS", strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
   systemConfigurationPartition = &debug_configuration_system;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
-  debugConfigurationInit(&debug_configuration_user,
-                         &debug_configuration_hardware,
+  debugConfigurationInit(&debug_configuration_user, &debug_configuration_hardware,
                          &debug_configuration_system);
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
-  bcl_init(&dfu_partition, &debug_configuration_user,
-           &debug_configuration_system);
+  bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
 
-  sensorConfig_t sensorConfig = {
-      .sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
-      .sensorsPollIntervalMs = sys_cfg_sensorsPollIntervalMs};
+  sensorConfig_t sensorConfig = {.sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
+                                 .sensorsPollIntervalMs = sys_cfg_sensorsPollIntervalMs};
   sensorSamplerInit(&sensorConfig);
   // must call sensorsInit after sensorSamplerInit
   sensorsInit();
@@ -404,7 +383,7 @@ static void defaultTask(void *parameters) {
   IOWrite(&LED_BLUE, BB_LED_OFF);
   IOWrite(&LED_RED, BB_LED_OFF);
   IOWrite(&BB_3V3_EN,
-          1); // 1 enables, 0 disables. Needed for I2C and I/O control.
+          1);                 // 1 enables, 0 disables. Needed for I2C and I/O control.
   IOWrite(&BB_VBUS_EN, 1);    // 0 enables, 1 disables. Needed for VOUT and 5V.
   IOWrite(&BB_PL_BUCK_EN, 1); // 0 enables, 1 disables. Vout
 #ifdef USE_MICROPYTHON

--- a/src/apps/bristleback_apps/loadcell/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/loadcell/user_code/user_code.cpp
@@ -3,10 +3,10 @@
 #include "bm_printf.h"
 #include "bm_pubsub.h"
 #include "bsp.h"
+#include "configuration.h"
 #include "debug.h"
 #include "loadCellSampler.h"
 #include "lwip/inet.h"
-#include "nau7802.h"
 #include "payload_uart.h"
 #include "sensors.h"
 #include "stm32_rtc.h"
@@ -14,14 +14,14 @@
 #include "uptime.h"
 #include "usart.h"
 #include "util.h"
+#include <string.h>
 
 #define LED_ON_TIME_MS 20
 #define LED_PERIOD_MS 1000
 
-NAU7802 loadCell(&i2c1, NAU7802_ADDR);
-
 // A timer variable we can set to trigger a pulse on LED2 when we get payload serial data
 static int32_t ledLinePulse = -1;
+extern cfg::Configuration *systemConfigurationPartition;
 // This function is called from the payload UART library in src/lib/common/payload_uart.cpp::processLine function.
 //  Every time the uart receives the configured termination character ('\0' character by default),
 //  It will:
@@ -30,10 +30,27 @@ static int32_t ledLinePulse = -1;
 //   -- write the line to a payload_data.log on the Spotter SD card.
 //   -- call this function, so we can do custom things with the data.
 //      In this case, we just set a trigger to pulse LED2 on the Dev Kit.
+NAU7802 load_cell(&i2c1, NAU7802_ADDR);
 
 void setup(void) {
+  LoadCellConfig_t load_cell_cfg = {
+      .calibration_factor = DEFAULT_CALIBRATION_FACTOR,
+      .zero_offset = DEFAULT_ZERO_OFFSET,
+  };
+  if (!systemConfigurationPartition->getConfig("loadCellCalibrationFactor",
+                                               strlen("loadCellCalibrationFactor"),
+                                               load_cell_cfg.calibration_factor)) {
+    systemConfigurationPartition->setConfig("loadCellCalibrationFactor",
+                                            strlen("loadCellCalibrationFactor"),
+                                            load_cell_cfg.calibration_factor);
+  }
+  if (!systemConfigurationPartition->getConfig(
+          "loadCellZeroOffset", strlen("loadCellZeroOffset"), load_cell_cfg.zero_offset)) {
+    systemConfigurationPartition->setConfig("loadCellZeroOffset", strlen("loadCellZeroOffset"),
+                                            load_cell_cfg.zero_offset);
+  }
   // Adds the load cell as a sensor for periodic sampling.
-  loadCellSamplerInit(&loadCell);
+  loadCellSamplerInit(&load_cell, load_cell_cfg);
   // Setup the UART – the on-board serial driver that talks to the RS232 transceiver.
   PLUART::init(USER_TASK_PRIORITY);
   // Baud set per expected baud rate of the sensor.

--- a/src/lib/sensor_sampler/loadCellSampler.h
+++ b/src/lib/sensor_sampler/loadCellSampler.h
@@ -2,4 +2,12 @@
 
 #include "nau7802.h"
 
-void loadCellSamplerInit(NAU7802 *sensor);
+#define DEFAULT_CALIBRATION_FACTOR 800.0
+#define DEFAULT_ZERO_OFFSET 80000
+
+typedef struct {
+  float calibration_factor;
+  int32_t zero_offset;
+} LoadCellConfig_t;
+
+void loadCellSamplerInit(NAU7802 *sensor, LoadCellConfig_t cfg);


### PR DESCRIPTION
- Changes where load cell is initialized at (app_main) due to the need of having configuration parameter class object available
- Will only initialize load cell on a loadcell app build
- Adds configuration parameters for calibration factor and zero offset. Default values at 800.0 and 80000 respectively.

Screenshot of setting the calibration factor:
![image](https://github.com/user-attachments/assets/5b0c0490-82e0-4d51-9f7a-5303a2f93d45)

Screenshot of setting the zero offset:
![image](https://github.com/user-attachments/assets/29ff00a9-58ff-4fe5-9440-b7fdf53ae2a9)

Screenshot of getting the calibration factor after saving:
![image](https://github.com/user-attachments/assets/502a464b-fb56-4087-a062-0831f52f6d8e)

Screenshot of getting the zero offset after saving:
![image](https://github.com/user-attachments/assets/2508b16f-e4ad-4b4b-b968-69b7be499bf9)

Below is a snippet of the load cell running with some "weight" (me squishing the loadcell) with configuration values:
```
Load cell sample called
adc0 - adc2:            0               123             84
adc0 - adc2:            0               122             191
adc0 - adc2:            0               120             130
adc0 - adc2:            0               120             77
adc0 - adc2:            0               120             108
adc0 - adc2:            0               118             201
adc0 - adc2:            0               121             20
adc0 - adc2:            0               125             105
adc0 - adc2:            0               124             114
2303285 | reading: 31572
byte zero 0
byte one 0
byte two 0
2303287 | weight: 26.158001
2303287 | calFactor: 1000.000000
2303287 | zeroOffset: 5000

```
