### PR TITLE
More print lines & corrected partition configs

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -162,7 +162,7 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d) {
     uint16_t do_read_len = PLUART::readLine(_DOTpayload_buffer, sizeof(_DOTpayload_buffer));
     ledBlinkOnce(&LED_GREEN);
     // Make spotter_log conditional on system config
-    if (pmeLogEnable) {
+    if (pmeLogEnable == 1) {
       spotter_log(0, PME_DO_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
                   uptimeGetMs(), rtc_time_str, do_read_len, _DOTpayload_buffer);
     }

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -42,8 +42,11 @@
 */
 
 uint32_t pmeLogEnable = 1;
+bool pmeLogEnableCfg = false;
 uint32_t pmeDOTIntervalS = 600;
+bool pmeDOTIntervalSCfg = false;
 uint32_t pmeWipeIntervalS = 14400;
+bool pmeWipeIntervalSCfg = false;
 
 static PmeSensor pmeSensor;
 
@@ -84,25 +87,44 @@ void debugTx(void) {}
 
 void setup(void) {
   // Load system configuration & initialize if not configured by user
-  get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_LOG_ENABLE, strlen(SENSOR_BM_LOG_ENABLE),
-                  &pmeLogEnable);
-  get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_DOT_INTERVAL_S,
-                  strlen(SENSOR_BM_DOT_INTERVAL_S), &pmeDOTIntervalS);
-  get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_WIPE_INTERVAL_S,
-                  strlen(SENSOR_BM_WIPE_INTERVAL_S), &pmeWipeIntervalS);
-  printf("pmeLogEnable: %" PRIu32 "\n", pmeLogEnable);
-  printf("pmeDOTIntervalS: %" PRIu32 "\n", pmeDOTIntervalS);
-  printf("pmeWipeIntervalS: %" PRIu32 "\n", pmeWipeIntervalS);
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_LOG_ENABLE, strlen(SENSOR_BM_LOG_ENABLE), &pmeLogEnable)) {
+    pmeLogEnableCfg = true;
+  }
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_DOT_INTERVAL_S, strlen(SENSOR_BM_DOT_INTERVAL_S), &pmeDOTIntervalS)) {
+    pmeDOTIntervalSCfg = true;
+  }
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_WIPE_INTERVAL_S, strlen(SENSOR_BM_WIPE_INTERVAL_S), &pmeWipeIntervalS)) {
+    pmeWipeIntervalSCfg = true;
+  }
 
   pmeSensor.init();
   pmeDoTopicStrLen = createPmeDoMeasurementDataTopic();
   pmeWipeTopicStrLen = createPmeWipeDataTopic();
   lastWipeEpochS = loadLastWipeEpoch();
   printf("Last wipe time: %lu\n", lastWipeEpochS);
+  if (pmeLogEnableCfg == true) {
+    printf("User-defined pmeLogEnable found: %" PRIu32 "\n", pmeLogEnable);
+  }
+  else {
+    printf("No user-defined pmeLogEnable - defaulting to: %" PRIu32 "\n", pmeLogEnable);
+  }
+
+  if (pmeDOTIntervalSCfg == true) {
+    printf("User-defined pmeDOTIntervalS found: %" PRIu32 " seconds.\n", pmeDOTIntervalS);
+  }
+  else {
+    printf("No user-defined pmeDOTIntervalS - defaulting to: %" PRIu32 " seconds.\n", pmeDOTIntervalS);
+  }
+
+  if (pmeWipeIntervalSCfg == true) {
+    printf("User-defined pmeWipeIntervalS found: %" PRIu32 " seconds.\n", pmeWipeIntervalS);
+  }
+  else {
+    printf("No user-defined pmeWipeIntervalS - defaulting to: %" PRIu32 " seconds.\n\n", pmeWipeIntervalS);
+  }
   // Ensure Vbus stable before enabling Vout
   IOWrite(&BB_VBUS_EN, 0);
   bm_delay(50);
-  // Turn off LEDs
   ledAllOff();
   //Set first DO measurement flag to true to trigger startup DO measurement
   firstDo = true;
@@ -112,13 +134,8 @@ void loop(void) {
   RTCTimeAndDate_t time_and_date = {};
   bool rtcIsSet = rtcGet(&time_and_date);
   uint64_t epochTimeSec = (rtcGetMicroSeconds(&time_and_date) / 1000000);
-  //used for debugging RTC intervals
-  // printf("&&& epochTimeSec: %llu\n", epochTimeSec);
   uint64_t currentUptimeSec = uptimeGetMs() / 1000;
-  // Debugging timers
-  // printf("currentUptimeSec: %llu\n",currentUptimeSec);
-  // printf("currentUptimeMs: %" PRIu64 ", uptimeGetMs: %" PRIu64 ", remainingWipeTime: %" PRIu64 ", remainingDoTime: %" PRIu64 "\n", currentUptimeMs, uptimeGetMs(), remainingWipeTime, remainingDoTime);
-
+ 
   //////////
   // Wipe //
   //////////
@@ -141,17 +158,20 @@ void loop(void) {
           bm_pub_wl(pmeWipeTopic, pmeWipeTopicStrLen, cborBuf, encodedLen, 0,
                     BM_COMMON_PUB_SUB_VERSION);
           printf("#  WIPE Encoding success! | Topic: %s, cborBuf: %d, \n", pmeWipeTopic,
-                 cborBuf); // Debugging
-          //optional with config, todo
+                 cborBuf); 
         } else {
           printf("!  Failed to encode WIPE data message\n");
         }
       }
     } else {
-      printf("Wipe timer: %llu of %i seconds\n", elapsedWipe, pmeWipeIntervalS);
+      if (elapsedWipe % 10 == 0) {
+        printf("Wipe timer: %llu of %i seconds\n", elapsedWipe, pmeWipeIntervalS);
+      }
     }
   } else {
-    printf("!  Not wiping; RTC is not set!\n");
+    if (currentUptimeSec % 10 == 0) {
+      printf("Wipe timer: !!! Not wiping - RTC is not set!\n");
+    }
   }
 
   /////////
@@ -171,10 +191,9 @@ void loop(void) {
       if (PmeDissolvedOxygenMsg::encode(d, cborBuf, sizeof(cborBuf), &encodedLen) ==
           CborNoError) {
         printf("#  DOT Encoding success! | Topic: %s, cborBuf: %d, \n", pmeDoTopic,
-               cborBuf); // Debugging
+               cborBuf);
         bm_pub_wl(pmeDoTopic, pmeDoTopicStrLen, cborBuf, encodedLen, 0,
                   BM_COMMON_PUB_SUB_VERSION);
-        //optional with config, todo
         if (true) {
           debugTx();
         }
@@ -186,7 +205,9 @@ void loop(void) {
     }
     lastDoMeasurementUptimeSec = currentUptimeSec;
   } else {
+    if (elapsedDoSec % 10 == 0) {
     printf("DOT timer: %llu of %i seconds\n", elapsedDoSec, pmeDOTIntervalS);
+    }
   }
   bm_delay(1000);
 }


### PR DESCRIPTION
## What changed?

User configurable settings (log enable, wipe interval, DOT interval) kept in system partition, wipeEpoch time kept in hardware partition. Added extra printf lines for clarity in console, removed old comments.


## How does it make Bristlemouth better?



## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
