### PR TITLE
Add salinity config to PME DO

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/CMakeLists.txt
+++ b/src/apps/bristleback_apps/pme_do_sensor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../bristleback_apps_common/sensors/sensors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/pme_do_sensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/user_code/do_calc.c
 )
 
 set(APP_INCLUDES

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.c
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.c
@@ -1,0 +1,60 @@
+#include "do_calc.h"
+#include <math.h>
+
+static double saturatedWaterVaporPressure(double t, double s);
+static double coStar(double t, double s);
+static double pO2(double p);
+
+double doConcMg(double t, double p, double s) {
+  return (doConcUmol(t, p, s) * (2.0 * 15.9994) / 1000.0);
+}
+
+double doConcUmol(double t, double p, double s) {
+  double Ptotal = p / 101325.0; // convert Pa to atm
+  double pWSat = saturatedWaterVaporPressure(t, s);
+  double pO2measured = pO2(Ptotal - pWSat);
+  double pO2reference = pO2(1.0 - pWSat);
+  return coStar(t, s) * pO2measured / pO2reference;
+}
+
+double salinityFactor(double t, double s) {
+  if (s != 0.0) {
+    return doConcMg(t, 101325.0, s) / doConcMg(t, 101325.0, 0.0);
+  } else {
+    return 1.0;
+  }
+}
+
+static double saturatedWaterVaporPressure(double t, double s) {
+
+  double TK = t + 273.15;
+
+  return exp(24.4543 - 67.4509 * (100.0 / TK) - 4.8489 * log(TK / 100.0) - 0.000544 * s);
+}
+
+static double coStar(double t, double s) {
+  double A0 = 2.00907;
+  double A1 = 3.22014;
+  double A2 = 4.05010;
+  double A3 = 4.94457;
+  double A4 = -0.256847;
+  double A5 = 3.88767;
+  double B0 = -6.24523e-3;
+  double B1 = -7.37614e-3;
+  double B2 = -1.03410e-2;
+  double B3 = -8.17083e-3;
+  double C0 = -4.88682e-7;
+
+  /*---compute scaled temperature according to Eq. 8---*/
+  double Ts = log((298.15 - t) / (273.15 + t));
+
+  /*---compute Co* according to Eq. 8  (cm^3 O2 at STP / dm^3 water)---*/
+  double result = exp(A0 + A1 * Ts + A2 * pow(Ts, 2) + A3 * pow(Ts, 3) +
+                           A4 * pow(Ts, 4) + A5 * pow(Ts, 5) +
+                           s * (B0 + B1 * Ts + B2 * pow(Ts, 2) + B3 * pow(Ts, 3)) +
+                           C0 * pow(s, 2));
+
+  return result * (1000.0 / 22.3916); // umol/L
+}
+
+static double pO2(double p) { return 0.209446 * p; }

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.h
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double doConcMg(double t, double p, double s);
+double doConcUmol(double t, double p, double s);
+double salinityFactor(double t, double s);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -3,6 +3,7 @@
 #include "bm_os.h"
 #include "bm_printf.h"
 #include "configuration.h"
+#include "do_calc.h"
 #include "payload_uart.h"
 #include "serial.h"
 #include "spotter.h"
@@ -145,7 +146,7 @@ void PmeSensor::init() {
  * @param d Reference to a PmeDissolvedOxygenMsg::Data structure where the parsed data will be stored.
  * @return Returns true if data was successfully retrieved and parsed, false otherwise.
  */
-bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d) {
+bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt) {
   bool success = false;
 
   RTCTimeAndDate_t time_and_date = {};
@@ -185,13 +186,17 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d) {
           q_signal.type != TYPE_DOUBLE) {
         printf("!  Parsed invalid DOT data");
       } else {
+        d.header.version = PmeDissolvedOxygenMsg::VERSION;
         d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
         d.header.reading_uptime_millis = uptimeGetMs();
+        d.header.sensor_reading_time_ms = 0;
         d.temperature_deg_c = temp_signal.data.double_val;
-        d.do_mg_per_l = do_signal.data.double_val;
+        d.do_mg_per_l =
+            do_signal.data.double_val * salinityFactor(d.temperature_deg_c, salinityPpt);
         d.quality = q_signal.data.double_val;
-
-        // TODO: Use d.salinity_ppt to calculate d.do_salinity_corrected_mg_per_l
+        // TODO: update PmeDissolvedOxygenMsg::Data to include salinity
+        //       which requires updating bm_common_messages and bm_core submodules
+        // d.salinity_ppt = salinityPpt;
 
         // DO Sat% not available at this time; setting to NULL causes error (converting NULL to double)
         //d.do_saturation_pct = 0;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -194,9 +194,7 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt) {
         d.do_mg_per_l =
             do_signal.data.double_val * salinityFactor(d.temperature_deg_c, salinityPpt);
         d.quality = q_signal.data.double_val;
-        // TODO: update PmeDissolvedOxygenMsg::Data to include salinity
-        //       which requires updating bm_common_messages and bm_core submodules
-        // d.salinity_ppt = salinityPpt;
+        d.salinity_ppt = salinityPpt;
 
         // DO Sat% not available at this time; setting to NULL causes error (converting NULL to double)
         //d.do_saturation_pct = 0;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -198,7 +198,7 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt) {
                                 doConcMg(d.temperature_deg_c, _barometric_pressure_mbar, 0.0) *
                                 100.0;
         } else {
-          d.do_saturation_pct = 0.0;
+          d.do_saturation_pct = NAN;
         }
         d.salinity_ppt = salinityPpt;
         success = true;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -190,6 +190,9 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d) {
         d.temperature_deg_c = temp_signal.data.double_val;
         d.do_mg_per_l = do_signal.data.double_val;
         d.quality = q_signal.data.double_val;
+
+        // TODO: Use d.salinity_ppt to calculate d.do_salinity_corrected_mg_per_l
+
         // DO Sat% not available at this time; setting to NULL causes error (converting NULL to double)
         //d.do_saturation_pct = 0;
         success = true;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -18,15 +18,14 @@
 #include <cstring>
 
 #define LAST_WIPE_EPOCH_KEY "lastWipeEpochS"
-//#define DOT_INTERVAL_KEY "DOTinterval"
-//#define WIPE_INTERVAL_KEY "WipeInterval"
 
 extern uint32_t pmeLogEnable;
 extern uint32_t sensorDebugTxEnable;
 
 uint32_t lastWipeEpochS = 0;
-//uint32_t DOTinterval = 600;
-//uint32_t WipeInterval = 14400;
+
+static constexpr uint32_t BAUD_RATE = 9600;
+static constexpr char LINE_TERM = '\r';
 
 //Function to request a DO measurement from the microDOT sensor
 static constexpr char queryMDOT[] = "MDOT\r";
@@ -194,10 +193,14 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt) {
         d.do_mg_per_l =
             do_signal.data.double_val * salinityFactor(d.temperature_deg_c, salinityPpt);
         d.quality = q_signal.data.double_val;
+        if (_is_baro_valid) {
+          d.do_saturation_pct = do_signal.data.double_val /
+                                doConcMg(d.temperature_deg_c, _barometric_pressure_mbar, 0.0) *
+                                100.0;
+        } else {
+          d.do_saturation_pct = 0.0;
+        }
         d.salinity_ppt = salinityPpt;
-
-        // DO Sat% not available at this time; setting to NULL causes error (converting NULL to double)
-        //d.do_saturation_pct = 0;
         success = true;
       }
     } else {
@@ -304,3 +307,8 @@ bool PmeSensor::getWipeData(PmeWipeMsg::Data &w) {
  * @brief Flushes the data from the sensor driver.
  */
 void PmeSensor::flush(void) { PLUART::reset(); }
+
+void PmeSensor::setBarometricPressure(double pressure) {
+  _barometric_pressure_mbar = pressure;
+  _is_baro_valid = true;
+}

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
@@ -14,7 +14,7 @@ public:
       : _DOTparser(",", 256, DOT_PARSER_VALUE_TYPE, 5),
         _WIPEparser(",", 256, WIPE_PARSER_VALUE_TYPE, 6) {};
   void init();
-  bool getDoData(PmeDissolvedOxygenMsg::Data &d);
+  bool getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt);
   bool getWipeData(PmeWipeMsg::Data &w);
   bool getSN(PmeDissolvedOxygenMsg::Data &s);
   void flush();

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
@@ -5,36 +5,35 @@
 #include <stdint.h>
 
 void saveLastWipeEpoch(uint32_t epochTimeSec);
-uint32_t loadLastWipeEpoch();
-void ledAllOff();
+uint32_t loadLastWipeEpoch(void);
+void ledAllOff(void);
 
 class PmeSensor {
 public:
-  PmeSensor()
+  PmeSensor(void)
       : _DOTparser(",", 256, DOT_PARSER_VALUE_TYPE, 5),
         _WIPEparser(",", 256, WIPE_PARSER_VALUE_TYPE, 6) {};
-  void init();
+  void init(void);
   bool getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt);
   bool getWipeData(PmeWipeMsg::Data &w);
   bool getSN(PmeDissolvedOxygenMsg::Data &s);
-  void flush();
+  void flush(void);
+  void setBarometricPressure(double pressure);
 
-public:
   static constexpr char PME_DO_RAW_LOG[] = "pme_do_raw.log";
   static constexpr char PME_WIPE_RAW_LOG[] = "pme_wipe_raw.log";
 
 private:
-  static constexpr uint32_t BAUD_RATE = 9600;
-  static constexpr char LINE_TERM = '\r';
   static constexpr ValueType DOT_PARSER_VALUE_TYPE[] = {TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,
                                                         TYPE_DOUBLE, TYPE_DOUBLE};
   static constexpr ValueType WIPE_PARSER_VALUE_TYPE[] = {TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,
                                                          TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE};
 
-private:
   OrderedSeparatorLineParser _DOTparser;
   OrderedSeparatorLineParser _WIPEparser;
   char _DOTpayload_buffer[2048];
   char _WIPEpayload_buffer[2048];
   char _SNpayload_buffer[2048];
+  bool _is_baro_valid = false;
+  double _barometric_pressure_mbar = 1013.25;
 };

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -4,6 +4,7 @@
 #include "app_pub_sub.h"
 #include "array_utils.h"
 #include "avgSampler.h"
