### PR TITLE
feat: add cmake presets for most apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tools/bin/mpy-cross
 .vscode
 cli-cmake-debug-build/
 *build/
+preset-builds
 
 src/bsp/pluteus_v3.1/*.s
 src/bsp/pluteus_v3.1/*.ld

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,318 @@
+{
+    "version": 8,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 29,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "unit-tests",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/preset-builds/${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Test",
+                "ENABLE_TESTING": "1"
+            }
+        },
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "USE_BOOTLOADER": "1",
+                "BOOTLOADER_PATH": "${sourceDir}/preset-builds/bootloader/src/bootloader-bootloader.elf",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SIGN_IMAGES": "0"
+            },
+            "toolchainFile": "${sourceDir}/cmake/arm-none-eabi-gcc.cmake"
+        },
+        {
+            "name": "bootloader",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "bootloader",
+                "BSP": "bootloader",
+                "CMAKE_BUILD_TYPE": "Release",
+                "USE_BOOTLOADER": "0"
+            }
+        },
+        {
+            "name": "aanderaa-bristleback",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "aanderaa",
+                "CMAKE_AANDERAA_TYPE": "4830"
+            }
+        },
+        {
+            "name": "aanderaa-rs232",
+            "inherits": "aanderaa-bristleback",
+            "cacheVariables": {
+                "BSP": "bm_mote_rs232",
+                "CMAKE_APP_TYPE": "rs232_expander"
+            }
+        },
+        {
+            "name": "adin-test",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "adin_test",
+                "BSP": "bm_mote_v1.0"
+            }
+        },
+        {
+            "name": "bridge",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "bridge",
+                "BSP": "bridge_v1_0"
+            }
+        },
+        {
+            "name": "bringup-bridge",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "bringup_bridge",
+                "BSP": "bridge_v1_0"
+            }
+        },
+        {
+            "name": "bringup-mote",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "bringup_mote",
+                "BSP": "bm_mote_v1.0"
+            }
+        },
+        {
+            "name": "devkit-monitor",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "devkit_monitor"
+            }
+        },
+        {
+            "name": "hello-world",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_APP_TYPE": "BMDK",
+                "APP": "hello_world",
+                "BSP": "bm_mote_v1.0"
+            }
+        },
+        {
+            "name": "loadcell",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "bm_loadcell"
+            }
+        },
+        {
+            "name": "loadcell-bristleback",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "loadcell"
+            }
+        },
+        {
+            "name": "mote-bristlefin",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "mote_bristlefin",
+                "BSP": "bm_mote_v1.0"
+            }
+        },
+        {
+            "name": "nortek",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "nortek"
+            }
+        },
+        {
+            "name": "nortek-bristleback",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "nortek"
+            }
+        },
+        {
+            "name": "rbr-bristleback",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "bm_rbr"
+            }
+        },
+        {
+            "name": "rbr-coda-example",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "rbr_coda_example"
+            }
+        },
+        {
+            "name": "rbr-rs232",
+            "inherits": "serial-payload-example-rs232",
+            "cacheVariables": {
+                "APP": "bm_rbr"
+            }
+        },
+        {
+            "name": "seapoint-turbidity-bristleback",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "seapoint_turbidity"
+            }
+        },
+        {
+            "name": "serial-payload-example",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "serial_payload_example"
+            }
+        },
+        {
+            "name": "serial-payload-example-bristleback",
+            "inherits": "serial-payload-example",
+            "cacheVariables": {
+                "BSP": "bm_mote_bristleback_v1_0",
+                "CMAKE_APP_TYPE": "bristleback"
+            }
+        },
+        {
+            "name": "serial-payload-example-rs232",
+            "inherits": "serial-payload-example",
+            "cacheVariables": {
+                "BSP": "bm_mote_rs232",
+                "CMAKE_APP_TYPE": "rs232_expander"
+            }
+        },
+        {
+            "name": "soft",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "bm_soft_module",
+                "BSP": "bm_mote_spi_v1_0"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "configurePreset": "unit-tests",
+            "name": "unit-tests",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "bootloader",
+            "name": "bootloader",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "aanderaa-bristleback",
+            "name": "aanderaa-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "aanderaa-rs232",
+            "name": "aanderaa-rs232",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "adin-test",
+            "name": "adin-test",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "bridge",
+            "name": "bridge",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "bringup-bridge",
+            "name": "bringup-bridge",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "bringup-mote",
+            "name": "bringup-mote",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "devkit-monitor",
+            "name": "devkit-monitor",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "hello-world",
+            "name": "hello-world",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "loadcell",
+            "name": "loadcell",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "loadcell-bristleback",
+            "name": "loadcell-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "mote-bristlefin",
+            "name": "mote-bristlefin",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "nortek",
+            "name": "nortek",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "nortek-bristleback",
+            "name": "nortek-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "rbr-bristleback",
+            "name": "rbr-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "rbr-coda-example",
+            "name": "rbr-coda-example",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "rbr-rs232",
+            "name": "rbr-rs232",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "seapoint-turbidity-bristleback",
+            "name": "seapoint-turbidity-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "serial-payload-example",
+            "name": "serial-payload-example",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "serial-payload-example-bristleback",
+            "name": "serial-payload-example-bristleback",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "serial-payload-example-rs232",
+            "name": "serial-payload-example-rs232",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "soft",
+            "name": "soft",
+            "jobs": 8
+        }
+    ]
+}


### PR DESCRIPTION
Originally added to the `experiment/bm_core` branch in https://github.com/bristlemouth/bm_protocol/pull/205. Here's the description from that PR:

> Since I blew away my previous IDE settings while debugging and was reconstructing them, I learned about a new feature — CMake Presets! As of this PR, you can now run the following commands and not have to remember all the magical incantations! I made the presets build in a new preset-builds folder so we don't overwrite existing build folders that people may have.
> 
>     cmake --list-presets
>     cmake --preset bootloader
>     cmake --build --preset bootloader
>     cmake --preset hello-world
>     cmake --build --preset hello-world
>     cmake --preset bridge
>     cmake --build --preset bridge
>     cmake --preset unit-tests
>     cmake --build --preset unit-tests
>     ctest --output-on-failure --test-dir preset-builds/unit-tests
> 
> Running cmake --preset hello-world for example configures the build, creating the build folder if it does not exist. After that you can just run cmake --build --preset hello-world each time you want to build.
> 
> This all integrates super well in VS Code too! Just open the side panel for the CMake extension and choose (near the top) the configure and build presets you want. Then F7 builds your selected preset.

Since then, I've added many more. Here's the list right now:

```
(bristlemouth) zac@532nm bm_protocol % cmake --list-presets
Available configure presets:

  "unit-tests"
  "bootloader"
  "aanderaa-bristleback"
  "aanderaa-rs232"
  "adin-test"
  "bridge"
  "bringup-bridge"
  "bringup-mote"
  "devkit-monitor"
  "hello-world"
  "loadcell"
  "loadcell-bristleback"
  "mote-bristlefin"
  "nortek"
  "nortek-bristleback"
  "rbr-bristleback"
  "rbr-coda-example"
  "rbr-rs232"
  "seapoint-turbidity-bristleback"
  "serial-payload-example"
  "serial-payload-example-bristleback"
  "serial-payload-example-rs232"
  "soft"
```