### PR TITLE
Add Handshaking When Determining A Nodes System Info

### DIFF
--- a/src/apps/bridge/topology_sampler.cpp
+++ b/src/apps/bridge/topology_sampler.cpp
@@ -68,6 +68,7 @@ static bool _send_on_boot;
 static node_list_s _node_list;
 static QueueHandle_t _sys_info_queue;
 static QueueHandle_t _config_cbor_map_queue;
+static SemaphoreHandle_t _sys_info_handshake;
 
 static void topology_timer_handler(TimerHandle_t tmr);
 static void topology_sampler_task(void *parameters);
@@ -118,14 +119,27 @@ static void topology_sample_cb(NetworkTopology *networkTopology) {
     bool exit = false;
 
     // Iterate through the entire list of nodes and request the sys info.
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
+                   "Bridge topology in topology sampler:\n");
     for (cursor = networkTopology->front, counter = 0;
          (cursor != NULL) && (counter < _node_list.num_nodes);
          cursor = cursor->nextNode, counter++) {
       _node_list.nodes[counter] = cursor->neighbor_table_reply->node_id;
-      if (!sys_info_service_request(_node_list.nodes[counter], sys_info_reply_cb,
-                                    NODE_SYS_INFO_REQUEST_TIMEOUT_S)) {
-        printf("Failed to send sys info request to node: %" PRIu64 "\n",
-               _node_list.nodes[counter]);
+      if (xSemaphoreTake(_sys_info_handshake,
+                         pdMS_TO_TICKS(NODE_NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS)) == pdTRUE) {
+        bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "%016" PRIx64 "\n",
+                       _node_list.nodes[counter]);
+        if (!sys_info_service_request(_node_list.nodes[counter], sys_info_reply_cb,
+                                      NODE_SYS_INFO_REQUEST_TIMEOUT_S)) {
+          printf("Failed to send sys info request to node: %" PRIu64 "\n",
+                 _node_list.nodes[counter]);
+          exit = true;
+          break;
+        }
+      } else {
+        bridgeLogPrint(
+            BRIDGE_SYS, BM_COMMON_LOG_LEVEL_ERROR, USE_HEADER,
+            "Failed to take sys_info semaphore when generating config topology report\n");
         exit = true;
         break;
       }
@@ -298,6 +312,9 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
   if (!rval && reply.app_name) {
     vPortFree(reply.app_name);
   }
+
+  xSemaphoreGive(_sys_info_handshake);
+
   return rval;
 }
 
@@ -396,8 +413,7 @@ static bool create_network_info_cbor_array(uint8_t *cbor_buffer, size_t &cbor_bu
         break;
       }
       // Update the network crc with all of the node crcs
-      if (xQueueReceive(_sys_info_queue, &info_reply,
-                        pdMS_TO_TICKS(NODE_NETWORK_SYS_INFO_REQUEST_TIMEOUT_MS))) {
+      if (xQueueReceive(_sys_info_queue, &info_reply, 0) == pdTRUE) {
 
         // This function will use the app name to determine the sensor type and update the _node_list.sensor_type array
         // so that the reportBuilder can pull the sensor type from the node id. The sensor type array must match the
@@ -581,6 +597,10 @@ void topology_sampler_init(BridgePowerController *power_controller) {
   _config_cbor_map_queue =
       xQueueCreate(TOPOLOGY_SAMPLER_MAX_NODE_LIST_SIZE, sizeof(ConfigCborMapReplyData));
   configASSERT(_config_cbor_map_queue);
+  _sys_info_handshake = xSemaphoreCreateBinary();
+  configASSERT(_sys_info_handshake);
+  xSemaphoreGive(_sys_info_handshake);
+
   // create task
   BaseType_t rval = xTaskCreate(topology_sampler_task, "TOPO_SAMPLER", 1024, NULL,
                                 TOPO_SAMPLER_TASK_PRIORITY, NULL);
@@ -820,8 +840,7 @@ static void _update_sensor_type_list(uint64_t node_id, char *app_name, uint32_t 
       } else if (strncmp(app_name, "seapoint_turbidity", strlen("seapoint_turbidity")) == 0) {
         _node_list.sensor_type[i] = SENSOR_TYPE_SEAPOINT_TURBIDITY;
         break;
-      } else if (strncmp(app_name, "pme_do_sensor", strlen("pme_do_sensor")) ==
-                 0) {
+      } else if (strncmp(app_name, "pme_do_sensor", strlen("pme_do_sensor")) == 0) {
         _node_list.sensor_type[i] = SENSOR_TYPE_PME_DO;
         break;
       }


### PR DESCRIPTION
## What changed?
Handshake added between subsequent `sys_info_service_requests` in topology_sampler's topology callback.


## How does it make Bristlemouth better?

Ensures that a system info request is received from nodes in order, this way nodes cannot receive info replies out of order. 

Adds print statements every time a topology request is made from topology sampler to ensure topology is not being reported out of order.

## Bug Explanation

There are one of two situations I can see occurring here:

1. The topology is being calculated incorrectly
2. There is a timing condition when obtaining the `sys_info` on a node in the topology (see below for details)

Big AHA moment when running through the logic for how this is handled.
Within the `topology_sampler` in the callback for the topology report here is how the flow of things work currently:

1. Iterate through the network topology (in order) and send a `sys_info_service_request`
    a. I thought this was a little interesting as we do not wait for a reply from the request, we immediately send the request to each node back to back
    b. In the topology module, we wait until we hear back from the each node after a neighbor table request before further nodes to the topology
2. Iterate through the NUMBER of nodes (not in order), wait for a `sys_info_reply` message to fill a queue item
    a. Ok this is where things can get out of order, if a `sys_info_reply` is received on one node before another, bad things will happen.
3. Send a `config_cbor_map_service_request` to the node we just received the `sys_info_reply` from
    a. This is done sequentially, we send a `config_cbor_map_service_request` in accordance the the node that we first received the `sys_info_reply` from
4. CBOR encode all this data, run a crc32 over  it, compare it against the last calculated crc32, if it is correct move on, if it is incorrect store the new config map and report it up to spotter.

Ok...
a lot going on.
From the information above, it seems like there is a timing condition with the `sys_info` request being sent to the nodes in the topology, but can we prove this?
Yes!

Tracing the variable `_node_list.nodes`  will help lead us to the promised land.
This variable is assigned based on the incoming topology.
`_node_list.nodes[0]` will be assigned to the first node in the topology, `_node_list.nodes[1]` will be assigned to the next node and so on.
This variable is used in the function: `topology_sampler_get_node_position`.
What calls this function?
All of the `sensorSubCallbacks` in the `src/apps/bridge/sensor_drivers` directory!
These callbacks are used to pipe data to the `XXXX_SENS_IND.csv` file on Spotter.
What does this mean you ask?
Well, if the topology report is correct, then the `node_positions` in the `XXXX_SENS_IND.csv` file will be correct, and they are!
This means that there *has* to be some timing issue in the sequencing of the `sys_info_request` messages, this can be remedied by ensuring that there is proper handshaking occurring here, ex a semaphore waiting until the previous node's `sys_info_service_reply` was received before moving onto the next.

Evidence:
[0001_BRIDGE_CFG.log](https://github.com/user-attachments/files/19763419/0001_BRIDGE_CFG.log)
[0001_SENS_IND.csv](https://github.com/user-attachments/files/19763455/0001_SENS_IND.csv.zip)

## Where should reviewers focus?
The evidence is a good place to start! Other than that, I want feedback on the new bridge prints added, these are for debugging to see if we ever get the topology out of order. I am fairly confident we will not, but it still could be a nice to have.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
