### PR TITLE
Add pcap debug dump functionality back in

### DIFF
--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -351,7 +351,6 @@ static void defaultTask(void *parameters) {
   pcapInit(&usbPcap);
 
   startCLI();
-  // pcapInit(&usbPcap);
 
   gpioISRStartTask();
 

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -349,7 +349,6 @@ static void defaultTask(void *parameters) {
   pcapInit(&usbPcap);
 
   startCLI();
-  // pcapInit(&usbPcap);
 
   gpioISRStartTask();
 

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -324,7 +324,6 @@ static void defaultTask(void *parameters) {
   pcapInit(&usbPcap);
 
   startCLI();
-  // pcapInit(&usbPcap);
 
   gpioISRStartTask();
 

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -321,7 +321,6 @@ static void defaultTask(void *parameters) {
   pcapInit(&usbPcap);
 
   startCLI();
-  // pcapInit(&usbPcap);
 
   gpioISRStartTask();
 

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -275,7 +275,6 @@ static void defaultTask(void *parameters) {
   pcapInit(&usbPcap);
 
   startCLI();
-  // pcapInit(&usbPcap);
 
   gpioISRStartTask();
 

--- a/src/lib/bm_integration/bristlemouth_client.cpp
+++ b/src/lib/bm_integration/bristlemouth_client.cpp
@@ -13,6 +13,7 @@
 #include "bm_ports.h"
 #include "bsp.h"
 #include "l2.h"
+#include "pcap.h"
 #include "task_priorities.h"
 
 extern "C" {
@@ -73,10 +74,12 @@ void bcl_init(void) {
 
   BmErr err = bristlemouth_init(adin_power_callback);
   if (err == BmOK) {
+    NetworkDevice network_device = bristlemouth_network_device();
+    network_device.callbacks->debug_packet_dump = pcapTxPacket;
     bcmp_cli_init();
 
 #ifdef STRESS_TEST_ENABLE
-    stress_test_init(bristlemouth_network_device(), STRESS_TEST_PORT);
+    stress_test_init(network_device, STRESS_TEST_PORT);
 #endif
 
   } else {


### PR DESCRIPTION
Relies on https://github.com/bristlemouth/bm_core/pull/59

Connects the existing pcap lib to the new network device callback `debug_packet_dump`. Here's a screenshot of Wireshark viewing a pcap file created during a stress test.

![Screenshot 2024-11-27 at 5 40 44 PM](https://github.com/user-attachments/assets/df6f93a9-c1b4-4cf9-889f-3c873b9d9074)
