### PR TITLE
Update Pub/Sub Return Values Checking

### DIFF
--- a/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
@@ -1,8 +1,8 @@
 #include "user_code.h"
 #include "pubsub.h"
 #include "uptime.h"
-#include <stdint.h>
 #include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -40,8 +40,8 @@ void loop(void) {
     // Print a simple message into the data buffer to publish to the topic.
     sprintf((char *)data_buffer, "[%" PRId64 " ms] Hello World!", uptimeGetMs());
     // Publish the data buffer to the topic.
-    if (!bm_pub(EXAMPLE_PUBLISH_TOPIC, data_buffer, sizeof(data_buffer),
-                EXAMPLE_PUBLISH_TOPIC_TYPE, EXAMPLE_PUBLISH_TOPIC_VERSION)) {
+    if (bm_pub(EXAMPLE_PUBLISH_TOPIC, data_buffer, sizeof(data_buffer),
+               EXAMPLE_PUBLISH_TOPIC_TYPE, EXAMPLE_PUBLISH_TOPIC_VERSION) == BmOK) {
       printf("Failed to publish message\n");
     } else {
       printf("Published message to network: %s\n", data_buffer);

--- a/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
@@ -1,7 +1,7 @@
-#include "pubsub.h"
 #include "bm_serial.h"
 #include "cobs.h"
 #include "payload_uart.h"
+#include "pubsub.h"
 #include "task_priorities.h"
 #include <string.h>
 
@@ -16,7 +16,7 @@ static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
                    const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
   (void)node_id;
   printf("publishing %u bytes to %.*s\n", len, topic_len, topic);
-  return bm_pub_wl(topic, topic_len, payload, len, type, version);
+  return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
 }
 
 void setup() {

--- a/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaSensor.cpp
@@ -23,7 +23,7 @@ bool AanderaaSensor::subscribe() {
   int topic_strlen =
       snprintf(sub, BM_TOPIC_MAX_LEN, "sensor/%016" PRIx64 "%s", node_id, subtag);
   if (topic_strlen > 0) {
-    rval = bm_sub_wl(sub, topic_strlen, aanderaSubCallback);
+    rval = bm_sub_wl(sub, topic_strlen, aanderaSubCallback) == BmOK;
   }
   vPortFree(sub);
   return rval;

--- a/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/rbrCodaSensor.cpp
@@ -24,7 +24,7 @@ bool RbrCodaSensor::subscribe() {
   int topic_strlen =
       snprintf(sub, BM_TOPIC_MAX_LEN, "sensor/%016" PRIx64 "%s", node_id, subtag);
   if (topic_strlen > 0) {
-    rval = bm_sub_wl(sub, topic_strlen, rbrCodaSubCallback);
+    rval = bm_sub_wl(sub, topic_strlen, rbrCodaSubCallback) == BmOK;
   }
   vPortFree(sub);
   return rval;

--- a/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.cpp
@@ -23,7 +23,7 @@ bool SeapointTurbiditySensor::subscribe() {
   int topic_strlen =
       snprintf(sub, BM_TOPIC_MAX_LEN, "sensor/%016" PRIx64 "%s", node_id, subtag);
   if (topic_strlen > 0) {
-    rval = bm_sub_wl(sub, topic_strlen, seapointTurbiditySubCallback);
+    rval = bm_sub_wl(sub, topic_strlen, seapointTurbiditySubCallback) == BmOK;
   }
   vPortFree(sub);
   return rval;

--- a/src/apps/bridge/sensor_drivers/softSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/softSensor.cpp
@@ -23,7 +23,7 @@ bool SoftSensor::subscribe() {
   int topic_strlen =
       snprintf(sub, BM_TOPIC_MAX_LEN, "sensor/%016" PRIx64 "%s", node_id, subtag);
   if (topic_strlen > 0) {
-    rval = bm_sub_wl(sub, topic_strlen, softSubCallback);
+    rval = bm_sub_wl(sub, topic_strlen, softSubCallback) == BmOK;
   }
   vPortFree(sub);
   return rval;

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -91,15 +91,15 @@ static bool bm_serial_pub_cb(const char *topic, uint16_t topic_len, uint64_t nod
                              uint8_t version) {
   printf("Pub data on topic \"%.*s\" from %016" PRIx64 " Type: %u, Version: %u\n", topic_len,
          topic, node_id, type, version);
-  return bm_pub_wl(topic, topic_len, payload, len, type, version);
+  return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
 }
 
 static bool bm_serial_sub_cb(const char *topic, uint16_t topic_len) {
-  return bm_sub_wl(topic, topic_len, ncp_uart_pub_cb);
+  return bm_sub_wl(topic, topic_len, ncp_uart_pub_cb) == BmOK;
 }
 
 static bool bm_serial_unsub_cb(const char *topic, uint16_t topic_len) {
-  return bm_unsub_wl(topic, topic_len, ncp_uart_pub_cb);
+  return bm_unsub_wl(topic, topic_len, ncp_uart_pub_cb) == BmOK;
 }
 
 static bool ncp_log_cb(uint64_t node_id, const uint8_t *data, size_t len) {


### PR DESCRIPTION
This is to compliment https://github.com/bristlemouth/bm_core/pull/45.

I changed the return value of the pub sub API to align with `BmErr` as I thought that would give users better return codes for debugging.