### PR TITLE
Fix/do aggregation

### DIFF
--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
@@ -96,6 +96,23 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
       dissolved_oxygen_aggs.quality_mean = quality.getMean();
       dissolved_oxygen_aggs.do_saturation_pct_mean = do_saturation_pct.getMean();
       dissolved_oxygen_aggs.reading_count = reading_count;
+
+      if (dissolved_oxygen_aggs.temperature_deg_c_mean < TEMP_SAMPLE_MEMBER_MIN ||
+          dissolved_oxygen_aggs.temperature_deg_c_mean > TEMP_SAMPLE_MEMBER_MAX) {
+        dissolved_oxygen_aggs.temperature_deg_c_mean = NAN;
+      }
+      if (dissolved_oxygen_aggs.do_mg_per_l_mean < DO_SAMPLE_MEMBER_MIN ||
+          dissolved_oxygen_aggs.do_mg_per_l_mean > DO_SAMPLE_MEMBER_MAX) {
+        dissolved_oxygen_aggs.do_mg_per_l_mean = NAN;
+      }
+      if (dissolved_oxygen_aggs.quality_mean < QUALITY_SAMPLE_MEMBER_MIN ||
+          dissolved_oxygen_aggs.quality_mean > QUALITY_SAMPLE_MEMBER_MAX) {
+        dissolved_oxygen_aggs.quality_mean = NAN;
+      }
+      if (dissolved_oxygen_aggs.do_saturation_pct_mean < DO_SATURATION_SAMPLE_MEMBER_MIN ||
+          dissolved_oxygen_aggs.do_saturation_pct_mean > DO_SATURATION_SAMPLE_MEMBER_MAX) {
+        dissolved_oxygen_aggs.do_saturation_pct_mean = NAN;
+      }
     }
 
     BmErr err = send_spotter_log_aggregate(

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
@@ -29,6 +29,15 @@ typedef struct PmeDissolvedOxygenSensor : public AbstractSensor {
   static constexpr uint32_t DEFAULT_PME_DISSOLVED_READING_PERIOD_MS = 10 * 60 * 1000;
   static constexpr uint32_t N_SAMPLES_PAD = 2;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 1;
+  static constexpr double TEMP_SAMPLE_MEMBER_MIN = -0.414;
+  static constexpr double TEMP_SAMPLE_MEMBER_MAX = 35.6;
+  static constexpr double DO_SAMPLE_MEMBER_MIN = -1.0;
+  static constexpr double DO_SAMPLE_MEMBER_MAX = 100.0;
+  static constexpr double QUALITY_SAMPLE_MEMBER_MIN = 0.0;
+  static constexpr double QUALITY_SAMPLE_MEMBER_MAX = 1.0;
+  static constexpr double DO_SATURATION_SAMPLE_MEMBER_MIN = 0.0;
+  static constexpr double DO_SATURATION_SAMPLE_MEMBER_MAX = 150.0;
+
 
 public:
   bool subscribe() override;

--- a/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.cpp
@@ -113,6 +113,17 @@ void SeapointTurbiditySensor::aggregate(void) {
       turbidity_aggs.turbidity_s_mean_ftu = turbidity_s_ftu.getMean();
       turbidity_aggs.turbidity_r_mean_ftu = turbidity_r_ftu.getMean();
       turbidity_aggs.reading_count = reading_count;
+
+      if (turbidity_aggs.turbidity_s_mean_ftu < S_SAMPLE_MEMBER_MIN) {
+        turbidity_aggs.turbidity_s_mean_ftu = -HUGE_VAL;
+      } else if (turbidity_aggs.turbidity_s_mean_ftu > S_SAMPLE_MEMBER_MAX) {
+        turbidity_aggs.turbidity_s_mean_ftu = HUGE_VAL;
+      }
+      if (turbidity_aggs.turbidity_r_mean_ftu < R_SAMPLE_MEMBER_MIN) {
+        turbidity_aggs.turbidity_r_mean_ftu = -HUGE_VAL;
+      } else if (turbidity_aggs.turbidity_r_mean_ftu > R_SAMPLE_MEMBER_MAX) {
+        turbidity_aggs.turbidity_r_mean_ftu = HUGE_VAL;
+      }
     }
     static constexpr uint8_t TIME_STR_BUFSIZE = 50;
     char time_str[TIME_STR_BUFSIZE];

--- a/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.h
+++ b/src/apps/bridge/sensor_drivers/seapointTurbiditySensor.h
@@ -27,6 +27,10 @@ typedef struct SeapointTurbiditySensor : public AbstractSensor {
   // 2 minutes is the minimum bridge on period and the turbidity sensor by default is sampling at 1Hz. So 1*120 + 30 = 150.
   static constexpr uint32_t N_SAMPLES_PAD = 150;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
+  static constexpr double S_SAMPLE_MEMBER_MIN = 0.0;
+  static constexpr double S_SAMPLE_MEMBER_MAX = 20971.48;
+  static constexpr double R_SAMPLE_MEMBER_MIN = 0.0;
+  static constexpr double R_SAMPLE_MEMBER_MAX = 163800.00;
 
 public:
   bool subscribe() override;


### PR DESCRIPTION
## What changed?
Adding aggregated data bound checks to the Dissolved oxygen and turbidity sensors.


## How does it make Bristlemouth better?
This makes sure we correctly report out of bound readings.


## Where should reviewers focus?
Refer the internal google sheet for the ranges of the DO and turbidity sensors.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
