### PR TITLE
CICD HIL Test On Local Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: bristlemouth
           environment-file: environment_ci.yml
           auto-activate-base: false
-
       - name: Checkout submodules
         run: |
           git submodule update --init --recursive src/lib/bm_core
@@ -50,6 +48,7 @@ jobs:
           git submodule update --init src/third_party/tinyusb
           git submodule update --init src/third_party/BME280_driver
           git submodule update --init test/third_party/fff
-
       - name: Run Tests
-        run: python3 tools/scripts/test/did_i_break_something.py tools/scripts/test/configs
+        run: python3 tools/scripts/test/did_i_break_something.py tools/scripts/test/configs --store
+      - name: Run HIL
+        run: python tools/scripts/cicd/bm_hil.py ./build/hello_world/src/bm_mote_v1.0-hello_world.elf.dfu.bin C000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build_and_test:
     # The type of runner that the job will run on
     runs-on:
-      # - self-hosted
+      - self-hosted
       # Uncomment to run on github's infrastructure (and comment out self-hosted above!)
-      - ubuntu-latest
+      # - ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,11 @@ jobs:
         run: python3 tools/scripts/test/did_i_break_something.py tools/scripts/test/configs --store
       - name: Run HIL
         run: python tools/scripts/cicd/bm_hil.py ./build/hello_world/src/bm_mote_v1.0-hello_world.elf.dfu.bin C000
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hil_log
+          path: ~/sys_logs/cicd
+      - name: Clean Up
+        run: |
+          mkdir -p ~/sys_logs/cicd_local
+          mv -v ~/sys_logs/cicd/* ~/sys_logs/cicd_local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build_and_test:
+  build:
     # The type of runner that the job will run on
     runs-on:
       - self-hosted

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -19,7 +19,7 @@ dependencies:
   - make=4.3
   - pre_commit
   - pyserial
-  - python=3.10
+  - python=3.12
   - pip
   - pip:
       - cbor2
@@ -31,4 +31,8 @@ dependencies:
       - pytest
       - python-dotenv
       - bitstring==4.2
-
+      - pyserial
+      - regex
+      - func_timeout
+      - pytest-order
+      - crcmod

--- a/tools/scripts/cicd/bm_hil.py
+++ b/tools/scripts/cicd/bm_hil.py
@@ -1,0 +1,144 @@
+import os
+import subprocess
+import serial.tools.list_ports
+import serial
+import re
+import sys
+from time import sleep
+from logging_helper import LoggingHelper
+
+directory = os.path.dirname(os.path.abspath(__file__))
+cwd = directory + "/../../../src/lib/bm_core/test/scripts"
+sys.path.insert(1, cwd)
+from serial_helper import SerialHelper
+
+LOGGER = None
+DFU_UTIL_RETRY = 3
+
+
+def execute(cmd: list[str]) -> str:
+    lines = ""
+    try:
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True,
+            cwd=os.getcwd(),
+        ) as p:
+            for line in p.stdout:
+                LOGGER.log(LOGGER.DEBUG, line)
+                lines += line
+            if p.returncode != 0 and p.returncode is not None:
+                raise subprocess.CalledProcessError(p.returncode, p.args)
+            return lines
+    except subprocess.CalledProcessError:
+        return None
+
+
+def dfu_util_update(image: str, offset: int = 0):
+    debug_str = "Updating Firmware Over DFU Util"
+    print(debug_str)
+    LOGGER.log(LOGGER.INFO, debug_str)
+
+    ports = serial.tools.list_ports.comports()
+    fail_count = 0
+    offset = 0x8000000 + offset
+
+    # Iterate updates over all nodes connected over serial
+    for port, desc, __ in sorted(ports):
+        if "Bristlemouth" in desc and int(port[-1]) == 1:
+            retry_count = 0
+            while retry_count < DFU_UTIL_RETRY:
+                status = True
+                ser = SerialHelper(port)
+                ser.transmit_str("\nbootloader\n")
+                ser.close()
+                debug_str = f"DFU Update On Port {port} For File: {image}"
+                print(debug_str)
+                LOGGER.log(LOGGER.INFO, debug_str)
+                sleep(5.0)
+                output = execute(
+                    [
+                        "dfu-util",
+                        "-a",
+                        "0",
+                        "-s",
+                        hex(offset) + ":leave",
+                        "-D",
+                        image,
+                    ]
+                )
+                find = re.search(r"File downloaded successfully", output)
+                if find is None:
+                    status = False
+                output_str = "DFU Update Status: "
+                output_str += "Success" if status is True else "Failure"
+                print(output_str)
+                if status is False:
+                    LOGGER.log(LOGGER.ERROR, output_str)
+                    fail_count += 1
+                    retry_count += 1
+                    print("Failure output result:\n" + output)
+                    if retry_count < DFU_UTIL_RETRY:
+                        debug_str = "Retrying DFU Util Update..."
+                        print(debug_str)
+                        LOGGER.log(LOGGER.WARNING, debug_str)
+                else:
+                    LOGGER.log(LOGGER.INFO, output_str)
+                    break
+
+
+def run_hil_tests():
+    debug_str = "Running HIL Tests"
+    print(debug_str)
+    LOGGER.log(LOGGER.INFO, debug_str)
+
+    # Set CWD to bm_core HIL test scripts
+    os.chdir(cwd)
+
+    ports = serial.tools.list_ports.comports()
+    fail_count = 0
+
+    # Iterate tests over all nodes connected over serial
+    for port, desc, __ in sorted(ports):
+        # Determine if this is a node we want to talk to over serial
+        if "Bristlemouth" in desc and int(port[-1]) == 1:
+            status = True
+            debug_str = f"HIL Test Running On: {port}"
+            print(debug_str)
+            LOGGER.log(LOGGER.INFO, debug_str)
+            output = execute(
+                [
+                    "pytest",
+                    "-s",
+                    "@tests_to_run.txt",
+                    "--port",
+                    port,
+                    "--baud",
+                    "921600",
+                ]
+            )
+
+            # Determine if any tests have failed
+            find = re.search(r"\w+ failed, \w+ passed", output)
+            if find:
+                status = False
+            output_str = "HIL Test Status: "
+            output_str += "Success" if status is True else "Failure"
+            print(output_str)
+            if status is False:
+                LOGGER.log(LOGGER.ERROR, output_str)
+                fail_count += 1
+                print("Failure output result:\n" + output)
+            else:
+                LOGGER.log(LOGGER.INFO, output_str)
+
+
+if __name__ == "__main__":
+    LOGGER = LoggingHelper("cicd", "hil_test")
+    if len(sys.argv) > 2:
+        dfu_util_update(sys.argv[1], int(sys.argv[2], 16))
+        # Let the nodes boot and finish initializing
+        sleep(10.0)
+    run_hil_tests()

--- a/tools/scripts/cicd/bm_hil.py
+++ b/tools/scripts/cicd/bm_hil.py
@@ -41,6 +41,7 @@ def dfu_util_update(image: str, offset: int = 0):
     print(debug_str)
     LOGGER.log(LOGGER.INFO, debug_str)
 
+    found = 0
     ports = serial.tools.list_ports.comports()
     fail_count = 0
     offset = 0x8000000 + offset
@@ -48,12 +49,18 @@ def dfu_util_update(image: str, offset: int = 0):
     # Iterate updates over all nodes connected over serial
     for port, desc, __ in sorted(ports):
         if "Bristlemouth" in desc and int(port[-1]) == 1:
+            found += 1
             retry_count = 0
             while retry_count < DFU_UTIL_RETRY:
                 status = True
-                ser = SerialHelper(port)
-                ser.transmit_str("\nbootloader\n")
-                ser.close()
+                try:
+                    ser = SerialHelper(port)
+                    ser.transmit_str("\nbootloader\n")
+                    ser.close()
+                except SerialHelper.SerialException:
+                    debug_str = "Device may already be in bootloader,"
+                    "cannot communicate over serial"
+                    LOGGER.log(LOGGER.WARNING, debug_str)
                 debug_str = f"DFU Update On Port {port} For File: {image}"
                 print(debug_str)
                 LOGGER.log(LOGGER.INFO, debug_str)
@@ -87,6 +94,11 @@ def dfu_util_update(image: str, offset: int = 0):
                 else:
                     LOGGER.log(LOGGER.INFO, output_str)
                     break
+    if found == 0:
+        debug_str = "Could not find any ports to run DFU update"
+        LOGGER.log(LOGGER.ERROR, debug_str)
+        print(debug_str)
+        sys.exit(1)
 
 
 def run_hil_tests():
@@ -97,6 +109,7 @@ def run_hil_tests():
     # Set CWD to bm_core HIL test scripts
     os.chdir(cwd)
 
+    found = 0
     ports = serial.tools.list_ports.comports()
     fail_count = 0
 
@@ -104,6 +117,7 @@ def run_hil_tests():
     for port, desc, __ in sorted(ports):
         # Determine if this is a node we want to talk to over serial
         if "Bristlemouth" in desc and int(port[-1]) == 1:
+            found += 1
             status = True
             debug_str = f"HIL Test Running On: {port}"
             print(debug_str)
@@ -133,6 +147,11 @@ def run_hil_tests():
                 print("Failure output result:\n" + output)
             else:
                 LOGGER.log(LOGGER.INFO, output_str)
+    if found == 0:
+        debug_str = "Could not find any ports to run HIL tests"
+        LOGGER.log(LOGGER.ERROR, debug_str)
+        print(debug_str)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/scripts/cicd/logging_helper.py
+++ b/tools/scripts/cicd/logging_helper.py
@@ -1,0 +1,55 @@
+import logging
+from pathlib import Path
+from time import time
+import os
+import sys
+
+
+class LoggingHelper:
+
+    LOG_DIR = "sys_logs"
+    CRITICAL = 50
+    ERROR = 40
+    WARNING = 30
+    INFO = 20
+    DEBUG = 10
+
+    def __init__(self, sub_dir: str, name: str, stdout: bool = False):
+        home = Path.home()
+        directory = str(home) + "/" + self.LOG_DIR + "/" + sub_dir
+        os.makedirs(directory, mode=0o777, exist_ok=True)
+        filename = directory + "/" + name + "_" + str(int(time())) + ".log"
+
+        # Set Up Logger to file
+        self.log_name = name
+        self.logger = logging.getLogger(self.log_name)
+        self.logger.setLevel(logging.DEBUG)
+        fh = logging.FileHandler(filename)
+        fh.setLevel(logging.DEBUG)
+
+        # Configure formatter
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s: %(message)s")
+        fh.setFormatter(formatter)
+
+        # Add file handler
+        self.logger.addHandler(fh)
+
+        # Add to stdout if required
+        if stdout is True:
+            ch = logging.StreamHandler(sys.stdout)
+            ch.setLevel(logging.DEBUG)
+            ch.setFormatter(formatter)
+            self.logger.addHandler(ch)
+
+    def log(self, level: int = DEBUG, msg: str = None):
+        msg = msg.strip()
+        if level == self.CRITICAL:
+            self.logger.critical(msg)
+        elif level == self.ERROR:
+            self.logger.error(msg)
+        elif level == self.WARNING:
+            self.logger.warning(msg)
+        elif level == self.INFO:
+            self.logger.info(msg)
+        else:
+            self.logger.debug(msg)

--- a/tools/scripts/cicd/logging_helper.py
+++ b/tools/scripts/cicd/logging_helper.py
@@ -1,4 +1,5 @@
 import logging
+import git
 from pathlib import Path
 from time import time
 import os
@@ -15,10 +16,21 @@ class LoggingHelper:
     DEBUG = 10
 
     def __init__(self, sub_dir: str, name: str, stdout: bool = False):
+        repo = git.Repo(search_parent_directories=True)
+        commit_hash = repo.head.commit.hexsha
         home = Path.home()
         directory = str(home) + "/" + self.LOG_DIR + "/" + sub_dir
         os.makedirs(directory, mode=0o777, exist_ok=True)
-        filename = directory + "/" + name + "_" + str(int(time())) + ".log"
+        filename = (
+            directory
+            + "/"
+            + name
+            + "_"
+            + commit_hash[:7]
+            + "_"
+            + str(int(time()))
+            + ".log"
+        )
 
         # Set Up Logger to file
         self.log_name = name

--- a/tools/scripts/test/configs/bridge.yaml
+++ b/tools/scripts/test/configs/bridge.yaml
@@ -5,6 +5,7 @@
     bsp: bridge_v1_0
     build_type: Release
     use_bootloader: True
+    sub: bridge
 
 - name: bridge w/upy - Release
   type: build_fw
@@ -14,6 +15,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DUSE_MICROPYTHON=1
+    sub: upy
 
 - name: bridge w/raw pressure - Release
   type: build_fw
@@ -23,3 +25,4 @@
     build_type: Release
     use_bootloader: True
     defines: -DRAW_PRESSURE_ENABLE=1
+    sub: raw_pressure

--- a/tools/scripts/test/configs/mote.yaml
+++ b/tools/scripts/test/configs/mote.yaml
@@ -5,6 +5,7 @@
     bsp: bm_mote_v1.0
     build_type: Release
     use_bootloader: True
+    sub: regular
 
 - name: mote_bristlefin w/upy on bm_mote_v1.0
   type: build_fw
@@ -14,6 +15,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DUSE_MICROPYTHON=1
+    sub: upy
 
 - name: hello_world on bm_mote_v1.0
   type: build_fw
@@ -41,6 +43,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=BMDK
+    sub: mote
 
 - name: devkit_monitor on bm_mote_v1.0
   type: build_fw
@@ -59,6 +62,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=bristleback
+    sub: bristleback
 
 - name: aanderaa on bm_mote_bristleback_v1_0
   type: build_fw
@@ -69,6 +73,7 @@
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=bristleback
              -DCMAKE_AANDERAA_TYPE=4830
+    sub: bristleback
 
 - name: nortek on bm_mote_bristleback_v1_0
   type: build_fw
@@ -78,6 +83,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=bristleback
+    sub: bristleback
 
 - name: nortek on bm_mote_v1.0
   type: build_fw
@@ -87,6 +93,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=BMDK
+    sub: mote
 
 - name: loadcell on bm_mote_v1.0
   type: build_fw
@@ -96,6 +103,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=BMDK
+    sub: mote
 
 - name: loadcell on bristleback
   type: build_fw
@@ -105,6 +113,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=bristleback
+    sub: bristleback
 
 - name: bm_soft_module on bm_mote_spi_v1_0
   type: build_fw
@@ -122,6 +131,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=bristleback
+    sub: bristleback
 
 - name: seapoint_turbidity on bm_mote_bristleback_v1_0
   type: build_fw
@@ -140,6 +150,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=rs232_expander
+    sub: rs232
 
 - name: bm_rbr on bm_mote_rs232
   type: build_fw
@@ -149,6 +160,7 @@
     build_type: Release
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=rs232_expander
+    sub: rs232
 
 - name: aanderaa on bm_mote_rs232
   type: build_fw
@@ -159,4 +171,4 @@
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=rs232_expander
              -DCMAKE_AANDERAA_TYPE=4830
-             
+    sub: rs232

--- a/tools/scripts/test/configs/unit_tests.yaml
+++ b/tools/scripts/test/configs/unit_tests.yaml
@@ -1,3 +1,5 @@
 # Run unit tests for entire repo
 - name: Unit Tests
   type: unit_tests
+  args:
+    app: unit_tests


### PR DESCRIPTION
## What changed?
Adds script to run HIL tests/update a node to the latest FW push.
When a PR is opened, the hello_world app will be flashed onto that mote with the updated code.
That newly flashed mote will then run the HIL tests.
Adds `did_i_break_something.py` script command line option to build all apps and store them at `path/to/bm_protocol/build` rather than in a temporary directory. This allows for apps to be flashed from local runner.

TODO:
Upon releases, we should flash all motes to the latest release (automated with DFU). Then PRs opened after the release will always be run against motes on the latest release.


## How does it make Bristlemouth better?
Automated HIL tests on every PR! WITH LOGS!


## Where should reviewers focus?
The python script, `bm_hil.py`. See if there are any improvements that can be made.
Currently we update the mote through dfu-util, but should we?
Or should we flash over the ST-Link.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
