### PR TITLE
Enable STOP1 low-power mode for SOFT app.

### DIFF
--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -405,7 +405,7 @@ static void defaultTask(void *parameters) {
   user_code_start();
 
   // Re-enable low power mode
-  // lpmPeripheralInactive(LPM_BOOT);
+  lpmPeripheralInactive(LPM_BOOT);
 
   while (1) {
     /* Do nothing */


### PR DESCRIPTION
## What changed?
Uncommented the line in SOFT app, re-enabling the STOP1 low-power mode.


## How does it make Bristlemouth better?
Save ~25 mW on the SOFT node! See joulescope before/after shots. _Note: since joulescope max voltage is 15V, while Bristlemouth bus is 24V, I used a resistor voltage divider to divide the input voltage in half. Thus, actual power is twice the measured power._
Before: 135 mW
<img width="407" alt="Screenshot 2025-02-10 at 4 29 32 PM" src="https://github.com/user-attachments/assets/b468fad3-5739-4186-983b-2bfefdd29f2f" />

After: 109 mW
<img width="407" alt="Screenshot 2025-02-10 at 4 27 46 PM" src="https://github.com/user-attachments/assets/de84568d-1b71-4796-b076-21cfcd07221d" />

## Where should reviewers focus?
Did I miss anything I should be adjusting, to allow SPI to safely operate when coming in and out of LPM?

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
