### PR TITLE
Allow debug_adin_raw module to initialize adin properly

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 if(APP_NAME MATCHES "bringup")
     list(APPEND LIB_FILES
         ${LIB_DIR}/debug/debug_uart.c
-        ${LIB_DIR}/debug/debug_adin_raw.c
+        ${LIB_DIR}/debug/debug_adin_raw.cpp
     )
 endif()
 

--- a/src/lib/bm_integration/bristlemouth_client.cpp
+++ b/src/lib/bm_integration/bristlemouth_client.cpp
@@ -40,7 +40,7 @@ static bool network_device_interrupt(const void *pinHandle, uint8_t value, void 
   return bm_l2_handle_device_interrupt() == BmOK;
 }
 
-static void adin_power_callback(bool on) {
+void bcl_power_callback(bool on) {
   IOWrite(&ADIN_PWR, on);
   if (on) {
     IOWrite(&ADIN_CS, 1);
@@ -76,7 +76,7 @@ void bcl_init(void) {
   printf("Starting up BCL\n");
   device_init(device);
 
-  BmErr err = bristlemouth_init(adin_power_callback);
+  BmErr err = bristlemouth_init(bcl_power_callback);
   if (err == BmOK) {
     NetworkDevice network_device = bristlemouth_network_device();
     network_device.callbacks->debug_packet_dump = pcapTxPacket;

--- a/src/lib/bm_integration/bristlemouth_client.h
+++ b/src/lib/bm_integration/bristlemouth_client.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
+void bcl_power_callback(bool on);
 void bcl_init(void);
 const char *bcl_get_ip_str(uint8_t ip);

--- a/src/lib/debug/debug_adin_raw.cpp
+++ b/src/lib/debug/debug_adin_raw.cpp
@@ -5,8 +5,10 @@
 /* FreeRTOS+CLI includes. */
 #include "FreeRTOS_CLI.h"
 
+#include "adi_hal.h"
 #include "bm_adin2111.h"
 #include "bm_config.h"
+#include "bristlemouth_client.h"
 #include "debug.h"
 #include "debug_adin_raw.h"
 #include "util.h"
@@ -70,13 +72,16 @@ static BaseType_t adinCommand(char *writeBuffer, size_t writeBufferLen,
     }
 
     if (strncmp("init", parameter, parameterStringLength) == 0) {
+      HAL_Init_Hook();
+      NetworkDevice network_device = adin2111_network_device();
+      network_device.callbacks->power = bcl_power_callback;
       BmErr err = adin2111_init();
       if (err == BmEALREADY) {
         printf("Adin already initialized\n");
       } else if (err == BmOK) {
         printf("Adin initialized successfully\n");
       } else {
-        printf("Adin initialization failed :(\n");
+        printf("Adin initialization failed, err: %d :(\n", err);
       }
     } else if (strncmp("tx", parameter, parameterStringLength) == 0) {
       NetworkDevice device = adin2111_network_device();

--- a/src/lib/drivers/adin2111/src/adi_hal.c
+++ b/src/lib/drivers/adin2111/src/adi_hal.c
@@ -62,12 +62,17 @@ uint32_t HAL_GetEnableIrq(void) { return NVIC_GetEnableIRQ(ADIN_INT_EXTI_IRQn); 
  */
 
 uint32_t HAL_Init_Hook(void) {
+  uint32_t ret = ADI_HAL_SUCCESS;
   BmErr err = BmENOMEM;
 
-  err = bm_task_create(adi_spi_task, "ADIN SPI Task", 512, NULL, ADIN_SPI_TASK_PRIORITY,
-                       &ADI_SPI_TASK_HANDLE);
+  if (!ADI_SPI_TASK_HANDLE) {
+    err = bm_task_create(adi_spi_task, "ADIN SPI Task", 512, NULL, ADIN_SPI_TASK_PRIORITY,
+                         &ADI_SPI_TASK_HANDLE);
 
-  return err == BmOK ? ADI_HAL_SUCCESS : ADI_HAL_ERROR;
+    ret = err == BmOK ? ADI_HAL_SUCCESS : ADI_HAL_ERROR;
+  }
+
+  return ret;
 }
 
 uint32_t HAL_UnInit_Hook(void) { return ADI_HAL_SUCCESS; }


### PR DESCRIPTION
## What changed?
Configure power callback for `adin init` command line call in the bringup app.
Also start the task for the network spi traffic when `adin init` is invoked.

## How does it make Bristlemouth better?
This allows the `adin init` call to work properly without failing in the bringup app.


## Where should reviewers focus?
Implementation in the `adin init` CLI call.
Should we just make a call to `bcl_init`  (that may defeat the purpose)?


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
