### PR TITLE
add -rc.X to the release tag options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,12 @@ name: release
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on tags with vX.X.X format (with optional -RC)
+  # Triggers the workflow on tags with vX.X.X format (with optional -RC or -rc.X)
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+", "v[0-9]+.[0-9]+.[0-9]+-RC[0-9]+"]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-RC[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## What changed?
Added `-rc.X` to the automated release tag options.


## How does it make Bristlemouth better?
It allows for the newer versioning system to trigger release builds!


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