+#include "barometric_pressure_data_msg.h"
 #include "bm_os.h"
 #include "bm_printf.h"
 #include "bsp.h"
@@ -49,6 +50,7 @@ uint32_t pmeWipeIntervalS = 14400;
 bool pmeWipeIntervalSCfg = false;
 uint32_t sensorDebugTxEnable = 0;
 bool sensorDebugTxEnableCfg = false;
+float salinityPpt = 35.0;
 
 static PmeSensor pmeSensor;
 
@@ -66,6 +68,7 @@ static constexpr char SENSOR_BM_LOG_ENABLE[] = "pmeLogEnable";
 static constexpr char SENSOR_BM_DOT_INTERVAL_S[] = "pmeDOTIntervalS";
 static constexpr char SENSOR_BM_WIPE_INTERVAL_S[] = "pmeWipeIntervalS";
 static constexpr char SENSOR_DEBUG_TX_ENABLE[] = "sensorDebugTxEnable";
+static constexpr char SALINITY_PPT[] = "salinityPpt";
 
 // Variables for measurements and timing
 static uint32_t lastWipeEpochS = 0;
@@ -84,6 +87,24 @@ static int createPmeWipeDataTopic(void) { // Wipe
                              "sensor/%016" PRIx64 "/pme/wipe_data", getNodeId());
   configASSERT(topicStrLen > 0 && topicStrLen < BM_TOPIC_MAX_LEN);
   return topicStrLen;
