### PR TITLE
fix: gcc format warnings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -146,6 +146,13 @@
             }
         },
         {
+            "name": "pme-do-sensor",
+            "inherits": "serial-payload-example-bristleback",
+            "cacheVariables": {
+                "APP": "pme_do_sensor"
+            }
+        },
+        {
             "name": "pub-example",
             "inherits": "hello-world",
             "cacheVariables": {
@@ -178,6 +185,13 @@
             "inherits": "hello-world",
             "cacheVariables": {
                 "APP": "rx_live_example"
+            }
+        },
+        {
+            "name": "sdi12-example",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "sdi12_example"
             }
         },
         {
@@ -315,6 +329,11 @@
             "jobs": 8
         },
         {
+            "configurePreset": "pme-do-sensor",
+            "name": "pme-do-sensor",
+            "jobs": 8
+        },
+        {
             "configurePreset": "pub-example",
             "name": "pub-example",
             "jobs": 8
@@ -337,6 +356,11 @@
         {
             "configurePreset": "rx-live-example",
             "name": "rx-live-example",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "sdi12-example",
+            "name": "sdi12-example",
             "jobs": 8
         },
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,7 +166,6 @@ set(COMPILE_FLAGS
 	-Wformat=2
 	-Wformat-overflow
 	-Wformat-signedness
-	-Wno-format
 	-Wno-narrowing
 
 	-Werror

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -305,7 +305,7 @@ void user_code_start() {
   BmErr err = bm_task_create(user_task, "USER", 4096, NULL, USER_TASK_PRIORITY, NULL);
   if (err != BmOK) {
     static const char *err_str = "Failed to create user task\n";
-    bm_debug(err_str);
+    bm_debug("%s", err_str);
     spotter_log(0, bmdk_log_filename, USE_TIMESTAMP, err_str);
     spotter_log_console(0, err_str);
   }

--- a/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
@@ -114,7 +114,7 @@ void loop(void) {
     rtcPrint(rtcTimeBuffer, &statsStartRtc);
     uint32_t statsEndTick = uptimeGetMs();
     sprintf(stats_print_buffer,
-            "rtc_start: %s, tick_start: %u, tick_end: %u, "
+            "rtc_start: %s, tick_start: %lu, tick_end: %lu, "
             "temp_n: %u, temp_min: %.4f, temp_max: %.4f, temp_mean: %.4f, "
             "temp_std: %.4f, "
             "hum_n: %u, hum_min: %.4f, hum_max: %.4f, hum_mean: %.4f, hum_std: "
@@ -165,27 +165,27 @@ void loop(void) {
   }
 
   if (pressure_stats.getNumSamples() >= MAX_SENSOR_SAMPLES) {
-    printf("ERR - No more room in pressure stats buffer, already have %lu readings!\n",
+    printf("ERR - No more room in pressure stats buffer, already have %" PRIu64 " readings!\n",
            MAX_SENSOR_SAMPLES);
   } else {
     float temperature, pressure = 0.0;
     if (pressureSamplerGetLatest(pressure, temperature)) {
       pressure_stats.addSample(pressure);
-      printf("pressure stats | count: %u/%lu, min: %f, max: %f\n",
+      printf("pressure stats | count: %lu/%llu, min: %f, max: %f\n",
              pressure_stats.getNumSamples(), MAX_SENSOR_SAMPLES - 10, pressure_stats.getMin(),
              pressure_stats.getMax());
     }
   }
 
   if (hum_stats.getNumSamples() >= MAX_SENSOR_SAMPLES) {
-    printf("ERR - No more room in hum/temp stats buffer, already have %lu readings!\n",
+    printf("ERR - No more room in hum/temp stats buffer, already have %" PRIu64 " readings!\n",
            MAX_SENSOR_SAMPLES);
   } else {
     float temperature, humidity = 0.0;
     if (htuSamplerGetLatest(humidity, temperature)) {
       hum_stats.addSample(humidity);
       temp_stats.addSample(temperature);
-      printf("hum-temp stats | count: %u/%lu, min_T: %f, max_T: %f, min_H: %f, "
+      printf("hum-temp stats | count: %lu/%llu, min_T: %f, max_T: %f, min_H: %f, "
              "max_H: %f\n",
              hum_stats.getNumSamples(), MAX_SENSOR_SAMPLES - 10, temp_stats.getMin(),
              temp_stats.getMax(), hum_stats.getMin(), hum_stats.getMax());
@@ -193,8 +193,7 @@ void loop(void) {
   }
 
   if (power_voltage_stats.getNumSamples() >= MAX_SENSOR_SAMPLES) {
-    printf("ERR - No more room in power stats buffer, already have %lu "
-           "readings!\n",
+    printf("ERR - No more room in power stats buffer, already have %" PRIu64 " readings!\n",
            MAX_SENSOR_SAMPLES);
   } else {
     float voltage_mote, current_mote = 0.0;
@@ -203,7 +202,7 @@ void loop(void) {
       power_voltage_stats.addSample(voltage_mote);
       power_current_stats.addSample(current_mote);
 
-      printf("power stats | count: %u/%lu, min_V: %f, max_V: %f, min_I: %f, max_I: "
+      printf("power stats | count: %lu/%llu, min_V: %f, max_V: %f, min_I: %f, max_I: "
              "%f\n",
              power_voltage_stats.getNumSamples(), MAX_SENSOR_SAMPLES - 10,
              power_voltage_stats.getMin(), power_voltage_stats.getMax(),

--- a/src/apps/bm_devkit/nortek/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/nortek/user_code/user_code.cpp
@@ -316,10 +316,10 @@ void loop(void) {
     printf("[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
 
     if (parser.parseLine(payload_buffer, read_len)) {
-      printf("parsed values: %f | %f\n", parser.getValue(23).data, parser.getValue(24).data);
+      printf("parsed values: %f | %f\n", parser.getValue(23).data.double_val, parser.getValue(24).data.double_val);
       fillNortekStruct(); //No args. This uses global parser to update global nortkeData
       if (month_stats.sample_count >= MAX_SENSOR_SAMPLES) {
-        printf("ERR - No more room in the Nortek stats buffer, already have %lu readings!\n", MAX_SENSOR_SAMPLES);
+        printf("ERR - No more room in the Nortek stats buffer, already have %llu readings!\n", MAX_SENSOR_SAMPLES);
         return;
       }
 
@@ -329,7 +329,7 @@ void loop(void) {
       rtcPrint(rtcTimeBuffer, NULL);
       this_uptime = uptimeGetMs();
 
-      printf("batt v from userProcessLine | count: %u/%lu batt v: %f \n",
+      printf("batt v from userProcessLine | count: %u/%llu batt v: %f \n",
         batt_v_stats.sample_count,
         MAX_SENSOR_SAMPLES-10,
         nortekData.batt_v);

--- a/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/pub_example/user_code/user_code.cpp
@@ -38,7 +38,7 @@ void loop(void) {
     // Clear the data buffer
     memset(data_buffer, 0, sizeof(data_buffer));
     // Print a simple message into the data buffer to publish to the topic.
-    sprintf((char *)data_buffer, "[%" PRId64 " ms] Hello World!", uptimeGetMs());
+    sprintf((char *)data_buffer, "[%" PRIu64 " ms] Hello World!", uptimeGetMs());
     // Publish the data buffer to the topic.
     if (bm_pub(EXAMPLE_PUBLISH_TOPIC, data_buffer, sizeof(data_buffer),
                EXAMPLE_PUBLISH_TOPIC_TYPE, EXAMPLE_PUBLISH_TOPIC_VERSION) != BmOK) {

--- a/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
@@ -238,7 +238,7 @@ void loop(void) {
     ledLinePulse = uptimeGetMs();
     // Now when we get a line of text data, our LineParser turns it into numeric values.
     if (parser.parseLine(payload_buffer, read_len)) {
-      printf("parsed values: %llu | %f\n", parser.getValue(0).data, parser.getValue(1).data);
+      printf("parsed values: %llu | %f\n", parser.getValue(0).data.uint64_val, parser.getValue(1).data.double_val);
     } else {
       printf("Error parsing line!\n");
       return; // FIXME: this is a little confusing
@@ -254,7 +254,7 @@ void loop(void) {
     double coda_reading = parser.getValue(1).data.double_val;
     coda_data.addSample(coda_reading);
 
-    printf("count: %u/%d, min: %f, max: %f\n", coda_data.getNumSamples(), MAX_CODA_SAMPLES,
+    printf("count: %lu/%d, min: %f, max: %f\n", coda_data.getNumSamples(), MAX_CODA_SAMPLES,
            coda_data.getMin(), coda_data.getMax());
   }
 }

--- a/src/apps/bm_devkit/rx_live_example/user_code/rx_live_sensor.cpp
+++ b/src/apps/bm_devkit/rx_live_example/user_code/rx_live_sensor.cpp
@@ -38,7 +38,7 @@ void RxLiveSensor::computeCCCode() {
   }
 
   _ccCode = sum; // Set the computed CC code to the sum of the digits
-  printf("%llut | Computed CC Code: %u for serial: %u\n", uptimeGetMs(), _ccCode,
+  printf("%llut | Computed CC Code: %u for serial: %lu\n", uptimeGetMs(), _ccCode,
          _serial_number);
 }
 
@@ -46,7 +46,7 @@ void RxLiveSensor::computeCCCode() {
 void RxLiveSensor::txCommand(const RxLiveCommand &command) const {
   // Transmit the command buffer using PLUART, with serial number and ccCode
   char formattedCommand[64] = {0};
-  snprintf(formattedCommand, sizeof(formattedCommand), "*%06u.0#%02u,%s\r",
+  snprintf(formattedCommand, sizeof(formattedCommand), "*%06lu.0#%02u,%s\r",
             _serial_number, _ccCode, command.command_buffer);
 
   const size_t commandLen = strlen(formattedCommand);
@@ -88,8 +88,8 @@ bool RxLiveSensor::sendCommand(RxLiveCommandType command_type) {
 }
 
 bool RxLiveSensor::validateResponseHeader(const char *rx_data) const {
-  char headerBuffer[13] = {0};
-  snprintf(headerBuffer, sizeof(headerBuffer), "*%06u.0#%02u", _serial_number, _ccCode);
+  char headerBuffer[20] = {0};
+  snprintf(headerBuffer, sizeof(headerBuffer), "*%06lu.0#%02u", _serial_number, _ccCode);
   return strstr(rx_data, headerBuffer) != nullptr;
 }
 
@@ -221,7 +221,7 @@ RxLiveStatusCode RxLiveSensor::run(const uint8_t *rx_data, const size_t rx_len) 
           printf("\t\tCode Char: %c\n", parsed_tag_id.code_char);
           printf("\t\tCode Freq: %u\n", parsed_tag_id.code_freq);
           printf("\t\tCode Channel: %u\n", parsed_tag_id.code_channel);
-          printf("\t\tTag Serial no: %u\n", parsed_tag_id.tag_serial_no);
+          printf("\t\tTag Serial no: %lu\n", parsed_tag_id.tag_serial_no);
           _latest_detection = parsed_tag_id;
           return RX_CODE_DETECTION;
         } else {
@@ -230,7 +230,7 @@ RxLiveStatusCode RxLiveSensor::run(const uint8_t *rx_data, const size_t rx_len) 
         }
       }
       printf("%llut | WARN - Rx-Live data was not an STD line!\n", uptimeGetMs());
-      printf("%llut | TODO, process data: %.*s\n", uptimeGetMs(), rx_len,
+      printf("%llut | TODO, process data: %.*s\n", uptimeGetMs(), (int)rx_len,
              reinterpret_cast<const char *>(rx_data));
       return RX_CODE_NO_PARSE;
     }

--- a/src/apps/bm_devkit/rx_live_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/rx_live_example/user_code/user_code.cpp
@@ -130,9 +130,9 @@ void tally_detection(const TagID &latest_detection) {
         tag_detections[i].detection_count++;
       } else {
         // Print an error for debugging
-        printf(
-            "Error: Detection count for tag serial no %u has reached its maximum value (%u).\n",
-            tag_detections[i].tag_serial_no, UINT16_MAX);
+        printf("Error: Detection count for tag serial no %lu has reached its maximum value "
+               "(%" PRIu16 ").\n",
+               tag_detections[i].tag_serial_no, UINT16_MAX);
       }
       found = true;
       break;
@@ -158,7 +158,7 @@ void tally_detection(const TagID &latest_detection) {
          "Freq", "Chan", "Detections");
   printf("---------------------------------------------------------\n");
   for (uint32_t i = 0; i < unique_tag_ids; ++i) {
-    printf("| %-5u | %-10u | %-6c | %-8u | %-5u | %-10u |\n", i,
+    printf("| %-5lu | %-10lu | %-6c | %-8u | %-5u | %-10u |\n", i,
            tag_detections[i].tag_serial_no, tag_detections[i].code_char,
            tag_detections[i].code_freq, tag_detections[i].code_channel,
            tag_detections[i].detection_count);

--- a/src/apps/bm_devkit/sdi12_example/user_code/exo3s_sensor.cpp
+++ b/src/apps/bm_devkit/sdi12_example/user_code/exo3s_sensor.cpp
@@ -92,7 +92,7 @@ void SondeEXO3sSensor::sdi_cmd(int cmd) {
     sdi_transmit("0I!");
     result = sdi_receive();
     if (result) {
-      printf("received data: %.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("received data: %.*s\n", (int)sizeof(rxBuffer), rxBuffer);
     }
     /* Response --- 013YSIIWQSGEXOSND100
        * 0 sdi-12 sensor address
@@ -113,7 +113,7 @@ void SondeEXO3sSensor::sdi_cmd(int cmd) {
     sdi_transmit("0M!");
     result = sdi_receive();
     if (result) {
-      printf("%.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("%.*s\n", (int)sizeof(rxBuffer), rxBuffer);
       // get time it takes for the measurement to be done
       delay = abs((rxBuffer[5] - '0') * 10 + (rxBuffer[6] - '0'));
       printf("wait %d seconds for measurement to complete\n", delay);
@@ -127,22 +127,22 @@ void SondeEXO3sSensor::sdi_cmd(int cmd) {
     vTaskDelay(pdMS_TO_TICKS(delay * 1000)); //62 seconds delay
     result = sdi_receive();
     if (result) {
-      printf("measuring done: %.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("measuring done: %.*s\n", (int)sizeof(rxBuffer), rxBuffer);
     }
     vTaskDelay(pdMS_TO_TICKS(1000));
     sdi_transmit("0D0!");
     result = sdi_receive();
     if (result) {
-      printf("%.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("%.*s\n", (int)sizeof(rxBuffer), rxBuffer);
       if (d0_parser.parseLine(reinterpret_cast<const char *>(rxBuffer), sizeof(rxBuffer))) {
         const Value d0_0 = d0_parser.getValue(1);
         const Value d0_1 = d0_parser.getValue(2);
         const Value d0_2 = d0_parser.getValue(3);
         const Value d0_3 = d0_parser.getValue(4);
-        printf("temp_sensor:  %.3f C\n", d0_0.data);
-        printf("sp_cond:      %.3f uS/cm\n", d0_1.data);
-        printf("pH:           %.3f\n", d0_2.data);
-        printf("pH:           %.3f mV\n", d0_3.data);
+        printf("temp_sensor:  %.3f C\n", d0_0.data.double_val);
+        printf("sp_cond:      %.3f uS/cm\n", d0_1.data.double_val);
+        printf("pH:           %.3f\n", d0_2.data.double_val);
+        printf("pH:           %.3f mV\n", d0_3.data.double_val);
         _latest_sample.temp_sensor = (float)d0_0.data.double_val;
         _latest_sample.sp_cond = (float)d0_1.data.double_val;
         _latest_sample.pH = (float)d0_2.data.double_val;
@@ -153,16 +153,16 @@ void SondeEXO3sSensor::sdi_cmd(int cmd) {
     sdi_transmit("0D1!");
     result = sdi_receive();
     if (result) {
-      printf("%.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("%.*s\n", (int)sizeof(rxBuffer), rxBuffer);
       if (d1_parser.parseLine(reinterpret_cast<const char *>(rxBuffer), sizeof(rxBuffer))) {
         const Value d1_0 = d1_parser.getValue(1);
         const Value d1_1 = d1_parser.getValue(2);
         const Value d1_2 = d1_parser.getValue(3);
         const Value d1_3 = d1_parser.getValue(4);
-        printf("DO:           %.3f Percent Sat\n", d1_0.data);
-        printf("DO:           %.3f mg/L\n", d1_1.data);
-        printf("turbidity:    %.3f NTU\n", d1_2.data);
-        printf("wiper pos:    %.3f V\n", d1_3.data);
+        printf("DO:           %.3f Percent Sat\n", d1_0.data.double_val);
+        printf("DO:           %.3f mg/L\n", d1_1.data.double_val);
+        printf("turbidity:    %.3f NTU\n", d1_2.data.double_val);
+        printf("wiper pos:    %.3f V\n", d1_3.data.double_val);
         _latest_sample.dis_oxy = (float)d1_0.data.double_val;
         _latest_sample.dis_oxy_mg = (float)d1_1.data.double_val;
         _latest_sample.turbidity = (float)d1_2.data.double_val;
@@ -173,12 +173,12 @@ void SondeEXO3sSensor::sdi_cmd(int cmd) {
     sdi_transmit("0D2!");
     result = sdi_receive();
     if (result) {
-      printf("%.*s\n", sizeof(rxBuffer), rxBuffer);
+      printf("%.*s\n", (int)sizeof(rxBuffer), rxBuffer);
       if (d2_parser.parseLine(reinterpret_cast<const char *>(rxBuffer), sizeof(rxBuffer))) {
         const Value d2_0 = d2_parser.getValue(1);
         const Value d2_1 = d2_parser.getValue(2);
-        printf("depth:        %.3f m\n", d2_0.data);
-        printf("power supply: %.3f V\n", d2_1.data);
+        printf("depth:        %.3f m\n", d2_0.data.double_val);
+        printf("power supply: %.3f V\n", d2_1.data.double_val);
         _latest_sample.depth = (float)d2_0.data.double_val;
         _latest_sample.power = (float)d2_1.data.double_val;
       }

--- a/src/apps/bm_devkit/sdi12_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/sdi12_example/user_code/user_code.cpp
@@ -75,7 +75,7 @@ void setup(void) {
   // samples per send
   get_config_uint(BM_CFG_PARTITION_USER, "sampleCount", strlen("sampleCount"), &sample_count);
   if (sample_count * SAMPLE_SIZE > MAX_TX_BUFFER_SIZE) {
-    printf("sampleCount value is larger than max buffer size: %d, limiting sampleCount to: %d",
+    printf("sampleCount value is larger than max buffer size: %d, limiting sampleCount to: %u",
            MAX_TX_BUFFER_SIZE, MAX_TX_BUFFER_SIZE / SAMPLE_SIZE);
     sample_count = MAX_TX_BUFFER_SIZE / SAMPLE_SIZE;
   }

--- a/src/apps/bm_soft_module/user_code/user_code.cpp
+++ b/src/apps/bm_soft_module/user_code/user_code.cpp
@@ -87,7 +87,7 @@ static void getConfigs() {
                       strlen(soft_cfg_reading_period_ms), &soft_delay_ms)) {
     printf("SOFT Delay: %" PRIu32 "ms\n", soft_delay_ms);
   } else {
-    printf("SOFT Delay: Using default % " PRIu32 "ms\n", soft_delay_ms);
+    printf("SOFT Delay: Using default %" PRIu32 "ms\n", soft_delay_ms);
   }
 
   get_config_uint(BM_CFG_PARTITION_SYSTEM, sensor_bm_log_enable, strlen(sensor_bm_log_enable),

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -75,7 +75,7 @@ void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t l
   if (len > 0) {
     switch (type) {
     case BM_COMMON_IND:
-      printf("[%s] %.*s", "BM_COMMON_IND", len, str);
+      printf("[%s] %.*s", "BM_COMMON_IND", (int)len, str);
       bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC,
                     sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC) - 1,
                     reinterpret_cast<const uint8_t *>(str), len,
@@ -83,7 +83,7 @@ void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t l
                     APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);
       break;
     case BM_COMMON_AGG:
-      printf("[%s] %.*s", "BM_COMMON_AGG", len, str);
+      printf("[%s] %.*s", "BM_COMMON_AGG", (int)len, str);
       bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC,
                     sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC) - 1,
                     reinterpret_cast<const uint8_t *>(str), len,

--- a/src/apps/bridge/network_config_logger.cpp
+++ b/src/apps/bridge/network_config_logger.cpp
@@ -13,7 +13,7 @@ static CborError print_stream_handler(void *out, const char *fmt, ...) {
 
   va_list args;
   va_start(args, fmt);
-  int n = vsnprintf(nullptr, log_buffer_max_size - log_buffer_size, fmt, args);
+  int n = vsnprintf(nullptr, 0, fmt, args);
   if (n > 0 && log_buffer_size < log_buffer_max_size) {
     vsnprintf(&log_buffer[log_buffer_size], log_buffer_max_size - log_buffer_size, fmt, args);
     log_buffer_size += n;

--- a/src/apps/bridge/sensor_drivers/abstractSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/abstractSensor.cpp
@@ -77,9 +77,9 @@ BmErr AbstractSensor::send_spotter_log_individual(const char *app_name,
           "%s,"             // node_app_name
           "%" PRIu64 ","    // reading_uptime_millis
           "%" PRIu64 "."    // reading_time_utc_ms seconds part
-          "%03" PRIu32 ","  // reading_time_utc_ms millis part
+          "%03" PRIu64 ","  // reading_time_utc_ms millis part
           "%" PRIu64 "."    // sensor_reading_time_ms seconds part
-          "%03" PRIu32 ",", // sensor_reading_time_ms millis part
+          "%03" PRIu64 ",", // sensor_reading_time_ms millis part
           node_id, update_node_position(max_reading_period_ms), app_name,
           header.reading_uptime_millis, GET_S_FROM_MS(header.reading_time_utc_ms),
           GET_MS_LEFT(header.reading_time_utc_ms), GET_S_FROM_MS(header.sensor_reading_time_ms),

--- a/src/apps/bridge/topology_sampler.cpp
+++ b/src/apps/bridge/topology_sampler.cpp
@@ -283,7 +283,7 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
                               const char *service, size_t reply_len, uint8_t *reply_data) {
   bool rval = false;
   SysInfoReplyData reply = {0, 0, 0, 0, NULL};
-  printf("Service: %.*s\n", service_strlen, service);
+  printf("Service: %.*s\n", (int)service_strlen, service);
   printf("Reply: %" PRIu32 "\n", msg_id);
   do {
     if (ack) {
@@ -296,7 +296,7 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
       printf(" * Node id: %016" PRIx64 "\n", reply.node_id);
       printf(" * Git SHA: 0x%08" PRIx32 "\n", reply.git_sha);
       printf(" * Sys config CRC: 0x%08" PRIx32 "\n", reply.sys_config_crc);
-      printf(" * App name: %.*s\n", reply.app_name_strlen, reply.app_name);
+      printf(" * App name: %.*s\n", (int)reply.app_name_strlen, reply.app_name);
       if (xQueueSend(_sys_info_queue, &reply, 0) != pdTRUE) {
         printf("Failed to send sys info\n");
         break;
@@ -332,7 +332,7 @@ static bool cbor_config_map_reply_cb(bool ack, uint32_t msg_id, size_t service_s
                                      uint8_t *reply_data) {
   bool rval = false;
   ConfigCborMapReplyData reply = {0, 0, 0, 0, NULL};
-  printf("Service: %.*s\n", service_strlen, service);
+  printf("Service: %.*s\n", (int)service_strlen, service);
   printf("Reply: %" PRIu32 "\n", msg_id);
   do {
     if (ack) {
@@ -343,9 +343,9 @@ static bool cbor_config_map_reply_cb(bool ack, uint32_t msg_id, size_t service_s
         break;
       }
       printf(" * Node id: %016" PRIx64 "\n", reply.node_id);
-      printf(" * Partition: %" PRId32 "\n", reply.partition_id);
+      printf(" * Partition: %" PRIu32 "\n", reply.partition_id);
       printf(" * Cbor map len: %" PRIu32 "\n", reply.cbor_encoded_map_len);
-      printf(" * Success: %" PRId32 "\n", reply.success);
+      printf(" * Success: %d\n", reply.success);
       if (reply.success) {
         for (uint32_t i = 0; i < reply.cbor_encoded_map_len; i++) {
           if (!reply.cbor_data) {

--- a/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/aanderaa/user_code/user_code.cpp
@@ -276,13 +276,13 @@ void setup(void) {
   printf("App configs:\n");
   printf("\tcurrent_agg_period_min: %f\n", current_agg_period_min);
   printf("\tCURRENT_AGG_PERIOD_MS: %f\n", CURRENT_AGG_PERIOD_MS);
-  printf("\tn_skip_readings: %u\n", n_skip_readings);
-  printf("\treading_interval_ms: %u\n", reading_interval_ms);
+  printf("\tn_skip_readings: %lu\n", n_skip_readings);
+  printf("\treading_interval_ms: %lu\n", reading_interval_ms);
   printf("\tmax_readings_in_agg: %llu\n", max_readings_in_agg);
-  printf("\tpayload_wd_to_s: %u\n", payload_wd_to_s);
-  printf("\tbaud_rate: %u\n", baud_rate);
-  printf("\tmfg_tx_test_enable: %u\n", mfg_tx_test_enable);
-  printf("\tsensorBmLogEnable: %u\n", sensorBmLogEnable);
+  printf("\tpayload_wd_to_s: %lu\n", payload_wd_to_s);
+  printf("\tbaud_rate: %lu\n", baud_rate);
+  printf("\tmfg_tx_test_enable: %lu\n", mfg_tx_test_enable);
+  printf("\tsensorBmLogEnable: %lu\n", sensorBmLogEnable);
 
   SensorWatchdog::SensorWatchdogAdd(AANDERAA_WATCHDOG_ID, PAYLOAD_WATCHDOG_TIMEOUT_MS,
                                     aanderaaSensorWatchdogHandler,
@@ -331,7 +331,7 @@ void loop(void) {
     rtcPrint(rtcTimeBuffer, &statsEndRtc);
     uint32_t statsEndTick = uptimeGetMs();
     int buffer_offset =
-        sprintf(stats_print_buffer, "rtc_end: %s, tick_start: %u, tick_end: %u | ",
+        sprintf(stats_print_buffer, "rtc_end: %s, tick_start: %lu, tick_end: %lu | ",
                 rtcTimeBuffer, statsStartTick, statsEndTick);
     for (uint8_t i = 0; i < NUM_PARAMS_TO_AGG; i++) {
       buffer_offset +=
@@ -421,11 +421,12 @@ void loop(void) {
     char rtcTimeBuffer[32] = {};
     rtcPrint(rtcTimeBuffer, NULL);
     if (sensorBmLogEnable) {
-      spotter_log(0, AANDERAA_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
-                 uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
+      spotter_log(0, AANDERAA_RAW_LOG, USE_TIMESTAMP,
+                  "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
+                  read_len, payload_buffer);
     }
     spotter_log_console(0, "[aanderaa] | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
-              rtcTimeBuffer, read_len, payload_buffer);
+                        rtcTimeBuffer, read_len, payload_buffer);
     printf("[aanderaa] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
            rtcTimeBuffer, read_len, payload_buffer);
 
@@ -478,7 +479,8 @@ void loop(void) {
     // Now let's aggregate those values into statistics
     if (current_data[0].getNumSamples() >= max_readings_in_agg &&
         max_readings_in_agg > N_SAMPLES_PAD) {
-      printf("ERR - No more room in current reading buffer, already have %d readings!\n",
+      printf("ERR - No more room in current reading buffer, already have %" PRIu64
+             " readings!\n",
              max_readings_in_agg);
       return;
     }
@@ -487,7 +489,7 @@ void loop(void) {
     for (uint8_t i = 0; i < NUM_PARAMS_TO_AGG; i++) {
       double param_reading = parser.getValue(i).data.double_val;
       current_data[i].addSample(param_reading);
-      printf("\t%s | value: %f, count: %u/%llu, min: %f, max: %f\n", keys[i], param_reading,
+      printf("\t%s | value: %f, count: %lu/%llu, min: %f, max: %f\n", keys[i], param_reading,
              current_data[i].getNumSamples(), max_readings_in_agg - N_SAMPLES_PAD,
              current_data[i].getMin(), current_data[i].getMax());
     }

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -165,7 +165,7 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
   spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
             read_len, s);
   printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
-         read_len, s);
+         (int)read_len, s);
 
   // Use LineParser to turn string data into numeric values.
   if (_parsers[_type] && _parsers[_type]->parseLine(s, read_len)) {

--- a/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
@@ -311,10 +311,10 @@ void loop(void) {
     printf("[nortek] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
 
     if (parser.parseLine(payload_buffer, read_len)) {
-      printf("parsed values: %f | %f\n", parser.getValue(23).data, parser.getValue(24).data);
+      printf("parsed values: %f | %f\n", parser.getValue(23).data.double_val, parser.getValue(24).data.double_val);
       fillNortekStruct(); //No args. This uses global parser to update global nortkeData
       if (month_stats.sample_count >= MAX_SENSOR_SAMPLES) {
-        printf("ERR - No more room in the Nortek stats buffer, already have %lu readings!\n", MAX_SENSOR_SAMPLES);
+        printf("ERR - No more room in the Nortek stats buffer, already have %llu readings!\n", MAX_SENSOR_SAMPLES);
         return;
       }
 
@@ -324,7 +324,7 @@ void loop(void) {
       rtcPrint(rtcTimeBuffer, NULL);
       this_uptime = uptimeGetMs();
 
-      printf("batt v from userProcessLine | count: %u/%lu batt v: %f \n",
+      printf("batt v from userProcessLine | count: %u/%llu batt v: %f \n",
         batt_v_stats.sample_count,
         MAX_SENSOR_SAMPLES-10,
         nortekData.batt_v);

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -90,16 +90,20 @@ void debugTx(void) {}
 
 void setup(void) {
   // Load system configuration & initialize if not configured by user
-  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_LOG_ENABLE, strlen(SENSOR_BM_LOG_ENABLE), &pmeLogEnable)) {
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_LOG_ENABLE,
+                      strlen(SENSOR_BM_LOG_ENABLE), &pmeLogEnable)) {
     pmeLogEnableCfg = true;
   }
-  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_DOT_INTERVAL_S, strlen(SENSOR_BM_DOT_INTERVAL_S), &pmeDOTIntervalS)) {
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_DOT_INTERVAL_S,
+                      strlen(SENSOR_BM_DOT_INTERVAL_S), &pmeDOTIntervalS)) {
     pmeDOTIntervalSCfg = true;
   }
-  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_WIPE_INTERVAL_S, strlen(SENSOR_BM_WIPE_INTERVAL_S), &pmeWipeIntervalS)) {
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_WIPE_INTERVAL_S,
+                      strlen(SENSOR_BM_WIPE_INTERVAL_S), &pmeWipeIntervalS)) {
     pmeWipeIntervalSCfg = true;
   }
-  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_DEBUG_TX_ENABLE, strlen(SENSOR_DEBUG_TX_ENABLE), &sensorDebugTxEnable)) {
+  if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_DEBUG_TX_ENABLE,
+                      strlen(SENSOR_DEBUG_TX_ENABLE), &sensorDebugTxEnable)) {
     sensorDebugTxEnableCfg = true;
   }
 
@@ -110,30 +114,29 @@ void setup(void) {
   printf("Last wipe time: %lu\n", lastWipeEpochS);
   if (pmeLogEnableCfg == true) {
     printf("User-defined pmeLogEnable found: %" PRIu32 "\n", pmeLogEnable);
-  }
-  else {
+  } else {
     printf("No user-defined pmeLogEnable - defaulting to: %" PRIu32 "\n", pmeLogEnable);
   }
 
   if (pmeDOTIntervalSCfg == true) {
     printf("User-defined pmeDOTIntervalS found: %" PRIu32 " seconds.\n", pmeDOTIntervalS);
-  }
-  else {
-    printf("No user-defined pmeDOTIntervalS - defaulting to: %" PRIu32 " seconds.\n", pmeDOTIntervalS);
+  } else {
+    printf("No user-defined pmeDOTIntervalS - defaulting to: %" PRIu32 " seconds.\n",
+           pmeDOTIntervalS);
   }
 
   if (pmeWipeIntervalSCfg == true) {
     printf("User-defined pmeWipeIntervalS found: %" PRIu32 " seconds.\n", pmeWipeIntervalS);
-  }
-  else {
-    printf("No user-defined pmeWipeIntervalS - defaulting to: %" PRIu32 " seconds.\n", pmeWipeIntervalS);
+  } else {
+    printf("No user-defined pmeWipeIntervalS - defaulting to: %" PRIu32 " seconds.\n",
+           pmeWipeIntervalS);
   }
 
   if (sensorDebugTxEnableCfg == true) {
     printf("User-defined sensorDebugTxEnable found: %" PRIu32 "\n", sensorDebugTxEnable);
-  }
-  else {
-    printf("No user-defined sensorDebugTxEnable - defaulting to: %" PRIu32 "\n", sensorDebugTxEnable);
+  } else {
+    printf("No user-defined sensorDebugTxEnable - defaulting to: %" PRIu32 "\n",
+           sensorDebugTxEnable);
   }
 
   // Ensure Vbus stable before enabling Vout
@@ -171,15 +174,16 @@ void loop(void) {
         if (PmeWipeMsg::encode(w, cborBuf, sizeof(cborBuf), &encodedLen) == CborNoError) {
           bm_pub_wl(pmeWipeTopic, pmeWipeTopicStrLen, cborBuf, encodedLen, 0,
                     BM_COMMON_PUB_SUB_VERSION);
-          printf("#  WIPE Encoding success! | Topic: %s, cborBuf: %d, \n", pmeWipeTopic,
-                 cborBuf);
+          printf("#  WIPE Encoding success! | Topic: %s, cborBuf: %" PRIx8 "%" PRIx8 "%" PRIx8
+                 "...\n",
+                 pmeWipeTopic, cborBuf[0], cborBuf[1], cborBuf[2]);
         } else {
           printf("!  Failed to encode WIPE data message\n");
         }
       }
     } else {
       if (elapsedWipe % 10 == 0) {
-        printf("Wipe timer: %llu of %i seconds\n", elapsedWipe, pmeWipeIntervalS);
+        printf("Wipe timer: %llu of %lu seconds\n", elapsedWipe, pmeWipeIntervalS);
       }
     }
   } else {
@@ -204,8 +208,9 @@ void loop(void) {
       size_t encodedLen = 0;
       if (PmeDissolvedOxygenMsg::encode(d, cborBuf, sizeof(cborBuf), &encodedLen) ==
           CborNoError) {
-        printf("#  DOT Encoding success! | Topic: %s, cborBuf: %d, \n", pmeDoTopic,
-               cborBuf);
+        printf("#  DOT Encoding success! | Topic: %s, cborBuf: %" PRIx8 "%" PRIx8 "%" PRIx8
+               "...\n",
+               pmeDoTopic, cborBuf[0], cborBuf[1], cborBuf[2]);
         bm_pub_wl(pmeDoTopic, pmeDoTopicStrLen, cborBuf, encodedLen, 0,
                   BM_COMMON_PUB_SUB_VERSION);
         if (true) {
@@ -220,7 +225,7 @@ void loop(void) {
     lastDoMeasurementUptimeSec = currentUptimeSec;
   } else {
     if (elapsedDoSec % 10 == 0) {
-    printf("DOT timer: %llu of %i seconds\n", elapsedDoSec, pmeDOTIntervalS);
+      printf("DOT timer: %llu of %lu seconds\n", elapsedDoSec, pmeDOTIntervalS);
     }
   }
   bm_delay(1000);

--- a/src/apps/rs232_expander_apps/aanderaa/user_code/user_code.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa/user_code/user_code.cpp
@@ -270,13 +270,13 @@ void setup(void) {
   printf("App configs:\n");
   printf("\tcurrent_agg_period_min: %f\n", current_agg_period_min);
   printf("\tCURRENT_AGG_PERIOD_MS: %f\n", CURRENT_AGG_PERIOD_MS);
-  printf("\tn_skip_readings: %u\n", n_skip_readings);
-  printf("\treading_interval_ms: %u\n", reading_interval_ms);
+  printf("\tn_skip_readings: %lu\n", n_skip_readings);
+  printf("\treading_interval_ms: %lu\n", reading_interval_ms);
   printf("\tmax_readings_in_agg: %llu\n", max_readings_in_agg);
-  printf("\tpayload_wd_to_s: %u\n", payload_wd_to_s);
-  printf("\tbaud_rate: %u\n", baud_rate);
-  printf("\tmfg_tx_test_enable: %u\n", mfg_tx_test_enable);
-  printf("\tsensorBmLogEnable: %u\n", sensorBmLogEnable);
+  printf("\tpayload_wd_to_s: %lu\n", payload_wd_to_s);
+  printf("\tbaud_rate: %lu\n", baud_rate);
+  printf("\tmfg_tx_test_enable: %lu\n", mfg_tx_test_enable);
+  printf("\tsensorBmLogEnable: %lu\n", sensorBmLogEnable);
 
   SensorWatchdog::SensorWatchdogAdd(AANDERAA_WATCHDOG_ID, PAYLOAD_WATCHDOG_TIMEOUT_MS,
                                     aanderaaSensorWatchdogHandler,
@@ -325,7 +325,7 @@ void loop(void) {
     rtcPrint(rtcTimeBuffer, &statsEndRtc);
     uint32_t statsEndTick = uptimeGetMs();
     int buffer_offset =
-        sprintf(stats_print_buffer, "rtc_end: %s, tick_start: %u, tick_end: %u | ",
+        sprintf(stats_print_buffer, "rtc_end: %s, tick_start: %lu, tick_end: %lu | ",
                 rtcTimeBuffer, statsStartTick, statsEndTick);
     for (uint8_t i = 0; i < NUM_PARAMS_TO_AGG; i++) {
       buffer_offset +=
@@ -386,11 +386,12 @@ void loop(void) {
     char rtcTimeBuffer[32] = {};
     rtcPrint(rtcTimeBuffer, NULL);
     if (sensorBmLogEnable) {
-      spotter_log(0, AANDERAA_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
-                 uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
+      spotter_log(0, AANDERAA_RAW_LOG, USE_TIMESTAMP,
+                  "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
+                  read_len, payload_buffer);
     }
     spotter_log_console(0, "[aanderaa] | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
-              rtcTimeBuffer, read_len, payload_buffer);
+                        rtcTimeBuffer, read_len, payload_buffer);
     printf("[aanderaa] | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
            rtcTimeBuffer, read_len, payload_buffer);
 
@@ -442,7 +443,8 @@ void loop(void) {
     // Now let's aggregate those values into statistics
     if (current_data[0].getNumSamples() >= max_readings_in_agg &&
         max_readings_in_agg > N_SAMPLES_PAD) {
-      printf("ERR - No more room in current reading buffer, already have %d readings!\n",
+      printf("ERR - No more room in current reading buffer, already have %" PRIu64
+             " readings!\n",
              max_readings_in_agg);
       return;
     }
@@ -451,7 +453,7 @@ void loop(void) {
     for (uint8_t i = 0; i < NUM_PARAMS_TO_AGG; i++) {
       double param_reading = parser.getValue(i).data.double_val;
       current_data[i].addSample(param_reading);
-      printf("\t%s | value: %f, count: %u/%llu, min: %f, max: %f\n", keys[i], param_reading,
+      printf("\t%s | value: %f, count: %lu/%llu, min: %f, max: %f\n", keys[i], param_reading,
              current_data[i].getNumSamples(), max_readings_in_agg - N_SAMPLES_PAD,
              current_data[i].getMin(), current_data[i].getMax());
     }

--- a/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -165,7 +165,7 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
   spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
             read_len, s);
   printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
-         read_len, s);
+         (int)read_len, s);
 
   // Use LineParser to turn string data into numeric values.
   if (_parsers[_type] && _parsers[_type]->parseLine(s, read_len)) {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -126,7 +126,7 @@ if(CMAKE_APP_TYPE STREQUAL "BMDK" OR
    CMAKE_APP_TYPE STREQUAL "bristleback" OR
    CMAKE_APP_TYPE STREQUAL "rs232_expander" OR
    APP_NAME STREQUAL "bringup_mote" OR
-   APP_NAME STREQUAL "mote_bristlefin" OR
+   APP_NAME MATCHES "mote_bristlefin" OR
    APP_NAME STREQUAL "bm_soft_module")
     if(NOT CMAKE_APP_TYPE STREQUAL "bristleback" AND
        NOT APP_NAME STREQUAL "bm_soft_module" AND

--- a/src/lib/bm_integration/bcmp_cli.cpp
+++ b/src/lib/bm_integration/bcmp_cli.cpp
@@ -510,7 +510,7 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
       data[dataStrLen] = 0;
 
       if (bm_pub(topic, data, dataStrLen, type, version) == BmOK) {
-        printf("Successfully published message to topic: %s of %d bytes\n", topic, dataStrLen);
+        printf("Successfully published message to topic: %s of %ld bytes\n", topic, dataStrLen);
       } else {
         printf("Could not publish message to topic: %s\n", topic);
       }
@@ -573,14 +573,14 @@ static BaseType_t cmd_bcmp_fn(char *writeBuffer, size_t writeBufferLen,
           data = (uint8_t)strtoul(data_str, NULL, 0);
           rb_buf[idx++] = data;
           if (idx >= CHUNK_SIZE_DFU) {
-            printf("Adding to queue at: %d\n", idx);
+            printf("Adding to queue at: %" PRIu32 "\n", idx);
             bm_dfu_host_queue_data(rb_buf, sizeof(rb_buf));
             idx = 0;
           }
         }
         printf("DFU Byte Added\n");
       } else if (strncmp("finish", sub_command, command_str_len) == 0) {
-        printf("Adding to queue at: %d\n", idx);
+        printf("Adding to queue at: %" PRIu32 "\n", idx);
         bm_dfu_host_queue_data(rb_buf, sizeof(rb_buf));
         idx = 0;
         printf("DFU Finish\n");

--- a/src/lib/common/device_info.c
+++ b/src/lib/common/device_info.c
@@ -10,7 +10,7 @@ extern uint8_t __start_gnu_build_id_start[];
 const ElfNoteSection_t *g_note_build_id = (ElfNoteSection_t *)__start_gnu_build_id_start;
 const uint32_t *UID = (const uint32_t *)(UID_BASE); // 96-bit unique hardware id
 
-static char fwVersionStr[128];
+static char fwVersionStr[132];
 static char uidStr[25];
 static char nodeidStr[17];
 static uint8_t hwVersion = 0;

--- a/src/lib/debug/debug_bm_service.cpp
+++ b/src/lib/debug/debug_bm_service.cpp
@@ -37,7 +37,7 @@ static bool reply_cb(bool ack, uint32_t msg_id, size_t service_strlen, const cha
                      size_t reply_len, uint8_t *reply_data) {
   printf("Msg id: %" PRIu32 "\n", msg_id);
   if (ack) {
-    printf("Service: %.*s\n", service_strlen, service);
+    printf("Service: %.*s\n", (int)service_strlen, service);
     printf("Reply: ");
     for (size_t i = 0; i < reply_len; i++) {
       printf("%02x ", reply_data[i]);
@@ -63,12 +63,12 @@ static bool sys_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
         printf("Failed to decode sys info reply\n");
         break;
       }
-      printf("Service: %.*s\n", service_strlen, service);
+      printf("Service: %.*s\n", (int)service_strlen, service);
       printf("Reply: \n");
       printf(" * Node id: %016" PRIx64 "\n", reply.node_id);
       printf(" * Git SHA: 0x%08" PRIx32 "\n", reply.git_sha);
       printf(" * Sys config CRC: 0x%08" PRIx32 "\n", reply.sys_config_crc);
-      printf(" * App name: %.*s\n", reply.app_name_strlen, reply.app_name);
+      printf(" * App name: %.*s\n", (int)reply.app_name_strlen, reply.app_name);
     } else {
       printf("NACK\n");
     }
@@ -91,7 +91,7 @@ static bool config_map_callback(bool ack, uint32_t msg_id, size_t service_strlen
         printf("Failed to decode sys info reply\n");
         break;
       }
-      printf("Service: %.*s\n", service_strlen, service);
+      printf("Service: %.*s\n", (int)service_strlen, service);
       printf("Reply: \n");
       printf(" * Node id: %016" PRIx64 "\n", reply.node_id);
       printf(" * Partition: %" PRIu32 "\n", reply.partition_id);

--- a/src/lib/drivers/nau7802.cpp
+++ b/src/lib/drivers/nau7802.cpp
@@ -24,21 +24,21 @@ bool NAU7802::begin() {
   bool rval = true;
   {
     rval &= reset(); // Reset all registers
-    printf("Post Reset rval: %u\n", rval);
+    printf("Post Reset rval: %d\n", rval);
     rval &= powerUp(); // Power on analog and digital sections of the scale
-    printf("Post Power Up rval: %u\n", rval);
+    printf("Post Power Up rval: %d\n", rval);
     rval &= setLDO(NAU7802_LDO_3V3); // Set LDO to 3.3V
-    printf("Post setLDO rval: %u\n", rval);
+    printf("Post setLDO rval: %d\n", rval);
     rval &= setGain(NAU7802_GAIN_128); // Set gain to 128
-    printf("post setGain rval: %u\n", rval);
+    printf("post setGain rval: %d\n", rval);
     rval &= setSampleRate(NAU7802_SPS_80); // Set samples per second to 10
-    printf("post setSampleRate rval: %u\n", rval);
+    printf("post setSampleRate rval: %d\n", rval);
     // Turn off CLK_CHP. From 9.1 power on sequencing.
     rval &= setRegister(NAU7802_ADC, 0x30);
-    printf("post setRegister rval: %u\n", rval);
+    printf("post setRegister rval: %d\n", rval);
     // Enable 330pF decoupling cap on chan 2. From 9.14 application circuit note.
     rval &= setBit(NAU7802_PGA_PWR_PGA_CAP_EN, NAU7802_PGA_PWR);
-    printf("post setBit rval: %u\n", rval);
+    printf("post setBit rval: %d\n", rval);
 
     // This call is disabled because it gives a really different result every time
     // (same every time on arduino). Risk of consequences but going ahead.

--- a/src/lib/sensor_sampler/loadCellSampler.cpp
+++ b/src/lib/sensor_sampler/loadCellSampler.cpp
@@ -64,7 +64,7 @@ static bool loadCellSample() {
   while ((!successful_lc_read) &&
          (((uptimeGetMicroSeconds() / 1000) - read_start_time) < read_attempt_duration)) {
     if (_loadCell->available()) {
-      printf("%llu | reading: %d\n", uptimeGetMicroSeconds() / 1000, reading);
+      printf("%llu | reading: %" PRId32 "\n", uptimeGetMicroSeconds() / 1000, reading);
       // printf("%llu | reading corrs: %d\n", uptimeGetMicroSeconds()/1000, reading-333900);
       _loadCell->getInternalOffsetCal();
 
@@ -82,7 +82,7 @@ static bool loadCellSample() {
                 uptimeGetMicroSeconds() / 1000, rtcTimeBuffer, weight);
       printf("%llu | weight: %f\n", uptimeGetMicroSeconds() / 1000, weight);
       printf("%llu | calFactor: %f\n", uptimeGetMicroSeconds() / 1000, calFactor);
-      printf("%llu | zeroOffset: %d\n", uptimeGetMicroSeconds() / 1000, zeroOffset);
+      printf("%llu | zeroOffset: %" PRId32 "\n", uptimeGetMicroSeconds() / 1000, zeroOffset);
       successful_lc_read = true;
     } else {
       vTaskDelay(pdMS_TO_TICKS(10));
@@ -139,7 +139,7 @@ static bool loadCellInit() {
       negative_factor = true;
   }
 
-  printf("loadCell init rval: %u\n", rval);
+  printf("loadCell init rval: %d\n", rval);
   return rval;
 
   // initial vals for force averaging.


### PR DESCRIPTION
## What changed?

I fixed compiler warnings regarding printf format specifiers. They became visible by removing `-Wno-format` from src/CMakeLists.txt. Thanks @campbellaos for the tip!

I added presets for the SDI-12 example app and the PME DO sensor app.

## How does it make Bristlemouth better?

This helps ensure that our printed strings contain the types and widths that we expect and helps us avoid memory corruption.

Going forward, these warnings that we were ignoring will be errors that fail the build.

## Where should reviewers focus?

If any of my format specifier changes look wrong or should be handled differently, let me know.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
