### PR TITLE
Fix concurrency issue with updating submodules in parallel operations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -431,6 +431,7 @@ setup_bm_os(FREERTOS "${BM_CORE_FREERTOS_INCLUDES}")
 add_subdirectory(${LIB_DIR}/bm_core bmcore)
 target_compile_definitions(middleware PRIVATE ${APP_DEFINES})
 target_link_libraries(bmcore PUBLIC lwipcore)
+add_dependencies(update_submodules update_submodules_bm_protocol)
 
 if (USE_MICROPYTHON STREQUAL 1)
 include(${LIB_DIR}/micropython/CMakeLists.txt)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(gtest PROPERTIES FOLDER extern)
 set_target_properties(gtest_main PROPERTIES FOLDER extern)
 set_target_properties(gmock PROPERTIES FOLDER extern)
 set_target_properties(gmock_main PROPERTIES FOLDER extern)
-add_dependencies(gtest update_submodules_bm_protocol)
+add_dependencies(update_submodules_bm_core update_submodules_bm_protocol)
 add_dependencies(gtest update_submodules_bm_core)
 
 add_compile_options(


### PR DESCRIPTION
## What changed?
I noticed a concurrency issue when invoking `make -j` for the unit tests and firmware builds.
When running `make -j` from the unit test build directory, sometimes, two git operations attempt to be performed at the same time, this prevents that from occurring.
In order to update bm_core's submodules, a dependency has been added to update it after `git submodule update --init` is ran from the root of the directory.


## How does it make Bristlemouth better?
Prevent two git operations from occurring at the same time and failing the build.


## Where should reviewers focus?
Trivial change, but test unit tests to ensure that it does not fail when running `make -j`.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