+}
+
+static void handle_barometric_pressure(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                       const uint8_t *data, uint16_t data_len, uint8_t type,
+                                       uint8_t version) {
+  (void)node_id;
+  (void)topic;
+  (void)topic_len;
+  (void)type;
+  (void)version;
+
+  BarometricPressureDataMsg::Data d;
+  CborError err = BarometricPressureDataMsg::decode(d, data, data_len);
+  if (err == CborNoError) {
+    // TODO: Use d.barometric_pressure_mbar to calculate DO saturation
+  } else {
+    printf("Failed to decode barometric pressure data message. err=%u\n", err);
+  }
 }
 
 void debugTx(void) {}
@@ -106,6 +127,13 @@ void setup(void) {
                       strlen(SENSOR_DEBUG_TX_ENABLE), &sensorDebugTxEnable)) {
     sensorDebugTxEnableCfg = true;
   }
+  get_config_float(BM_CFG_PARTITION_SYSTEM, SALINITY_PPT, strlen(SALINITY_PPT), &salinityPpt);
+  printf("Salinity PPT: %f\n", salinityPpt);
+
+  // Subscribe to barometric pressure
+  bm_sub("sensor/*/barometric_pressure", handle_barometric_pressure);
+  // Possibly longer term, subscribe to salinity
+  // bm_sub("sensor/*/salinity", handle_salinity);
 
   pmeSensor.init();
   pmeDoTopicStrLen = createPmeDoMeasurementDataTopic();
