### PR TITLE
Allows Load Cells That Decrease Readings With Tension Applied

### DIFF
--- a/src/lib/drivers/nau7802.cpp
+++ b/src/lib/drivers/nau7802.cpp
@@ -351,15 +351,18 @@ void NAU7802::setCalibrationFactor(float newCalFactor) {
 float NAU7802::getCalibrationFactor() { return (_calibrationFactor); }
 
 // Returns the y of y = mx + b using the current weight on scale, the cal factor, and the offset.
-float NAU7802::getWeight(bool allowNegativeWeights, uint8_t samplesToTake) {
+float NAU7802::getWeight(bool negativeScale, uint8_t samplesToTake) {
   int32_t onScale = getAverage(samplesToTake);
 
   // Prevent the current reading from being less than zero offset
   // This happens when the scale is zero'd, unloaded, and the load cell reports a value slightly less than zero value
   // causing the weight to be negative or jump to millions of pounds
-  if (allowNegativeWeights == false) {
+  if (negativeScale == false) {
     if (onScale < _zeroOffset)
       onScale = _zeroOffset; // Force reading to zero
+  } else {
+    if (onScale > _zeroOffset)
+      onScale = _zeroOffset;
   }
 
   float weight = (onScale - _zeroOffset) / _calibrationFactor;

--- a/src/lib/drivers/nau7802.h
+++ b/src/lib/drivers/nau7802.h
@@ -159,7 +159,7 @@ public:
   float getCalibrationFactor();
 
   // Once you've set zero offset and cal factor, you can ask the library to do the calculations for you.
-  float getWeight(bool allowNegativeWeights = false, uint8_t samplesToTake = 8);
+  float getWeight(bool negativeScale = false, uint8_t samplesToTake = 8);
 
   // Set the gain. x1, 2, 4, 8, 16, 32, 64, 128 are available
   bool setGain(uint8_t gainValue);

--- a/src/lib/sensor_sampler/loadCellSampler.cpp
+++ b/src/lib/sensor_sampler/loadCellSampler.cpp
@@ -15,17 +15,18 @@
 #include <stdint.h>
 
 static NAU7802 *_loadCell;
-bool successful_lc_read = false;
-uint64_t read_attempt_duration = 100;
-uint64_t read_start_time;
+static bool successful_lc_read = false;
+static uint64_t read_attempt_duration = 100;
+static uint64_t read_start_time;
 
-uint32_t cellular_send_read_counter;
-float mean_force;
-float mean_sum;
-float max_force;
-float min_force;
-uint32_t num_reads = 240; //This should be 4 minutes
-LoadCellConfig_t _cfg;
+static bool negative_factor = false;
+static uint32_t cellular_send_read_counter;
+static float mean_force;
+static float mean_sum;
+static float max_force;
+static float min_force;
+static uint32_t num_reads = 240; //This should be 4 minutes
+static LoadCellConfig_t _cfg;
 
 #define INA_STR_LEN 80
 
@@ -45,7 +46,7 @@ static bool loadCellSample() {
 
   bool rval = true;
   int32_t reading = _loadCell->getReading();
-  float weight = _loadCell->getWeight();
+  float weight = _loadCell->getWeight(negative_factor);
   float calFactor = _loadCell->getCalibrationFactor();
   int32_t zeroOffset = _loadCell->getZeroOffset();
 
@@ -134,6 +135,9 @@ static bool loadCellInit() {
   rval = _loadCell->begin();
   _loadCell->setCalibrationFactor(_cfg.calibration_factor);
   _loadCell->setZeroOffset(_cfg.zero_offset);
+  if (_cfg.calibration_factor < 0.0) {
+      negative_factor = true;
+  }
 
   printf("loadCell init rval: %u\n", rval);
   return rval;


### PR DESCRIPTION
## What changed?
When the factor/divider of the load cell is negative, the system will assume there is negative readings. 
The factor/divider is a configuration in the system partition named `loadCellCalibrationFactor`.


## How does it make Bristlemouth better?
Allows load cells that decrease readings when tension is applied to have weight readings.
When tension is applied to a load cell that decreases in readings, the logic will always zero out the reading.

## Testing Results
For testing, there are two potential behaviors a load cell might exhibit:

1. Readings increase as tension is applied
2. Readings decrease as tension is applied

The following covers both of these cases

- Testing results when the readings increase as weight is applied (1st condition from above):
  - Positive Factor:
    - No Tension Applied
      ```
       1217445 | reading: 15073
       byte zero 0
       byte one 0
       byte two 0
       1217447 | weight: 0.646000
       1217447 | calFactor: 1000.000000
       1217447 | zeroOffset: 13528
      ```
     - Tension Applied
        ```
        77445 | reading: 33813
        byte zero 0
        byte one 0
        byte two 0
        77447 | weight: 21.211000
        77447 | calFactor: 1000.000000
        77447 | zeroOffset: 13528
        ```
    - As can be seen, when the reading increases so does the weight
  - Negative Factor:
    - No Tension Applied:
      ```
      17444 | reading: 15015
      byte zero 0
      byte one 0
      byte two 0
      17446 | weight: 0.000000
      17446 | calFactor: -1000.000000
      17446 | zeroOffset: 13528
      ```
    - Tension Applied:
      ```
      37448 | reading: 35795
      byte zero 0
      byte one 0
      byte two 0
      37450 | weight: 0.000000
      37450 | calFactor: -1000.000000
      37450 | zeroOffset: 13528
      ```
  - As can be seen, with a negative factor, the weight remains at zero when the reading increases

- Testing results when the readings decrease as weight is applied (2nd condition from above):
  - Positive Factor:
    - No Tension Applied
      ```
      107452 | reading: 13986
      byte zero 0
      byte one 0
      byte two 0
      107454 | weight: 1.022000
      107454 | calFactor: 1000.000000
      107454 | zeroOffset: 13528
      ```
    - Tension Applied
      ```
      127455 | reading: 8898
      byte zero 0
      byte one 0
      byte two 0
      127457 | weight: 0.000000
      127457 | calFactor: 1000.000000
      127457 | zeroOffset: 13528
      ```
    - As can be seen, when tension is applied, the reading decreases, and the weight is reduced to zero (rather than increasing in value)
  - Negative Factor:
    - No Tension Applied:
      ```
      37447 | reading: 13527
      byte zero 0
      byte one 0
      byte two 0
      37449 | weight: 0.000000
      37449 | calFactor: -1000.000000
      37449 | zeroOffset: 13528
      ```
    - Tension Applied:
      ```
      17445 | reading: 8897
      byte zero 0
      byte one 0
      byte two 0
      17447 | weight: 6.012000
      17447 | calFactor: -1000.000000
      17447 | zeroOffset: 13528
      ```
    - As tension is applied, the reading drops, but the weight increases (as expected)

## Where should reviewers focus?
Take a look at the testing results! The changes are pretty trivial.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
