### PR TITLE
CMake Presets!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tools/bin/mpy-cross
 .vscode
 cli-cmake-debug-build/
 *build/
+preset-builds
 
 src/bsp/pluteus_v3.1/*.s
 src/bsp/pluteus_v3.1/*.ld

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,60 @@
+{
+    "version": 8,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 29,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "hello-world",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/preset-builds/${presetName}",
+            "cacheVariables": {
+                "CMAKE_APP_TYPE": "BMDK",
+                "APP": "hello_world",
+                "BSP": "bm_mote_v1.0",
+                "USE_BOOTLOADER": "1",
+                "BOOTLOADER_PATH": "${sourceDir}/preset-builds/bootloader/src/bootloader-bootloader.elf",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SIGN_IMAGES": "0"
+            },
+            "toolchainFile": "${sourceDir}/cmake/arm-none-eabi-gcc.cmake"
+        },
+        {
+            "name": "bridge",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/preset-builds/${presetName}",
+            "cacheVariables": {
+                "APP": "bridge",
+                "BSP": "bridge_v1_0",
+                "USE_BOOTLOADER": "1",
+                "BOOTLOADER_PATH": "${sourceDir}/preset-builds/bootloader/src/bootloader-bootloader.elf",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SIGN_IMAGES": "0"
+            },
+            "toolchainFile": "${sourceDir}/cmake/arm-none-eabi-gcc.cmake"
+        },
+        {
+            "name": "bootloader",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/preset-builds/${presetName}",
+            "cacheVariables": {
+                "APP": "bootloader",
+                "BSP": "bootloader",
+                "CMAKE_BUILD_TYPE": "Release",
+                "SIGN_IMAGES": "0"
+            },
+            "toolchainFile": "${sourceDir}/cmake/arm-none-eabi-gcc.cmake"
+        },
+        {
+            "name": "unit-tests",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/preset-builds/${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Test",
+                "ENABLE_TESTING": "1"
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,5 +56,27 @@
                 "ENABLE_TESTING": "1"
             }
         }
+    ],
+    "buildPresets": [
+        {
+            "configurePreset": "hello-world",
+            "name": "hello-world",
+            "jobs": 0
+        },
+        {
+            "configurePreset": "bridge",
+            "name": "bridge",
+            "jobs": 0
+        },
+        {
+            "configurePreset": "bootloader",
+            "name": "bootloader",
+            "jobs": 0
+        },
+        {
+            "configurePreset": "unit-tests",
+            "name": "unit-tests",
+            "jobs": 0
+        }
     ]
 }


### PR DESCRIPTION
Since I blew away my previous IDE settings while debugging and was reconstructing them, I learned about a new feature — CMake Presets! As of this PR, you can now run the following commands and not have to remember all the magical incantations! I made the presets build in a new `preset-builds` folder so we don't overwrite existing build folders that people may have.

```
cmake --list-presets
cmake --preset bootloader
cmake --build --preset bootloader
cmake --preset hello-world
cmake --build --preset hello-world
cmake --preset bridge
cmake --build --preset bridge
cmake --preset unit-tests
cmake --build --preset unit-tests
ctest --output-on-failure --test-dir preset-builds/unit-tests
```

Running `cmake --preset hello-world` for example *configures* the build, creating the build folder if it does not exist. After that you can just run `cmake --build --preset hello-world` each time you want to build.

This all integrates super well in VS Code too! Just open the side panel for the CMake extension and choose (near the top) the configure and build presets you want. Then F7 builds your selected preset.