### PR TITLE
Updates Usage Docs And Shuffles Around Where Device Gets Configured

### DIFF
--- a/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(${SRC_DIR}/lib/usb usb_build)
 include(${SRC_DIR}/third_party/memfault.cmake)
 
 # Include BCMP
-add_subdirectory(${SRC_DIR}/lib/bm_integration bcmp)
+add_subdirectory(${SRC_DIR}/l:qib/bm_integration bcmp)
 
 set(BRISTLEMOUTH_FILES
     ${BM_INTEGRATION_FILES}

--- a/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/serial_payload_example/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(${SRC_DIR}/lib/usb usb_build)
 include(${SRC_DIR}/third_party/memfault.cmake)
 
 # Include BCMP
-add_subdirectory(${SRC_DIR}/l:qib/bm_integration bcmp)
+add_subdirectory(${SRC_DIR}/lib/bm_integration bcmp)
 
 set(BRISTLEMOUTH_FILES
     ${BM_INTEGRATION_FILES}

--- a/src/lib/bm_integration/bristlemouth_client.cpp
+++ b/src/lib/bm_integration/bristlemouth_client.cpp
@@ -4,7 +4,6 @@
 #include "bristlemouth.h"
 #include "bsp.h"
 #include "device_info.h"
-#include "l2.h"
 #include "pcap.h"
 #include "task_priorities.h"
 
@@ -25,7 +24,7 @@ static bool network_device_interrupt(const void *pinHandle, uint8_t value, void 
   (void)pinHandle;
   (void)value;
   (void)args;
-  return bm_l2_handle_device_interrupt() == BmOK;
+  return bristlemouth_handle_network_device_interrupt() == BmOK;
 }
 
 static void adin_power_callback(bool on) {

--- a/src/lib/bm_integration/bristlemouth_client.cpp
+++ b/src/lib/bm_integration/bristlemouth_client.cpp
@@ -1,25 +1,15 @@
 #include "bristlemouth_client.h"
-
-// Includes for FreeRTOS
-#include "FreeRTOS.h"
-#include "configuration.h"
-#include "device_info.h"
-#include "dfu.h"
-#include "messages.h"
-#include "queue.h"
-#include "task.h"
-
 #include "bcmp_cli.h"
 #include "bm_ports.h"
+#include "bristlemouth.h"
 #include "bsp.h"
+#include "device_info.h"
 #include "l2.h"
 #include "pcap.h"
 #include "task_priorities.h"
 
 extern "C" {
 #include "bm_ip.h"
-#include "bristlemouth.h"
-#include "device.h"
 }
 
 #ifdef STRESS_TEST_ENABLE
@@ -50,9 +40,6 @@ static void adin_power_callback(bool on) {
 }
 
 void bcl_init(void) {
-  IORegisterCallback(adin_pins.interrupt, network_device_interrupt, NULL);
-  config_init();
-  //TODO: This should all be moved to user code
   uint8_t major, minor, patch;
   getFWVersion(&major, &minor, &patch);
   DeviceCfg device = {
@@ -70,9 +57,9 @@ void bcl_init(void) {
   };
 
   printf("Starting up BCL\n");
-  device_init(device);
+  IORegisterCallback(adin_pins.interrupt, network_device_interrupt, NULL);
 
-  BmErr err = bristlemouth_init(adin_power_callback);
+  BmErr err = bristlemouth_init(adin_power_callback, device);
   if (err == BmOK) {
     NetworkDevice network_device = bristlemouth_network_device();
     network_device.callbacks->debug_packet_dump = pcapTxPacket;

--- a/test/src/apps/bridge/CMakeLists.txt
+++ b/test/src/apps/bridge/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(sm_config_crc_list_tests
     ${TEST_DIR}/mocks
     ${TEST_DIR}/third_party/fff
     ${SRC_DIR}/apps/bridge
+    ${SRC_DIR}/lib/bm_core/test/mocks
     ${SRC_DIR}/lib/common
     ${SRC_DIR}/lib/drivers/abstract
     ${SRC_DIR}/lib/sys


### PR DESCRIPTION
Device configuration (device_init) should not be an API that the user must call so the struct should be passed into the bristlemout_init function
Updates docs to reflect this

To go along with: 
**https://github.com/bristlemouth/bm_core/pull/51**