### PR TITLE
Updates all bmdk, rs232, SOFT, and bristleback apps to use bm_core

### DIFF
--- a/src/apps/bm_devkit/bm_loadcell/CMakeLists.txt
+++ b/src/apps/bm_devkit/bm_loadcell/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -53,12 +56,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -104,18 +109,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -136,7 +134,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -144,7 +141,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -234,7 +230,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -262,7 +257,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -139,8 +139,8 @@ SerialHandle_t usbPcap = {
 
 // TODO - make a getter API for these
 cfg::Configuration *userConfigurationPartition = NULL;
-cfg::Configuration *sysConfigurationPartition = NULL;
-cfg::Configuration *hwConfigurationPartition = NULL;
+cfg::Configuration *systemConfigurationPartition = NULL;
+cfg::Configuration *hardwareConfigurationPartition = NULL;
 NvmPartition *dfu_partition_global = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
@@ -386,8 +386,8 @@ static void defaultTask(void *parameters) {
   debug_configuration_system.getConfig("sensorsCheckIntervalS", strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
-  sysConfigurationPartition = &debug_configuration_system;
-  hwConfigurationPartition = &debug_configuration_hardware;
+  systemConfigurationPartition = &debug_configuration_system;
+  hardwareConfigurationPartition = &debug_configuration_hardware;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   dfu_partition_global = &dfu_partition;

--- a/src/apps/bm_devkit/devkit_monitor/CMakeLists.txt
+++ b/src/apps/bm_devkit/devkit_monitor/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -103,18 +108,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -135,7 +133,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -143,7 +140,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -233,7 +229,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -261,7 +256,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/nortek/CMakeLists.txt
+++ b/src/apps/bm_devkit/nortek/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -53,7 +56,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -61,6 +63,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -89,6 +92,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -105,18 +110,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -137,7 +135,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -145,7 +142,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -263,7 +258,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/pub_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/pub_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -103,18 +108,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -135,7 +133,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -143,7 +140,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -233,7 +229,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -261,7 +256,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
@@ -2,6 +2,8 @@
 #include "pubsub.h"
 #include "uptime.h"
 #include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
 #include <string.h>
 
 /*

--- a/src/apps/bm_devkit/rbr_coda_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/rbr_coda_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -42,7 +46,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,12 +58,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -89,6 +92,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -105,18 +110,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -137,7 +135,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -145,7 +142,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -263,7 +258,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/serial_bridge/CMakeLists.txt
+++ b/src/apps/bm_devkit/serial_bridge/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
     ${SRC_DIR}/third_party/cobs-c/cobs.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,7 +136,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -147,7 +144,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
     ${SRC_DIR}/third_party/cobs-c
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -237,7 +233,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -265,7 +260,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -104,18 +109,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -136,7 +134,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -144,7 +141,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -234,7 +230,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -262,7 +257,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/sub_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/sub_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/uptime.c
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -103,18 +108,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -135,7 +133,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -143,7 +140,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -233,7 +229,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -261,7 +256,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_devkit/sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/sub_example/user_code/user_code.cpp
@@ -2,6 +2,8 @@
 #include "pubsub.h"
 #include "uptime.h"
 #include <stdint.h>
+#include <stdio.h>
+#include <inttypes.h>
 #include <string.h>
 
 /*

--- a/src/apps/bm_soft_module/CMakeLists.txt
+++ b/src/apps/bm_soft_module/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,7 +58,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -63,6 +65,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -91,6 +94,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,7 +136,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -146,7 +143,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -236,7 +232,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -263,7 +258,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bmdk_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -138,8 +138,8 @@ SerialHandle_t usbPcap = {
 };
 
 cfg::Configuration *userConfigurationPartition = NULL;
-cfg::Configuration *sysConfigurationPartition = NULL;
-cfg::Configuration *hwConfigurationPartition = NULL;
+cfg::Configuration *systemConfigurationPartition = NULL;
+cfg::Configuration *hardwareConfigurationPartition = NULL;
 NvmPartition *dfu_partition_global = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
@@ -386,9 +386,9 @@ static void defaultTask(void *parameters) {
                                        sys_cfg_sensorsPollIntervalMs);
   debug_configuration_system.getConfig("sensorsCheckIntervalS", strlen("sensorsCheckIntervalS"),
                                        sys_cfg_sensorsCheckIntervalS);
-  sysConfigurationPartition = &debug_configuration_system;
+  systemConfigurationPartition = &debug_configuration_system;
   userConfigurationPartition = &debug_configuration_user;
-  hwConfigurationPartition = &debug_configuration_hardware;
+  hardwareConfigurationPartition = &debug_configuration_hardware;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   dfu_partition_global = &dfu_partition;

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -139,6 +139,8 @@ SerialHandle_t usbPcap = {
 
 cfg::Configuration *userConfigurationPartition = NULL;
 cfg::Configuration *sysConfigurationPartition = NULL;
+cfg::Configuration *hwConfigurationPartition = NULL;
+NvmPartition *dfu_partition_global = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
@@ -386,14 +388,16 @@ static void defaultTask(void *parameters) {
                                        sys_cfg_sensorsCheckIntervalS);
   sysConfigurationPartition = &debug_configuration_system;
   userConfigurationPartition = &debug_configuration_user;
+  hwConfigurationPartition = &debug_configuration_hardware;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
+  dfu_partition_global = &dfu_partition;
   debugConfigurationInit(&debug_configuration_user, &debug_configuration_hardware,
                          &debug_configuration_system);
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
-  bcl_init(&dfu_partition, &debug_configuration_user, &debug_configuration_system);
+  bcl_init();
 
   sensorConfig_t sensorConfig = {.sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
                                  .sensorsPollIntervalMs = sys_cfg_sensorsPollIntervalMs};
@@ -405,9 +409,8 @@ static void defaultTask(void *parameters) {
 
   bm_sub(APP_PUB_SUB_UTC_TOPIC, handle_bm_subscriptions);
   echo_service_init();
-  sys_info_service_init(debug_configuration_system);
-  config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
-                               debug_configuration_user);
+  sys_info_service_init();
+  config_cbor_map_service_init();
 #ifdef USE_MICROPYTHON
   micropython_freertos_init(&usbCLI);
 #endif

--- a/src/apps/bm_soft_module/user_code/user_code.cpp
+++ b/src/apps/bm_soft_module/user_code/user_code.cpp
@@ -32,7 +32,7 @@ static constexpr char sensor_bm_log_enable[] = "sensorBmLogEnable";
 
 // app_main passes a handle to the user config partition in NVM.
 extern cfg::Configuration *userConfigurationPartition;
-extern cfg::Configuration *sysConfigurationPartition;
+extern cfg::Configuration *systemConfigurationPartition;
 
 static TSYS01 soft(&spi1, &BM_CS);
 static uint32_t serial_number = 0;
@@ -49,7 +49,7 @@ static int createBmSoftDataTopic(void);
 static void BmSoftInitalize(void);
 
 static void getConfigs() {
-  if (sysConfigurationPartition->getConfig(soft_cfg_tsys_id, strlen(soft_cfg_tsys_id),
+  if (systemConfigurationPartition->getConfig(soft_cfg_tsys_id, strlen(soft_cfg_tsys_id),
                                            serial_number)) {
     printf("TSYS serial number: %" PRIu32 "\n", serial_number);
   } else {
@@ -59,7 +59,7 @@ static void getConfigs() {
   }
 
   int32_t calTempC = 0;
-  if (sysConfigurationPartition->getConfig(soft_cfg_cal_temp_c, strlen(soft_cfg_cal_temp_c),
+  if (systemConfigurationPartition->getConfig(soft_cfg_cal_temp_c, strlen(soft_cfg_cal_temp_c),
                                            calTempC)) {
     printf("Calibration temperature: %" PRId32 "\n", calTempC);
   } else {
@@ -68,7 +68,7 @@ static void getConfigs() {
     bm_printf(0, "No calibration temperature found");
   }
 
-  if (sysConfigurationPartition->getConfig(soft_cfg_cal_time_epoch,
+  if (systemConfigurationPartition->getConfig(soft_cfg_cal_time_epoch,
                                            strlen(soft_cfg_cal_time_epoch), cal_time_epoch)) {
     printf("Calibration time: %" PRIu32 "\n", cal_time_epoch);
   } else {
@@ -78,7 +78,7 @@ static void getConfigs() {
   }
 
   int32_t calOffsetMilliC = 0;
-  if (sysConfigurationPartition->getConfig(
+  if (systemConfigurationPartition->getConfig(
           soft_cfg_cal_offset_milli_c, strlen(soft_cfg_cal_offset_milli_c), calOffsetMilliC)) {
     printf("Calibration offset (milliDegC): %" PRId32 "\n", calOffsetMilliC);
   } else {
@@ -95,14 +95,14 @@ static void getConfigs() {
     printf("SOFT Delay: Using default % " PRIu32 "ms\n", soft_delay_ms);
   }
 
-  sysConfigurationPartition->getConfig(sensor_bm_log_enable, strlen(sensor_bm_log_enable),
+  systemConfigurationPartition->getConfig(sensor_bm_log_enable, strlen(sensor_bm_log_enable),
                                        sensorBmLogEnable);
   printf("sensorBmLogEnable: %" PRIu32 "\n", sensorBmLogEnable);
 }
 
 void setup(void) {
   configASSERT(userConfigurationPartition);
-  configASSERT(sysConfigurationPartition);
+  configASSERT(systemConfigurationPartition);
   getConfigs();
   BmSoftInitalize();
   bmSoftTopicStrLen = createBmSoftDataTopic();
@@ -190,7 +190,7 @@ static bool BmSoftStartAndValidate(void) {
       printf("SOFT Serial Number: Get SN Failed\n");
       break;
     }
-    if (!sysConfigurationPartition->setConfig("tsysId", strlen("tsysId"), serial_number)) {
+    if (!systemConfigurationPartition->setConfig("tsysId", strlen("tsysId"), serial_number)) {
       printf("SOFT Serial Number: Set SN Failed\n");
       break;
     }

--- a/src/apps/bristleback_apps/aanderaa/CMakeLists.txt
+++ b/src/apps/bristleback_apps/aanderaa/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,7 +58,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -63,6 +65,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -91,6 +94,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedKVPLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,14 +136,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -263,7 +258,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bristleback_apps/bm_rbr/CMakeLists.txt
+++ b/src/apps/bristleback_apps/bm_rbr/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -57,7 +60,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -66,6 +68,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/bm_rbr_data_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -94,6 +97,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -112,18 +117,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/OrderedKVPLineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -144,14 +142,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -241,7 +237,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/rbr_sensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/rbr_sensor_util.cpp
@@ -271,7 +266,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bristleback_apps/loadcell/CMakeLists.txt
+++ b/src/apps/bristleback_apps/loadcell/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -89,6 +92,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -104,18 +109,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/sensor_sampler/loadCellSampler.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -136,14 +134,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -233,7 +229,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -261,7 +256,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bristleback_apps/nortek/CMakeLists.txt
+++ b/src/apps/bristleback_apps/nortek/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -103,18 +108,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -135,14 +133,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -232,7 +228,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -260,7 +255,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bristleback_apps/seapoint_turbidity/CMakeLists.txt
+++ b/src/apps/bristleback_apps/seapoint_turbidity/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,7 +58,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -63,6 +65,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -91,6 +94,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,14 +136,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/seapoint_turbidity_sensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
@@ -264,7 +259,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/bristleback_apps/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bristleback_apps/serial_payload_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -102,18 +107,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/sensor_sampler/powerSampler.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -134,7 +132,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
@@ -142,7 +139,6 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/bristlefin
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -232,7 +228,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -260,7 +255,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/rs232_expander_apps/aanderaa/CMakeLists.txt
+++ b/src/apps/rs232_expander_apps/aanderaa/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,7 +58,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -63,6 +65,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -91,6 +94,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedKVPLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,14 +136,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -263,7 +258,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/rs232_expander_apps/bm_rbr/CMakeLists.txt
+++ b/src/apps/rs232_expander_apps/bm_rbr/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -57,7 +60,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -66,6 +68,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/bm_rbr_data_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -94,6 +97,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -112,18 +117,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/OrderedKVPLineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -144,14 +142,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -241,7 +237,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/rbr_sensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/rbr_sensor_util.cpp
@@ -271,7 +266,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -109,6 +109,8 @@ SerialHandle_t usbPcap = {
 
 cfg::Configuration *userConfigurationPartition = NULL;
 cfg::Configuration *systemConfigurationPartition = NULL;
+cfg::Configuration *hardwareConfigurationPartition = NULL;
+NvmPartition *dfu_partition_global = NULL;
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
 uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
@@ -318,16 +320,17 @@ static void defaultTask(void *parameters) {
                                        sys_cfg_sensorsCheckIntervalS);
   userConfigurationPartition = &debug_configuration_user;
   systemConfigurationPartition = &debug_configuration_system;
+  hardwareConfigurationPartition = &debug_configuration_hardware;
   NvmPartition debug_cli_partition(debugW25, cli_configuration);
   NvmPartition dfu_partition(debugW25, dfu_configuration);
+  dfu_partition_global = &dfu_partition;
   debugConfigurationInit(&debug_configuration_user,
                          &debug_configuration_hardware,
                          &debug_configuration_system);
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
-  bcl_init(&dfu_partition, &debug_configuration_user,
-           &debug_configuration_system);
+  bcl_init();
 
   sensorConfig_t sensorConfig = {
       .sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
@@ -336,9 +339,8 @@ static void defaultTask(void *parameters) {
   // must call sensorsInit after sensorSamplerInit
   sensorsInit();
   debugBmServiceInit();
-  sys_info_service_init(debug_configuration_system);
-  config_cbor_map_service_init(debug_configuration_hardware, debug_configuration_system,
-                               debug_configuration_user);
+  sys_info_service_init();
+  config_cbor_map_service_init();
   SensorWatchdog::SensorWatchdogInit();
   bm_sub(APP_PUB_SUB_UTC_TOPIC, handle_bm_subscriptions);
 

--- a/src/apps/rs232_expander_apps/seapoint_turbidity/CMakeLists.txt
+++ b/src/apps/rs232_expander_apps/seapoint_turbidity/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -41,7 +45,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -55,7 +58,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
     ${SRC_DIR}/lib/common/watchdog.c
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
@@ -63,6 +65,7 @@ set(LIB_FILES
     ${SRC_DIR}/lib/bm_common_messages/sensor_header_msg.cpp
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -91,6 +94,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -106,18 +111,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/lib/common/OrderedSeparatorLineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -138,14 +136,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -235,7 +231,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/seapoint_turbidity_sensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/sensors/sensors.cpp
@@ -264,7 +259,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/apps/rs232_expander_apps/serial_payload_example/CMakeLists.txt
+++ b/src/apps/rs232_expander_apps/serial_payload_example/CMakeLists.txt
@@ -28,6 +28,10 @@ set(BRISTLEMOUTH_INCLUDES
     ${SRC_DIR}/lib/middleware/services
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc
+    ${SRC_DIR}/lib/bm_core/include
+    ${SRC_DIR}/lib/bm_core/third_party/tinycbor/src
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/include
+    ${CMAKE_BINARY_DIR}/_deps/bm_common-src/third_party/crc
     ${BCMP_INCLUDES}
     ${BM_COMMON_MESSAGES_INCLUDES}
     )
@@ -40,7 +44,6 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/external_flash_partitions.c
     ${SRC_DIR}/lib/common/freertos_support.c
     ${SRC_DIR}/lib/common/gpioISR.c
-    ${SRC_DIR}/lib/common/lib_state_machine.cpp
     ${SRC_DIR}/lib/common/lpm_u5.c
     ${SRC_DIR}/lib/common/lptimTick_u5.c
     ${SRC_DIR}/lib/common/nvmPartition.cpp
@@ -54,12 +57,12 @@ set(LIB_FILES
     ${SRC_DIR}/lib/common/util.c
     ${SRC_DIR}/lib/common/watchdog.c
     ${SRC_DIR}/lib/common/sensorWatchdog.cpp
-    ${SRC_DIR}/lib/common/timer_callback_handler.cpp
     ${SRC_DIR}/lib/bm_common_messages/sys_info_svc_reply_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_request_msg.c
     ${SRC_DIR}/lib/bm_common_messages/config_cbor_map_srv_reply_msg.c
     ${SRC_DIR}/lib/sys/ram_partitions.c
     ${SRC_DIR}/lib/sys/configuration.cpp
+    ${SRC_DIR}/lib/sys/bm_config_wrapper.cpp
     ${SRC_DIR}/lib/debug/debug.c
     ${SRC_DIR}/lib/debug/debug_spotter.cpp
     ${SRC_DIR}/lib/debug/debug_gpio.c
@@ -88,6 +91,8 @@ set(LIB_FILES
     ${SRC_DIR}/lib/drivers/protected/protected_i2c.c
     ${SRC_DIR}/lib/drivers/protected/protected_spi.c
     ${SRC_DIR}/lib/drivers/abstract/abstract_spi.cpp
+    ${SRC_DIR}/lib/drivers/bm_dfu_wrapper.cpp
+    ${SRC_DIR}/lib/drivers/bm_rtc_wrapper.c
     ${SRC_DIR}/lib/drivers/stm32_adc.c
     ${SRC_DIR}/lib/drivers/stm32_io.c
     ${SRC_DIR}/lib/drivers/stm32_rtc.c
@@ -102,18 +107,11 @@ set(LIB_FILES
     ${SRC_DIR}/lib/sensor_sampler/powerSampler.cpp
     ${SRC_DIR}/lib/common/LineParser.cpp
     ${SRC_DIR}/third_party/aligned_malloc/aligned_malloc.c
-    ${SRC_DIR}/third_party/crc/crc16.c
-    ${SRC_DIR}/third_party/crc/crc32.c
     ${SRC_DIR}/third_party/fnv/hash_32a.c
     ${SRC_DIR}/third_party/fnv/hash_64a.c
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/FreeRTOS_CLI.c
     ${SRC_DIR}/third_party/mbedtls_base64/base64.c
     ${SRC_DIR}/third_party/printf/printf.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborparser.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder_float.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborencoder.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborerrorstrings.c
-    ${SRC_DIR}/third_party/tinycbor/src/cborvalidation.c
     ${SRC_DIR}/lib/drivers/bme280driver.cpp
     ${SRC_DIR}/third_party/BME280_driver/bme280.c
     )
@@ -134,14 +132,12 @@ set(LIB_INCLUDES
     ${SRC_DIR}/lib/middleware
     ${SRC_DIR}/third_party/
     ${SRC_DIR}/third_party/aligned_malloc/
-    ${SRC_DIR}/third_party/crc
     ${SRC_DIR}/third_party/fnv/
     ${SRC_DIR}/third_party/FreeRTOS-Plus-CLI/
     ${SRC_DIR}/third_party/printf/
     ${SRC_DIR}/lib/bridge
     ${SRC_DIR}/lib/sensor_sampler
     ${SRC_DIR}/lib/sys
-    ${SRC_DIR}/third_party/tinycbor/src
     ${SRC_DIR}/third_party/BME280_driver
     )
 
@@ -231,7 +227,6 @@ include(${LWIP_DIR}/src/Filelists.cmake)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/app_main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/bm_config.c
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common/sensors/sensors.cpp
     ${MCUBOOT_FILES}
@@ -259,7 +254,30 @@ set(APP_INCLUDES
 
 set(APP_LIBS
     lwipcore
+    bmcore
     )
+
+# Include bm_core
+set(BM_CORE_LWIP_INCLUDES
+    ${SRC_DIR}/lib/lwip
+    ${LWIP_INCLUDE_DIRS}
+    ${BCMP_INCLUDES}
+    ${BRISTLEMOUTH_INCLUDES}
+)
+set(BM_CORE_FREERTOS_INCLUDES
+    ${FREERTOS_INCLUDES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../rs232_expander_apps_common
+    ${SRC_DIR}/lib/common
+    ${MEMFAULT_INCLUDES}
+)
+
+include(${SRC_DIR}/lib/bm_core/cmake/bm_core.cmake)
+setup_bm_ip_stack(LWIP "${BM_CORE_LWIP_INCLUDES}")
+setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
+add_subdirectory(${SRC_DIR}/lib/bm_core bmcore)
+target_compile_options(bmcore PRIVATE ${COMPILE_FLAGS})
+target_compile_options(bmcommon PRIVATE ${COMPILE_FLAGS})
+target_link_libraries(bmcore PUBLIC lwipcore)
 
 set(APP_DEFINES
     APP_NAME="${APP_NAME}"

--- a/src/lib/drivers/bm_dfu_wrapper.cpp
+++ b/src/lib/drivers/bm_dfu_wrapper.cpp
@@ -13,7 +13,7 @@ extern "C" {
 static constexpr char dfu_confirm_config_key[] = "dfu_confirm";
 
 using namespace cfg;
-extern cfg::Configuration *sysConfigurationPartition;
+extern cfg::Configuration *systemConfigurationPartition;
 extern NvmPartition *dfu_partition_global;
 
 BmErr bm_dfu_client_set_confirmed(void) {
@@ -68,20 +68,20 @@ uint32_t bm_dfu_client_flash_area_get_size(const void *flash_area) {
 
 bool bm_dfu_client_confirm_is_enabled(void) {
   uint32_t val = 1;
-  if (!sysConfigurationPartition) {
+  if (!systemConfigurationPartition) {
     return false;
   }
-  sysConfigurationPartition->getConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key),
+  systemConfigurationPartition->getConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key),
                                        val);
   return val == 1;
 }
 
 void bm_dfu_client_confirm_enable(bool en) {
   uint32_t val = en;
-  if (sysConfigurationPartition) {
-    sysConfigurationPartition->setConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key),
+  if (systemConfigurationPartition) {
+    systemConfigurationPartition->setConfig(dfu_confirm_config_key, strlen(dfu_confirm_config_key),
                                          val);
-    sysConfigurationPartition->saveConfig(true);
+    systemConfigurationPartition->saveConfig(true);
   }
 }
 

--- a/src/lib/sys/bm_config_wrapper.cpp
+++ b/src/lib/sys/bm_config_wrapper.cpp
@@ -6,8 +6,8 @@ extern "C" {
 using namespace cfg;
 
 extern cfg::Configuration *userConfigurationPartition;
-extern cfg::Configuration *sysConfigurationPartition;
-extern cfg::Configuration *hwConfigurationPartition;
+extern cfg::Configuration *systemConfigurationPartition;
+extern cfg::Configuration *hardwareConfigurationPartition;
 
 const GenericConfigKey *bcmp_config_get_stored_keys(uint8_t *num_stored_keys,
                                                     BmConfigPartition partition) {
@@ -15,9 +15,9 @@ const GenericConfigKey *bcmp_config_get_stored_keys(uint8_t *num_stored_keys,
   if (partition == BM_CFG_PARTITION_USER) {
     cfg = userConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_SYSTEM) {
-    cfg = sysConfigurationPartition;
+    cfg = systemConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_HARDWARE) {
-    cfg = hwConfigurationPartition;
+    cfg = hardwareConfigurationPartition;
   } else {
     printf("Invalid configuration\n");
     return NULL;
@@ -30,9 +30,9 @@ bool bcmp_remove_key(const char *key, size_t key_len, BmConfigPartition partitio
   if (partition == BM_CFG_PARTITION_USER) {
     cfg = userConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_SYSTEM) {
-    cfg = sysConfigurationPartition;
+    cfg = systemConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_HARDWARE) {
-    cfg = hwConfigurationPartition;
+    cfg = hardwareConfigurationPartition;
   } else {
     return false;
   }
@@ -45,10 +45,10 @@ bool bcmp_config_needs_commit(BmConfigPartition partition) {
     return userConfigurationPartition->needsCommit();
   }
   case BM_CFG_PARTITION_SYSTEM: {
-    return sysConfigurationPartition->needsCommit();
+    return systemConfigurationPartition->needsCommit();
   }
   case BM_CFG_PARTITION_HARDWARE: {
-    return hwConfigurationPartition->needsCommit();
+    return hardwareConfigurationPartition->needsCommit();
   }
   default: {
     printf("Invalid partition\n");
@@ -64,11 +64,11 @@ bool bcmp_commit_config(BmConfigPartition partition) {
     return true;
   }
   case BM_CFG_PARTITION_SYSTEM: {
-    sysConfigurationPartition->saveConfig(); // Reboot!
+    systemConfigurationPartition->saveConfig(); // Reboot!
     return true;
   }
   case BM_CFG_PARTITION_HARDWARE: {
-    hwConfigurationPartition->saveConfig(); // Reboot!
+    hardwareConfigurationPartition->saveConfig(); // Reboot!
     return true;
   }
   default:
@@ -83,9 +83,9 @@ bool bcmp_set_config(const char *key, size_t key_len, uint8_t *value, size_t val
   if (partition == BM_CFG_PARTITION_USER) {
     cfg = userConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_SYSTEM) {
-    cfg = sysConfigurationPartition;
+    cfg = systemConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_HARDWARE) {
-    cfg = hwConfigurationPartition;
+    cfg = hardwareConfigurationPartition;
   } else {
     return false;
   }
@@ -98,9 +98,9 @@ bool bcmp_get_config(const char *key, size_t key_len, uint8_t *value, size_t *va
   if (partition == BM_CFG_PARTITION_USER) {
     cfg = userConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_SYSTEM) {
-    cfg = sysConfigurationPartition;
+    cfg = systemConfigurationPartition;
   } else if (partition == BM_CFG_PARTITION_HARDWARE) {
-    cfg = hwConfigurationPartition;
+    cfg = hardwareConfigurationPartition;
   } else {
     return false;
   }


### PR DESCRIPTION
This gets all of the BMDK, RS232, Bristleback and SOFT apps to conform to the same pattern that the bmdk/hello_world app has been using to test with bm_core.

We recently started editing all of the cmakelists when making changes to the hello_world on, but we didn't start out doing that, so this brings in all those initial changes.

The following are still not using bm_core: `bridge`, `bringup_bridge`, `bringup_mote`, `mote_bristlefin`, `adin_test`.

All of the updated apps compile on my machine. The CI will still likely fail because of the non-updated apps.

Now when we add new parts, such as aligned malloc, netif etc we can edit all of these cmakelists to use the new stuff right away!