### PR TITLE
Increase TSYS01 conversion time delay

### DIFF
--- a/src/apps/bm_soft_module/user_code/user_code.cpp
+++ b/src/apps/bm_soft_module/user_code/user_code.cpp
@@ -169,8 +169,8 @@ void loop(void) {
   }
   }
 
-  // Delay between readings
-  vTaskDelay(pdMS_TO_TICKS(soft_delay_ms));
+  // Delay between readings, need to subtract the time it takes to do the conversion
+  vTaskDelay(pdMS_TO_TICKS(soft_delay_ms - ADC_CONV_WAIT_TIME_MS));
 }
 
 static bool BmSoftStartAndValidate(void) {

--- a/src/lib/drivers/TSYS01.h
+++ b/src/lib/drivers/TSYS01.h
@@ -20,7 +20,7 @@
 #define SN_ADDR_1 0xAE
 
 #define RESET_WAIT_TIME_MS 6     // 2.8 ms x2 for assurance
-#define ADC_CONV_WAIT_TIME_MS 10 // 8.22 ms + 1 ms for assurance
+#define ADC_CONV_WAIT_TIME_MS 20 // 8.22 ms + 11 ms for assurance
 #define PROM_ADDR_CNT 8
 #define CALIB_CNT 5
 


### PR DESCRIPTION
## What changed?
Increased the TSYS01 ADC conversion wait time.


## How does it make Bristlemouth better?
It will decrease the number of missed readings on sensors that may have slightly slower conversion times.


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
