### PR TITLE
adding config flag to DO app to be able to turn on/off spotter tx data

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -21,6 +21,7 @@
 //#define WIPE_INTERVAL_KEY "WipeInterval"
 
 extern uint32_t pmeLogEnable;
+extern uint32_t sensorDebugTxEnable;
 
 uint32_t lastWipeEpochS = 0;
 //uint32_t DOTinterval = 600;
@@ -168,8 +169,9 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d) {
     }
     spotter_log_console(0, "DOT | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
                         rtc_time_str, do_read_len, _DOTpayload_buffer);
-
-    spotter_tx_data(_DOTpayload_buffer, do_read_len, BmNetworkTypeCellularIriFallback);
+    if (sensorDebugTxEnable) {
+      spotter_tx_data(_DOTpayload_buffer, do_read_len, BmNetworkTypeCellularIriFallback);
+    }
 
     printf("#  DOT | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtc_time_str,
            do_read_len, _DOTpayload_buffer);
@@ -246,7 +248,9 @@ bool PmeSensor::getWipeData(PmeWipeMsg::Data &w) {
     }
     spotter_log_console(0, "WIPE | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
                         rtc_time_str, wipe_read_len, _WIPEpayload_buffer);
-    spotter_tx_data(_WIPEpayload_buffer, wipe_read_len, BmNetworkTypeCellularIriFallback);
+    if (sensorDebugTxEnable) {
+      spotter_tx_data(_WIPEpayload_buffer, wipe_read_len, BmNetworkTypeCellularIriFallback);
+    }
     printf("Wipe | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtc_time_str,
            wipe_read_len, _WIPEpayload_buffer);
 

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -47,6 +47,8 @@ uint32_t pmeDOTIntervalS = 600;
 bool pmeDOTIntervalSCfg = false;
 uint32_t pmeWipeIntervalS = 14400;
 bool pmeWipeIntervalSCfg = false;
+uint32_t sensorDebugTxEnable = 0;
+bool sensorDebugTxEnableCfg = false;
 
 static PmeSensor pmeSensor;
 
@@ -63,6 +65,7 @@ static constexpr uint32_t pmeSensorDataMsgMaxSize = 256;
 static constexpr char SENSOR_BM_LOG_ENABLE[] = "pmeLogEnable";
 static constexpr char SENSOR_BM_DOT_INTERVAL_S[] = "pmeDOTIntervalS";
 static constexpr char SENSOR_BM_WIPE_INTERVAL_S[] = "pmeWipeIntervalS";
+static constexpr char SENSOR_DEBUG_TX_ENABLE[] = "sensorDebugTxEnable";
 
 // Variables for measurements and timing
 static uint32_t lastWipeEpochS = 0;
@@ -96,6 +99,9 @@ void setup(void) {
   if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_WIPE_INTERVAL_S, strlen(SENSOR_BM_WIPE_INTERVAL_S), &pmeWipeIntervalS)) {
     pmeWipeIntervalSCfg = true;
   }
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_DEBUG_TX_ENABLE, strlen(SENSOR_DEBUG_TX_ENABLE), &sensorDebugTxEnable)) {
+    sensorDebugTxEnableCfg = true;
+  }
 
   pmeSensor.init();
   pmeDoTopicStrLen = createPmeDoMeasurementDataTopic();
@@ -120,8 +126,16 @@ void setup(void) {
     printf("User-defined pmeWipeIntervalS found: %" PRIu32 " seconds.\n", pmeWipeIntervalS);
   }
   else {
-    printf("No user-defined pmeWipeIntervalS - defaulting to: %" PRIu32 " seconds.\n\n", pmeWipeIntervalS);
+    printf("No user-defined pmeWipeIntervalS - defaulting to: %" PRIu32 " seconds.\n", pmeWipeIntervalS);
   }
+
+  if (sensorDebugTxEnableCfg == true) {
+    printf("User-defined sensorDebugTxEnable found: %" PRIu32 "\n", sensorDebugTxEnable);
+  }
+  else {
+    printf("No user-defined sensorDebugTxEnable - defaulting to: %" PRIu32 "\n", sensorDebugTxEnable);
+  }
+
   // Ensure Vbus stable before enabling Vout
   IOWrite(&BB_VBUS_EN, 0);
   bm_delay(50);
@@ -135,7 +149,7 @@ void loop(void) {
   bool rtcIsSet = rtcGet(&time_and_date);
   uint64_t epochTimeSec = (rtcGetMicroSeconds(&time_and_date) / 1000000);
   uint64_t currentUptimeSec = uptimeGetMs() / 1000;
- 
+
   //////////
   // Wipe //
   //////////
@@ -158,7 +172,7 @@ void loop(void) {
           bm_pub_wl(pmeWipeTopic, pmeWipeTopicStrLen, cborBuf, encodedLen, 0,
                     BM_COMMON_PUB_SUB_VERSION);
           printf("#  WIPE Encoding success! | Topic: %s, cborBuf: %d, \n", pmeWipeTopic,
-                 cborBuf); 
+                 cborBuf);
         } else {
           printf("!  Failed to encode WIPE data message\n");
         }


### PR DESCRIPTION
## What changed?
Adding the `sensorDebugTxEnable` config to the DO app to allow for the enabling/disabling of spotter_tx_data from the DO node. By default it will be 0 (OFF).

Immediately after updating the node we can see the first DO sample being logged, but not being sent since by default it will not spotter_tx_data it:
<img width="742" alt="Screenshot 2025-04-28 at 12 02 11 PM" src="https://github.com/user-attachments/assets/df54d8a1-ee36-4245-9f8e-3237d41f5890" />


After setting the config to 1 we can see that the data is sent:
Setting the config to 1:
<img width="1422" alt="Screenshot 2025-04-28 at 12 13 24 PM" src="https://github.com/user-attachments/assets/7092c6b8-9fb6-4a6e-bb8e-d5ffd49fb334" />
The first DO sample sending out via spotter_tx_data:
<img width="1423" alt="Screenshot 2025-04-28 at 12 13 35 PM" src="https://github.com/user-attachments/assets/e126b623-6ba9-477e-afc3-528584286410" />

After setting the config to 0 we can see that the data is no longer sent via spotter_tx_data again:
<img width="807" alt="Screenshot 2025-04-28 at 12 10 08 PM" src="https://github.com/user-attachments/assets/666263e6-7053-4ad3-b761-2e3d907e2642" />



## How does it make Bristlemouth better?
This allows users to decrease/increase output or debugging capabilities of their DO sensor.


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
