### PR TITLE
Remove 10 ms delay between handling incoming bytes in serial_bridge

### DIFF
--- a/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
@@ -37,7 +37,7 @@ static void reset() {
 }
 
 void loop() {
-  if (PLUART::byteAvailable()) {
+  while (PLUART::byteAvailable()) {
     const uint8_t b = PLUART::readByte();
     rx_buffer[rx_idx++] = b;
     if (rx_idx >= rx_buf_size) {


### PR DESCRIPTION
This avoids incurring the `bm_delay(10)` within the caller of `loop()` between all incoming bytes, which would add latency and artificially limit the effective throughput to 100 byte/s regardless of baud rate

## What changed?
`if (PLUART::byteAvailable())` is replaced with `while (PLUART::byteAvailable())` within bm_devkit/serial_bridge/user_code/user_code.cpp


## How does it make Bristlemouth better?
The serial_bridge app will be more reactive and not artificially limit the throughput to 100 byte/s.


## Where should reviewers focus?
Verify there were no other prior factors which make this change redundant


## Checklist

- [x] Independently test on hardware
