### PR TITLE
change wipe time config to use hardware parition

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -67,14 +67,14 @@ void ledAllOff() {
 }
 
 void saveLastWipeEpoch(uint32_t newLastWipeEpochS) {
-  set_config_uint(BM_CFG_PARTITION_SYSTEM, LAST_WIPE_EPOCH_KEY, strlen(LAST_WIPE_EPOCH_KEY),
+  set_config_uint(BM_CFG_PARTITION_HARDWARE, LAST_WIPE_EPOCH_KEY, strlen(LAST_WIPE_EPOCH_KEY),
                   newLastWipeEpochS);
-  save_config(BM_CFG_PARTITION_SYSTEM, false);
+  save_config(BM_CFG_PARTITION_HARDWARE, false);
   lastWipeEpochS = newLastWipeEpochS;
 }
 
 uint32_t loadLastWipeEpoch() {
-  bool success = get_config_uint(BM_CFG_PARTITION_SYSTEM, LAST_WIPE_EPOCH_KEY,
+  bool success = get_config_uint(BM_CFG_PARTITION_HARDWARE, LAST_WIPE_EPOCH_KEY,
                                  strlen(LAST_WIPE_EPOCH_KEY), &lastWipeEpochS);
   if (!success) {
     printf("LAST_WIPE_EPOCH_KEY not found. Initializing to 0.\n");


### PR DESCRIPTION
## What changed?
Changed where the Dissolved oxygen sensor + wiper saves its last wipe time config from the system partition to the hardware partition.


## How does it make Bristlemouth better?
This makes sure that the system config map  crc for every node is not changing every 4 hours.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
