### PR TITLE
Wrap malloc/free call to utilize bm_core versions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -332,6 +332,7 @@ add_link_options(
 				-Wl,--build-id
                 -Wl,--wrap=malloc
                 -Wl,--wrap=free
+                -Wl,--wrap=calloc
         # -specs=nano.specs
         # -lc
         # -lm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,6 +330,8 @@ add_link_options(
         -T${CMAKE_CURRENT_BINARY_DIR}/${LINKER_FILE}.lds
         ${BSP_CPU_FLAGS}
 				-Wl,--build-id
+                -Wl,--wrap=malloc
+                -Wl,--wrap=free
         # -specs=nano.specs
         # -lc
         # -lm

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIB_FILES
     ${LIB_DIR}/common/reset_reason.c
     ${LIB_DIR}/common/serial.c
     ${LIB_DIR}/common/sensorWatchdog.cpp
+    ${LIB_DIR}/common/malloc.c
     ${LIB_DIR}/common/serial_console_u5.cpp
     ${LIB_DIR}/common/stress.c
     ${LIB_DIR}/common/tokenize.c

--- a/src/lib/common/malloc.c
+++ b/src/lib/common/malloc.c
@@ -1,0 +1,10 @@
+#include "bm_os.h"
+#include <stdio.h>
+
+void *__wrap_malloc(size_t size) { return bm_malloc(size); }
+
+void __wrap_free(void *p) {
+  if (p) {
+    bm_free(p);
+  }
+}

--- a/src/lib/common/malloc.c
+++ b/src/lib/common/malloc.c
@@ -1,7 +1,18 @@
 #include "bm_os.h"
 #include <stdio.h>
+#include <string.h>
 
 void *__wrap_malloc(size_t size) { return bm_malloc(size); }
+
+void *__wrap_calloc(size_t num, size_t size) {
+  void *ret = bm_malloc(num * size);
+
+  if (ret) {
+    memset(ret, 0, num * size);
+  }
+
+  return ret;
+}
 
 void __wrap_free(void *p) {
   if (p) {


### PR DESCRIPTION
## What changed?
Wraps malloc and free calls in order to utilize Bristlemouth Core versions.


## How does it make Bristlemouth better?
Prevents developers from allocating to non-FreeRTOS heap, placing the application in a dangerous memory situation.


## Where should reviewers focus?
Code will be the most important area of focus. I have tested with a debugger to make sure that these calls are being invoked properly.


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
