### PR TITLE
fix: variable length arrays in C++ are not standard

### DIFF
--- a/src/lib/common/Exo3LineParser.cpp
+++ b/src/lib/common/Exo3LineParser.cpp
@@ -32,7 +32,7 @@ bool Exo3DataLineParser::parseValueFromToken(const char* token, size_t index, ch
     printf("ERR - token too large!\n");
     return false;
   }
-  char token_copy[2 + token_len];  // 1 for separator + token_len + 1 for null terminator
+  char token_copy[256];  // 1 for separator + token_len + 1 for null terminator
   // Insert the '+' or '-' separator at start. `strto` functions in parent
   //  OrderedSeparatorLineParser::parseValueFromToken know how to handle those.
   token_copy[0] = foundSeparator;

--- a/src/lib/common/Exo3LineParser.cpp
+++ b/src/lib/common/Exo3LineParser.cpp
@@ -5,34 +5,34 @@
 #include "Exo3LineParser.h"
 #include "string.h"
 
-Exo3DataLineParser::Exo3DataLineParser(size_t numValues, const char* header)
+Exo3DataLineParser::Exo3DataLineParser(size_t numValues, const char *header)
     : OrderedSeparatorLineParser("+-", 256, nullptr, numValues + 1, header) {
   // Allocate and set up `valueTypes` based on `num_values`, add one for response identifier header
   auto value_types = new ValueType[numValues + 1];
-  value_types[0] = TYPE_INVALID;  // First value as placeholder if needed
+  value_types[0] = TYPE_INVALID; // First value as placeholder if needed
   for (size_t i = 0; i < numValues; ++i) {
-    value_types[i+1] = TYPE_DOUBLE;  // Set all subsequent values as TYPE_DOUBLE
+    value_types[i + 1] = TYPE_DOUBLE; // Set all subsequent values as TYPE_DOUBLE
   }
   _valueTypes = value_types;
 }
 
-
 Exo3DataLineParser::~Exo3DataLineParser() {
-  delete[] _valueTypes;  // Free dynamically allocated `value_types` array
+  delete[] _valueTypes; // Free dynamically allocated `value_types` array
 }
 
-bool Exo3DataLineParser::parseValueFromToken(const char* token, size_t index, char foundSeparator) {
+bool Exo3DataLineParser::parseValueFromToken(const char *token, size_t index,
+                                             char foundSeparator) {
   // If there's no separator, call the parent method directly with the token
   if (foundSeparator == '\0') {
     return OrderedSeparatorLineParser::parseValueFromToken(token, index, foundSeparator);
   }
   // Buffer to hold separator + token (only allocate if separator is present)
   const size_t token_len = strlen(token);
-  if (token_len >= 255) {  // Limit size to avoid overflows
+  if (token_len >= 255) { // Limit size to avoid overflows
     printf("ERR - token too large!\n");
     return false;
   }
-  char token_copy[256];  // 1 for separator + token_len + 1 for null terminator
+  char token_copy[256]; // 1 for separator + token_len + 1 for null terminator
   // Insert the '+' or '-' separator at start. `strto` functions in parent
   //  OrderedSeparatorLineParser::parseValueFromToken know how to handle those.
   token_copy[0] = foundSeparator;


### PR DESCRIPTION
## What changed?

Fixes this error I saw when building the unit tests:

```
[build] [ 10%] Building CXX object test/src/common/CMakeFiles/lineParsers.dir/__/__/__/src/lib/common/Exo3LineParser.cpp.o
[build] /Users/zac/code/bristlemouth/bm_protocol/src/lib/common/Exo3LineParser.cpp:35:19: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
[build]    35 |   char token_copy[2 + token_len];  // 1 for separator + token_len + 1 for null terminator
[build]       |                   ^~~~~~~~~~~~~
[build] /Users/zac/code/bristlemouth/bm_protocol/src/lib/common/Exo3LineParser.cpp:35:23: note: initializer of 'token_len' is not a constant expression
[build]    35 |   char token_copy[2 + token_len];  // 1 for separator + token_len + 1 for null terminator
[build]       |                       ^
[build] /Users/zac/code/bristlemouth/bm_protocol/src/lib/common/Exo3LineParser.cpp:30:16: note: declared here
[build]    30 |   const size_t token_len = strlen(token);
[build]       |                ^
[build] 1 error generated.
[build] make[2]: *** [test/src/common/CMakeFiles/lineParsers.dir/build.make:104: test/src/common/CMakeFiles/lineParsers.dir/__/__/__/src/lib/common/Exo3LineParser.cpp.o] Error 1
[build] make[1]: *** [CMakeFiles/Makefile2:1330: test/src/common/CMakeFiles/lineParsers.dir/all] Error 2
```

## How does it make Bristlemouth better?

Uses standard C++

## Where should reviewers focus?

Probably a rubber stamp.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
