### PR TITLE
fix: serial bridge build

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -100,7 +100,8 @@ set(LIB_FILES
 )
 
 if(APP_NAME MATCHES "bridge" AND
-   NOT APP_NAME MATCHES "bringup")
+   NOT APP_NAME MATCHES "bringup" AND
+   NOT APP_NAME MATCHES "serial")
     list(APPEND LIB_FILES
         ${LIB_DIR}/debug/debug_bridge_power_controller.cpp
         ${BM_NCP_FILES}


### PR DESCRIPTION
## What changed?

I excluded `debug_bridge_power_controller.cpp` from the source files for the mote `serial_bridge` app. It got unintentionally included via app name matching in PR #234.

## How does it make Bristlemouth better?

Fixes a build error discovered while tagging a release candidate.

## Where should reviewers focus?

Pretty much a rubber stamp. 😄 

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
