### PR TITLE
External bm_protocol Debug Support

### DIFF
--- a/tools/scripts/debug/debug.py
+++ b/tools/scripts/debug/debug.py
@@ -15,7 +15,7 @@ import time
 
 def get_project_root():
     git_repo = git.Repo(os.path.abspath(__file__), search_parent_directories=True)
-    return os.path.realpath(git_repo.git.rev_parst("--show-toplevel"))
+    return os.path.realpath(git_repo.git.rev_parse("--show-toplevel"))
 
 
 # Don't close python script with Ctrl+C since GDB uses it

--- a/tools/scripts/debug/debug.py
+++ b/tools/scripts/debug/debug.py
@@ -14,13 +14,14 @@ import time
 
 
 def get_project_root():
-    git_repo = git.Repo(search_parent_directories=True)
-    return os.path.realpath(git_repo.git.rev_parse("--show-toplevel"))
+    git_repo = git.Repo(os.path.abspath(__file__), search_parent_directories=True)
+    return os.path.realpath(git_repo.git.rev_parst("--show-toplevel"))
 
 
 # Don't close python script with Ctrl+C since GDB uses it
 def sig_handler(signum, frame):
     pass
+
 
 # Try ports in range until one is open
 # Used in case we launch multiple openocd/gdb instances at once
@@ -107,7 +108,7 @@ def run_openocd(args, port=3333):
             # Comment out the following two lines to print openocd output to console
             # stdout=subprocess.DEVNULL,
             # stderr=subprocess.STDOUT,
-            startupinfo=startupinfo
+            startupinfo=startupinfo,
         )
     elif os.name == "posix":
         # https://stackoverflow.com/questions/5045771/python-how-to-prevent-subprocesses-from-receiving-ctrl-c-control-c-sigint


### PR DESCRIPTION
## What changed?
Allows Debugging To Occur From An External Project (Outside Of bm_protocol)


## How does it make Bristlemouth better?
Allows applications built outside of `bm_protocol` to be debugged.


## Where should reviewers focus?
Rubber stamp, try it on an external project!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
