### PR TITLE
Handle SPI Callbacks Asynchronous In Adin Callstack

### DIFF
--- a/src/lib/bm_integration/bristlemouth_client.cpp
+++ b/src/lib/bm_integration/bristlemouth_client.cpp
@@ -9,6 +9,7 @@
 #include "queue.h"
 #include "task.h"
 
+#include "adi_hal.h"
 #include "bcmp_cli.h"
 #include "bm_ports.h"
 #include "bsp.h"
@@ -51,6 +52,7 @@ static void adin_power_callback(bool on) {
 
 void bcl_init(void) {
   IORegisterCallback(adin_pins.interrupt, network_device_interrupt, NULL);
+  HAL_Init_Hook();
   config_init();
   //TODO: This should all be moved to user code
   uint8_t major, minor, patch;

--- a/src/lib/drivers/adin2111/src/adi_hal.c
+++ b/src/lib/drivers/adin2111/src/adi_hal.c
@@ -1,13 +1,32 @@
 #include "adi_hal.h"
+#include "FreeRTOS.h"
 #include "app_util.h"
+#include "bm_os.h"
 #include "bsp.h"
 #include "protected_spi.h"
+#include "semphr.h"
+#include "util.h"
 #include <stdio.h>
 #include <string.h>
+
+#define adin_spi_task_priority 30
+#define adin_semaphore_max_queue 10
 
 static HAL_Callback_t ADIN2111_MAC_SPI_CALLBACK = NULL;
 static void *ADIN2111_MAC_SPI_CALLBACK_PARAM = NULL;
 extern adin_pins_t adin_pins;
+static BmTaskHandle ADI_SPI_TASK_HANDLE = NULL;
+
+static void adi_spi_task(void *arg) {
+  (void)arg;
+  while (1) {
+    if (ulTaskNotifyTake(pdFALSE, portMAX_DELAY) == pdTRUE) {
+      if (ADIN2111_MAC_SPI_CALLBACK) {
+        ADIN2111_MAC_SPI_CALLBACK(ADIN2111_MAC_SPI_CALLBACK_PARAM, 0, NULL);
+      }
+    }
+  }
+}
 
 uint32_t HAL_EnterCriticalSection(void) {
   __disable_irq();
@@ -42,7 +61,14 @@ uint32_t HAL_GetEnableIrq(void) { return NVIC_GetEnableIRQ(ADIN_INT_EXTI_IRQn); 
  * @return none
  */
 
-uint32_t HAL_Init_Hook(void) { return ADI_HAL_SUCCESS; }
+uint32_t HAL_Init_Hook(void) {
+  BmErr err = BmENOMEM;
+
+  err = bm_task_create(adi_spi_task, "ADIN SPI Task", 512, NULL, adin_spi_task_priority,
+                       &ADI_SPI_TASK_HANDLE);
+
+  return err == BmOK ? ADI_HAL_SUCCESS : ADI_HAL_ERROR;
+}
 
 uint32_t HAL_UnInit_Hook(void) { return ADI_HAL_SUCCESS; }
 
@@ -79,10 +105,8 @@ uint32_t HAL_SpiReadWrite(uint8_t *pBufferTx, uint8_t *pBufferRx, uint32_t nByte
   }
   IOWrite(adin_pins.chipSelect, 1);
 
-  if (status == 0) {
-    if (ADIN2111_MAC_SPI_CALLBACK) {
-      ADIN2111_MAC_SPI_CALLBACK(ADIN2111_MAC_SPI_CALLBACK_PARAM, 0, NULL);
-    }
+  if (status == SPI_OK && ADI_SPI_TASK_HANDLE) {
+    xTaskNotifyGive(ADI_SPI_TASK_HANDLE);
   } else {
     printf("Network SPI Read/Write Failed\n");
   }

--- a/src/lib/drivers/adin2111/src/adi_hal.c
+++ b/src/lib/drivers/adin2111/src/adi_hal.c
@@ -5,11 +5,11 @@
 #include "bsp.h"
 #include "protected_spi.h"
 #include "semphr.h"
+#include "task_priorities.h"
 #include "util.h"
 #include <stdio.h>
 #include <string.h>
 
-#define adin_spi_task_priority 30
 #define adin_semaphore_max_queue 10
 
 static HAL_Callback_t ADIN2111_MAC_SPI_CALLBACK = NULL;
@@ -64,7 +64,7 @@ uint32_t HAL_GetEnableIrq(void) { return NVIC_GetEnableIRQ(ADIN_INT_EXTI_IRQn); 
 uint32_t HAL_Init_Hook(void) {
   BmErr err = BmENOMEM;
 
-  err = bm_task_create(adi_spi_task, "ADIN SPI Task", 512, NULL, adin_spi_task_priority,
+  err = bm_task_create(adi_spi_task, "ADIN SPI Task", 512, NULL, ADIN_SPI_TASK_PRIORITY,
                        &ADI_SPI_TASK_HANDLE);
 
   return err == BmOK ? ADI_HAL_SUCCESS : ADI_HAL_ERROR;


### PR DESCRIPTION
## What changed?
Previously over at Sofar, there has been call stack traced from the Adin driver code reaching over 60 calls deep in the L2 task!
Handling the callbacks in a separate task rather than the calling task of `HAL_SpiReadWrite` will help reduce the size of the task's call stack.
The following is a peek at what the callback stack will look like when being handled from a separate task:

![image](https://github.com/user-attachments/assets/7e454821-ca43-4e6a-b55e-7095cdcbf1ac)

Below is what it has looked like previously:

![image](https://github.com/user-attachments/assets/ca05e847-77bb-4333-bb4b-16f4e322d2c1)
![image](https://github.com/user-attachments/assets/3994235c-7880-4632-a4b9-7ac7b91b20f4)

(With even more calls to go if I continue debugging the total trace!)

The provided solution waits on a recursive notification in the new *ADIN SPI Task*.
The notification is given every time a successful SPI transfer occurs.
Then the callback set by the ADIN driver is invoked in the *ADIN SPI Task*!

Following the SPI transaction flow through `protected_spi.c`, there is no need to trigger this notification from an interrupt, or through any other source. The notification will occur after the transaction has been completed every time in the provided solution.

## How does it make Bristlemouth better?
Reduce the risk of a stack overflow!

## Where should reviewers focus?
Look at resource allocation, I provided 512 bytes to the new task's stack, but that might be overkill.
Also, from the Adin driver, `HAL_Init_Hook` is never called, but is available in the `adi_hal.h` file.
To initialize this new task,
`HAL_Init_Hook` is utilized but called in the `bristlemouth_client.cpp` file.
Is this desired? I feel like it creates confusion.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