@@ -202,6 +230,10 @@ void loop(void) {
     if (firstDo) {
       firstDo = false; //Turn off initial DO flag
     }
+
+    // TODO: update PmeDissolvedOxygenMsg::Data to include salinity
+    // Longer term, salinity could be updated from a subscribed conductivity/salinity sensor
+    // d.salinity_ppt = salinityPpt;
 
     if (pmeSensor.getDoData(d)) {
       static uint8_t cborBuf[pmeSensorDataMsgMaxSize];

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -39,7 +39,6 @@
 - Comment code
 - Remove or comment out debugging printf's
 - Follow as bm_pub_wl is developed
-- Pull barometric pressure from spotter to use for DOsat% calc
 */
 
 uint32_t pmeLogEnable = 1;
@@ -102,7 +101,7 @@ static void handle_barometric_pressure(uint64_t node_id, const char *topic, uint
   BarometricPressureDataMsg::Data d;
   CborError err = BarometricPressureDataMsg::decode(d, data, data_len);
   if (err == CborNoError) {
-    // TODO: Use d.barometric_pressure_mbar to calculate DO saturation
+    pmeSensor.setBarometricPressure(d.barometric_pressure_mbar);
   } else {
     printf("Failed to decode barometric pressure data message. err=%d\n", err);
   }
@@ -232,10 +231,6 @@ void loop(void) {
       firstDo = false; //Turn off initial DO flag
     }
 
-    // TODO: update PmeDissolvedOxygenMsg::Data to include salinity
-    // Longer term, salinity could be updated from a subscribed conductivity/salinity sensor
-    // d.salinity_ppt = salinityPpt;
-
     if (pmeSensor.getDoData(d, salinityPpt)) {
       static uint8_t cborBuf[pmeSensorDataMsgMaxSize];
       size_t encodedLen = 0;
@@ -246,7 +241,7 @@ void loop(void) {
                pmeDoTopic, cborBuf[0], cborBuf[1], cborBuf[2]);
         bm_pub_wl(pmeDoTopic, pmeDoTopicStrLen, cborBuf, encodedLen, 0,
                   BM_COMMON_PUB_SUB_VERSION);
-        if (true) {
+        if (false) {
           debugTx();
         }
       } else {

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -50,7 +50,8 @@ uint32_t pmeWipeIntervalS = 14400;
 bool pmeWipeIntervalSCfg = false;
 uint32_t sensorDebugTxEnable = 0;
 bool sensorDebugTxEnableCfg = false;
-float salinityPpt = 35.0;
+
+static float salinityPpt = 35.0;
 
 static PmeSensor pmeSensor;
 
@@ -103,7 +104,7 @@ static void handle_barometric_pressure(uint64_t node_id, const char *topic, uint
   if (err == CborNoError) {
     // TODO: Use d.barometric_pressure_mbar to calculate DO saturation
   } else {
-    printf("Failed to decode barometric pressure data message. err=%u\n", err);
+    printf("Failed to decode barometric pressure data message. err=%d\n", err);
   }
 }
 
@@ -235,7 +236,7 @@ void loop(void) {
     // Longer term, salinity could be updated from a subscribed conductivity/salinity sensor
     // d.salinity_ppt = salinityPpt;
 
-    if (pmeSensor.getDoData(d)) {
+    if (pmeSensor.getDoData(d, salinityPpt)) {
       static uint8_t cborBuf[pmeSensorDataMsgMaxSize];
       size_t encodedLen = 0;
       if (PmeDissolvedOxygenMsg::encode(d, cborBuf, sizeof(cborBuf), &encodedLen) ==


### PR DESCRIPTION
## What changed?

Added a salinity config to the PME DO application.

Code contributions look like they come from @towynlin but this was all in a lot of live coding collaboration with @b-haist and Peter at PME.

## How does it make Bristlemouth better?

This will allow customers of the PME DO sensor to correct their dissolved oxygen values with a reasonable default salinity for the deployment site. In the future, when there's a Bristlemouth salinity sensor, this app will be able to subscribe to the live feed of salinity values!

## Where should reviewers focus?

Not much review needed. PME will test the salinity math against other known good software. Perhaps reviewers could share thoughts on how we're managing the config value and cbor encoder.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
