### PR TITLE
fix: handle RBR negative temperatures correctly

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor_util.cpp
@@ -103,6 +103,7 @@ static bool validSpecialChar(char c) {
   switch (c) {
   case ',':
   case '.':
+  case '-':
     return true;
   default:
     return false;

--- a/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor_util.cpp
+++ b/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor_util.cpp
@@ -103,6 +103,7 @@ static bool validSpecialChar(char c) {
   switch (c) {
   case ',':
   case '.':
+  case '-':
     return true;
   default:
     return false;

--- a/test/src/apps/bm_rbr/rbr_sensor_util_ut.cpp
+++ b/test/src/apps/bm_rbr/rbr_sensor_util_ut.cpp
@@ -12,9 +12,11 @@ TEST(rbrSensorUtilTest, validString) {
   static constexpr char temp[] = "14500, 17.7684\n";
   static constexpr char pressure[] = "332500, 9.9915\n";
   static constexpr char pressureAndTemp[] = "332500, 9.9915, 17.7684\n";
+  static constexpr char negTempAndPressure[] = "4500, -0.5079, 9.9655\n";
   EXPECT_TRUE(validSensorDataString(temp, strlen(temp)));
   EXPECT_TRUE(validSensorDataString(pressure, strlen(pressure)));
   EXPECT_TRUE(validSensorDataString(pressureAndTemp, strlen(pressureAndTemp)));
+  EXPECT_TRUE(validSensorDataString(negTempAndPressure, strlen(negTempAndPressure)));
 }
 
 TEST(rbrSensorUtilTest, InvalidString) {


### PR DESCRIPTION
## What changed?

We learned through a customer service interaction that we were not handling negative temperature values from RBR sensors correctly.

## How does it make Bristlemouth better?

This fixes a problem with our RBR adapter code to handle data that is perfectly valid but uncommon.

## Where should reviewers focus?

Can you think of related code that should change?

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
