### PR TITLE
Fix bridge with raw pressure

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,6 +71,13 @@
             }
         },
         {
+            "name": "bridge-raw-pressure",
+            "inherits": "bridge",
+            "cacheVariables": {
+                "RAW_PRESSURE_ENABLE": "1"
+            }
+        },
+        {
             "name": "bringup-bridge",
             "inherits": "default",
             "cacheVariables": {
@@ -255,6 +262,11 @@
         {
             "configurePreset": "bridge",
             "name": "bridge",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "bridge-raw-pressure",
+            "name": "bridge-raw-pressure",
             "jobs": 8
         },
         {

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -310,7 +310,6 @@ endif()
 if (RAW_PRESSURE_ENABLE STREQUAL 1)
 list(APPEND APP_FILES  ${CMAKE_CURRENT_SOURCE_DIR}/rbrPressureProcessor.cpp)
 list(APPEND APP_FILES  ${SRC_DIR}/lib/common/differenceSignal.cpp)
-list(APPEND APP_FILES  ${SRC_DIR}/lib/bm_common_messages/bm_rbr_pressure_difference_signal_msg.cpp)
 list(APPEND APP_DEFINES "RAW_PRESSURE_ENABLE")
 endif()
 

--- a/src/apps/bridge/app_config.cpp
+++ b/src/apps/bridge/app_config.cpp
@@ -147,9 +147,9 @@ raw_pressure_config_s getRawPressureConfigs(void) {
     save = true;
   }
   cfg.rawDepthThresholdUbar = RbrPressureProcessor::DEFAULT_RAW_DEPTH_THRESHOLD_UBAR;
-  if (!get_config_uint(BM_CFG_PARTITION_SYSTEM, AppConfig::RBR_RAW_DEPTH_THRESHOLD_UBAR,
-                       strlen(AppConfig::RBR_RAW_DEPTH_THRESHOLD_UBAR),
-                       &cfg.rawDepthThresholdUbar)) {
+  if (!get_config_float(BM_CFG_PARTITION_SYSTEM, AppConfig::RBR_RAW_DEPTH_THRESHOLD_UBAR,
+                        strlen(AppConfig::RBR_RAW_DEPTH_THRESHOLD_UBAR),
+                        &cfg.rawDepthThresholdUbar)) {
     bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                    "Failed to get rbr pressure differential threshold from config, using "
                    "default value and writing "

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -435,12 +435,9 @@ static void defaultTask(void *parameters) {
 #endif
 
 #ifdef RAW_PRESSURE_ENABLE
-  < < < < < < < HEAD raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs();
-=======
-  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs(debug_configuration_system);
->>>>>>> origin/develop
+  raw_pressure_config_s raw_pressure_cfg = getRawPressureConfigs();
   rbrPressureProcessorInit(raw_pressure_cfg.rawSampleS, raw_pressure_cfg.maxRawReports,
-                           raw_pressure_cfg.rawDepthThresholdUbar, &debug_configuration_user,
+                           raw_pressure_cfg.rawDepthThresholdUbar,
                            raw_pressure_cfg.rbrCodaReadingPeriodMs);
 #endif // RAW_PRESSURE_ENABLE
 

--- a/src/apps/bridge/rbrPressureProcessor.cpp
+++ b/src/apps/bridge/rbrPressureProcessor.cpp
@@ -1,7 +1,6 @@
 #include "rbrPressureProcessor.h"
 #include "FreeRTOS.h"
 #include "app_pub_sub.h"
-#include "spotter.h"
 #include "bm_rbr_pressure_difference_signal_msg.h"
 #include "bm_serial.h"
 #include "bridgeLog.h"
@@ -9,6 +8,7 @@
 #include "differenceSignal.h"
 #include "event_groups.h"
 #include "queue.h"
+#include "spotter.h"
 #include "task.h"
 #include "task_priorities.h"
 #include "timers.h"
@@ -28,7 +28,6 @@ typedef struct PressureProcessorContext {
   uint32_t maxRawReports;
   double rawDepthThresholdUbar;
   bool started;
-  cfg::Configuration *usrCfg;
   uint32_t nRawReportsSent;
   uint32_t rbrCodaReadingPeriodMs;
 } PressureProcessorContext_t;
@@ -50,13 +49,11 @@ static void diffSigSendTimerCallback(TimerHandle_t xTimer);
 static PressureProcessorContext_t _ctx;
 
 void rbrPressureProcessorInit(uint32_t rawSampleS, uint32_t maxRawReports,
-                              double rawDepthThresholdUbar, cfg::Configuration *usrCfg,
-                              uint32_t rbrCodaReadingPeriodMs) {
-  configASSERT(usrCfg);
-  _ctx.usrCfg = usrCfg;
+                              double rawDepthThresholdUbar, uint32_t rbrCodaReadingPeriodMs) {
   _ctx.rbrCodaReadingPeriodMs = rbrCodaReadingPeriodMs;
-  if (!_ctx.usrCfg->getConfig(kRBRnRawReportsSent, strlen(kRBRnRawReportsSent),
-                              _ctx.nRawReportsSent)) {
+  bool success = get_config_uint(BM_CFG_PARTITION_USER, kRBRnRawReportsSent,
+                                 strlen(kRBRnRawReportsSent), &_ctx.nRawReportsSent);
+  if (!success) {
     _ctx.nRawReportsSent = 0;
   }
   _ctx.q = xQueueCreate(10, sizeof(BmRbrDataMsg::Data));
@@ -168,9 +165,11 @@ static void runTask(void *param) {
             vTaskDelay(100);
           }
           _ctx.nRawReportsSent++;
-          _ctx.usrCfg->setConfig(kRBRnRawReportsSent, strlen(kRBRnRawReportsSent),
-                                 _ctx.nRawReportsSent);
-          _ctx.usrCfg->saveConfig(false);
+          bool success = set_config_uint(BM_CFG_PARTITION_USER, kRBRnRawReportsSent,
+                                         strlen(kRBRnRawReportsSent), _ctx.nRawReportsSent);
+          if (success) {
+            save_config(BM_CFG_PARTITION_USER, false);
+          }
         }
       } while (0);
 

--- a/src/apps/bridge/rbrPressureProcessor.h
+++ b/src/apps/bridge/rbrPressureProcessor.h
@@ -13,9 +13,8 @@ constexpr uint32_t DEFAULT_MAX_RAW_REPORTS = 200;
 constexpr double DEFAULT_RAW_DEPTH_THRESHOLD_UBAR = 1500000.0;
 } // namespace RbrPressureProcessor
 
-void rbrPressureProcessorInit(uint32_t rawSampleS,
-                              uint32_t maxRawReports, double rawDepthThresholdUbar,
-                              cfg::Configuration *usrCfg, uint32_t rbrCodaReadingPeriodMs);
+void rbrPressureProcessorInit(uint32_t rawSampleS, uint32_t maxRawReports,
+                              double rawDepthThresholdUbar, uint32_t rbrCodaReadingPeriodMs);
 
 bool rbrPressureProcessorAddSample(BmRbrDataMsg::Data &rbr_data, uint32_t timeout_ms);
 

--- a/test/src/common/lineParsers_ut.cpp
+++ b/test/src/common/lineParsers_ut.cpp
@@ -5,7 +5,6 @@
 #include "gtest/gtest.h"
 
 #include "fff.h"
-#include "util.h"
 #include "string.h"
 #include "OrderedSeparatorLineParser.h"
 #include "Exo3LineParser.h"

--- a/tools/scripts/test/configs/bridge.yaml
+++ b/tools/scripts/test/configs/bridge.yaml
@@ -1,4 +1,4 @@
-- name: bridge on bridge - Debug (w/ bootloader)
+- name: bridge - Release
   type: build_fw
   args:
     app: bridge
@@ -6,7 +6,7 @@
     build_type: Release
     use_bootloader: True
 
-- name: bridge w/upy on bridge - Debug (w/ bootloader)
+- name: bridge w/upy - Release
   type: build_fw
   args:
     app: bridge
@@ -14,3 +14,12 @@
     build_type: Release
     use_bootloader: True
     defines: -DUSE_MICROPYTHON=1
+
+- name: bridge w/raw pressure - Release
+  type: build_fw
+  args:
+    app: bridge
+    bsp: bridge_v1_0
+    build_type: Release
+    use_bootloader: True
+    defines: -DRAW_PRESSURE_ENABLE=1


### PR DESCRIPTION
I noticed that a recent merge commit https://github.com/bristlemouth/bm_protocol/commit/56b7a9a8c320d96ee2d3aea0546995c8253e2e2a#diff-2c23633dd934ba3ff7f6be1ea6872d2f8a369c65dcc90173da6159723e943d67R438 had conflict markers in `bridge/app_main.cpp`.

CI was passing because that part of the bridge code was only evaluated when `RAW_PRESSURE_ENABLE` is defined, which was not a part of any of our CI builds. So, I added that as well as a cmake preset. There were other failures as well related to configs, which I cleaned up.