### PR TITLE
Fix SOFT debug builds

### DIFF
--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -28,7 +28,6 @@
 #include "debug_gpio.h"
 #include "debug_memfault.h"
 #include "debug_nvm_cli.h"
-#include "debug_pluart_cli.h"
 #include "debug_rtc.h"
 #include "debug_spotter.h"
 #include "debug_sys.h"
@@ -380,7 +379,6 @@ static void defaultTask(void *parameters) {
   NvmPartition dfu_partition(debugW25, dfu_configuration);
   dfu_partition_global = &dfu_partition;
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
-  debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
   bcl_init();
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",


### PR DESCRIPTION
## What changed?
Removed Pluart from the soft app since is unused. The release builds optimized this unused code out allowing CI and release builds to pass. However, I tried to make a debug build locally and it failed.


## How does it make Bristlemouth better?



## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
