### PR TITLE
Feature/borealis levels pspls messages

### DIFF
--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -323,15 +323,24 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
         if (!sensorControllerFindSensorById(reply.node_id, SENSOR_TYPE_BOREALIS_SPECTRUM)) {
           Borealis_t *borealis_spectrum_sub =
               createBorealisSensorSub(SENSOR_TYPE_BOREALIS_SPECTRUM, reply.node_id);
-          if (borealis_spectrum_sub) {
-            Borealis_t *borealis_levels_sub =
-                createBorealisSensorSub(SENSOR_TYPE_BOREALIS_LEVELS, reply.node_id);
-            if (borealis_levels_sub) {
-              abstractSensorAddSensorSub(borealis_spectrum_sub);
-              abstractSensorAddSensorSub(borealis_levels_sub);
-            } else {
-              bm_free(borealis_spectrum_sub);
-            }
+          Borealis_t *borealis_levels_sub =
+              createBorealisSensorSub(SENSOR_TYPE_BOREALIS_LEVELS, reply.node_id);
+          Borealis_t *borealis_levels_statistics_sub =
+              createBorealisSensorSub(SENSOR_TYPE_BOREALIS_LEVEL_STATISTICS, reply.node_id);
+          Borealis_t *borealis_recording_status_sub =
+              createBorealisSensorSub(SENSOR_TYPE_BOREALIS_RECORDING_STATUS, reply.node_id);
+
+          if (borealis_spectrum_sub && borealis_levels_sub && borealis_levels_statistics_sub &&
+              borealis_recording_status_sub) {
+            abstractSensorAddSensorSub(borealis_spectrum_sub);
+            abstractSensorAddSensorSub(borealis_levels_sub);
+            abstractSensorAddSensorSub(borealis_levels_statistics_sub);
+            abstractSensorAddSensorSub(borealis_recording_status_sub);
+          } else {
+            bm_free(borealis_spectrum_sub);
+            bm_free(borealis_levels_sub);
+            bm_free(borealis_levels_statistics_sub);
+            bm_free(borealis_recording_status_sub);
           }
         }
       }

--- a/src/apps/bridge/sensor_drivers/abstractSensor.h
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.h
@@ -15,6 +15,8 @@ typedef enum abstractSensorType : uint8_t {
   SENSOR_TYPE_BOREALIS_LEVELS = 6,
   SENSOR_TYPE_PME_DO = 7,
   SENSOR_TYPE_PME_WIPE = 8,
+  SENSOR_TYPE_BOREALIS_LEVEL_STATISTICS = 9,
+  SENSOR_TYPE_BOREALIS_RECORDING_STATUS = 10,
 } abstractSensorType_e;
 
 struct AbstractSensor {

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -37,6 +37,12 @@ bool BorealisSensor::subscribe() {
   case SENSOR_TYPE_BOREALIS_LEVELS:
     subtag = subtag_levels;
     break;
+  case SENSOR_TYPE_BOREALIS_LEVEL_STATISTICS:
+    subtag = subtag_level_statistics;
+    break;
+  case SENSOR_TYPE_BOREALIS_RECORDING_STATUS:
+    subtag = subtag_recstatus;
+    break;
   default:
     break;
   }
@@ -79,6 +85,10 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
     sensor_type = SENSOR_TYPE_BOREALIS_SPECTRUM;
   } else if (strstr(topic, subtag_levels) != NULL) {
     sensor_type = SENSOR_TYPE_BOREALIS_LEVELS;
+  } else if (strstr(topic, subtag_level_statistics) != NULL) {
+    sensor_type = SENSOR_TYPE_BOREALIS_LEVEL_STATISTICS;
+  } else if (strstr(topic, subtag_recstatus) != NULL) {
+    sensor_type = SENSOR_TYPE_BOREALIS_RECORDING_STATUS;
   }
 
   if (sensor_type != SENSOR_TYPE_UNKNOWN) {
@@ -91,23 +101,46 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
     if (xSemaphoreTake(borealis->_mutex, portMAX_DELAY) == pdTRUE) {
       switch (borealis->type) {
       case SENSOR_TYPE_BOREALIS_SPECTRUM: {
-        borealis_spectrum_data d;
+        struct borealis_spectrum_data d;
         if (borealis_spectrum_data_decode(&d, (uint8_t *)data, data_len) == CborNoError) {
           err = borealis->send_spotter_log_individual(
               "borealis", d.header,
               MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms),
-              "%.3f,%.3f,%u,%s\n", d.dt, d.df, d.bands_per_octave, d.spectrum_as_base64);
+              "%.3f,%.3f,%u,%.*s\n", d.dt, d.df, d.bands_per_octave, d.spectrum_length,
+              d.spectrum_as_base64);
           bm_free(d.spectrum_as_base64);
         }
       } break;
       case SENSOR_TYPE_BOREALIS_LEVELS: {
-        borealis_levels d;
+        struct borealis_levels d;
         if (borealis_levels_decode(&d, (uint8_t *)data, data_len) == CborNoError) {
           err = borealis->send_spotter_log_individual(
               "borealis", d.header,
+              MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms), "%.3f,%u,%.*s\n",
+              d.dt, d.first_band_index, d.levels_length, d.levels);
+          bm_free(d.levels);
+        }
+      } break;
+      case SENSOR_TYPE_BOREALIS_LEVEL_STATISTICS: {
+        struct borealis_level_statistics d;
+        if (borealis_levels_statistics_decode(&d, (uint8_t *)data, data_len) == CborNoError) {
+          err = borealis->send_spotter_log_individual(
+              "borealis", d.header,
               MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms),
-              "%.3f,%.3f,%u,%s\n", d.dt, d.dt_report, d.first_band_index, d.levels_as_base64);
-          bm_free(d.levels_as_base64);
+              "%.3f,%.3f,%.3f,%u,%.*s\n", d.dt, d.dt_report, d.max_iqr, d.first_band_index,
+              d.levels_length, d.levels);
+          bm_free(d.levels);
+        }
+      } break;
+      case SENSOR_TYPE_BOREALIS_RECORDING_STATUS: {
+        struct borealis_recording_status d;
+        if (borealis_recording_status_decode(&d, (uint8_t *)data, data_len) == CborNoError) {
+          err = borealis->send_spotter_log_individual(
+              "borealis", d.header,
+              MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms),
+              "%.u,%.3f,%.3f,%.*s\n", d.flags, d.seconds_written, d.seconds_free,
+              d.filename_length, d.filename);
+          bm_free(d.filename);
         }
       } break;
       default:

--- a/src/apps/bridge/sensor_drivers/borealisSensor.h
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.h
@@ -14,6 +14,8 @@ private:
                                   uint8_t version);
   static constexpr char subtag_spectrum[] = "/aos/borealis/spectrum";
   static constexpr char subtag_levels[] = "/aos/borealis/levels";
+  static constexpr char subtag_level_statistics[] = "/aos/borealis/level_statistics";
+  static constexpr char subtag_recstatus[] = "/aos/borealis/recstatus";
 } Borealis_t;
 
 Borealis_t *createBorealisSensorSub(abstractSensorType_e type, uint64_t node_id);


### PR DESCRIPTION
## What changed?
Ability for the Bridge to parse new level statistics message and unused recording status message and send the 


## How does it make Bristlemouth better?
Brings us closer to being able to send BOREALIS data over the air! The level statistics give us a run down of the SEL over the past configured amount of time (5 mins default). This makes it easier to send data at lower intervals than SPL messages and provide more information for other potential future features!


## Where should reviewers focus?
`borealisSensor.cpp` would be a great first place to start! This is where the newly added message comes from.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
