### PR TITLE
add salinity to the bridge DO code

### DIFF
--- a/src/apps/bridge/reportBuilder.cpp
+++ b/src/apps/bridge/reportBuilder.cpp
@@ -389,6 +389,13 @@ static bool addSamplesToReport(sensor_report_encoder_context_t &context, uint8_t
                      "Failed to add pme_do sample member in addSamplesToReport\n");
       break;
     }
+    if (sensor_report_encoder_add_sample_member(context, encode_double_sample_member,
+                                                &pme_do_sample.salinity_ppt_mean) !=
+        CborNoError) {
+      bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_ERROR, USE_HEADER,
+                     "Failed to add pme_do sample member in addSamplesToReport\n");
+      break;
+    }
     if (sensor_report_encoder_close_sample(context) != CborNoError) {
       bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_ERROR, USE_HEADER,
                      "Failed to close sample in addSamplesToReport\n");

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
@@ -68,7 +68,7 @@ void PmeDissolvedOxygenSensor::pmeDissolvedOxygenSubCallback(
             "%.3f,"   // do_mg_per_l
             "%.3f,"   // quality
             "%.1f,"   // do_saturation_pct
-            "%.2f\n", // salinity_ppt
+            "%.1f\n", // salinity_ppt
             dissolved_oxygen_data.temperature_deg_c, dissolved_oxygen_data.do_mg_per_l,
             dissolved_oxygen_data.quality, dissolved_oxygen_data.do_saturation_pct,
             dissolved_oxygen_data.salinity_ppt);
@@ -132,7 +132,7 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
         "%.3f,"   // do_mg_per_l
         "%.3f,"   // quality
         "%.1f"    // do_saturation_pct
-        "%.2f\n", // salinity_ppt_mean
+        "%.1f\n", // salinity_ppt_mean
         dissolved_oxygen_aggs.temperature_deg_c_mean, dissolved_oxygen_aggs.do_mg_per_l_mean,
         dissolved_oxygen_aggs.quality_mean, dissolved_oxygen_aggs.do_saturation_pct_mean,
         dissolved_oxygen_aggs.salinity_ppt_mean);

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
@@ -130,7 +130,7 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
         "%.4f,"   // temperature_deg_c
         "%.3f,"   // do_mg_per_l
         "%.3f,"   // quality
-        "%.1f"    // do_saturation_pct
+        "%.1f,"    // do_saturation_pct
         "%.1f\n", // salinity_ppt_mean
         dissolved_oxygen_aggs.temperature_deg_c_mean, dissolved_oxygen_aggs.do_mg_per_l_mean,
         dissolved_oxygen_aggs.quality_mean, dissolved_oxygen_aggs.do_saturation_pct_mean,

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
@@ -3,7 +3,6 @@
 #include "app_config.h"
 #include "avgSampler.h"
 #include "bm_config.h"
-#include "sensorController.h"
 #include "bm_os.h"
 #include "bridgeLog.h"
 #include "cbor.h"
@@ -13,6 +12,7 @@
 #include "pubsub.h"
 #include "reportBuilder.h"
 #include "semphr.h"
+#include "sensorController.h"
 #include "spotter.h"
 #include "stm32_rtc.h"
 #include "topology_sampler.h"
@@ -57,8 +57,7 @@ void PmeDissolvedOxygenSensor::pmeDissolvedOxygenSubCallback(
         dissolved_oxygen_sensor->quality.addSample(dissolved_oxygen_data.quality);
         dissolved_oxygen_sensor->do_saturation_pct.addSample(
             dissolved_oxygen_data.do_saturation_pct);
-        dissolved_oxygen_sensor->salinity_ppt.addSample(
-            dissolved_oxygen_data.salinity_ppt);
+        dissolved_oxygen_sensor->salinity_ppt.addSample(dissolved_oxygen_data.salinity_ppt);
         dissolved_oxygen_sensor->reading_count++;
 
         BmErr err = dissolved_oxygen_sensor->send_spotter_log_individual(

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.cpp
@@ -57,6 +57,8 @@ void PmeDissolvedOxygenSensor::pmeDissolvedOxygenSubCallback(
         dissolved_oxygen_sensor->quality.addSample(dissolved_oxygen_data.quality);
         dissolved_oxygen_sensor->do_saturation_pct.addSample(
             dissolved_oxygen_data.do_saturation_pct);
+        dissolved_oxygen_sensor->salinity_ppt.addSample(
+            dissolved_oxygen_data.salinity_ppt);
         dissolved_oxygen_sensor->reading_count++;
 
         BmErr err = dissolved_oxygen_sensor->send_spotter_log_individual(
@@ -65,9 +67,11 @@ void PmeDissolvedOxygenSensor::pmeDissolvedOxygenSubCallback(
             "%.4f,"   // temperature_deg_c
             "%.3f,"   // do_mg_per_l
             "%.3f,"   // quality
-            "%.1f\n", // do_saturation_pct
+            "%.1f,"   // do_saturation_pct
+            "%.2f\n", // salinity_ppt
             dissolved_oxygen_data.temperature_deg_c, dissolved_oxygen_data.do_mg_per_l,
-            dissolved_oxygen_data.quality, dissolved_oxygen_data.do_saturation_pct);
+            dissolved_oxygen_data.quality, dissolved_oxygen_data.do_saturation_pct,
+            dissolved_oxygen_data.salinity_ppt);
         if (err != BmOK) {
           bm_debug("ERROR: Failed to print PME Dissolved Oxygen data to IND log, err: %d\n",
                    err);
@@ -89,6 +93,7 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
                                                                  .do_mg_per_l_mean = NAN,
                                                                  .quality_mean = NAN,
                                                                  .do_saturation_pct_mean = NAN,
+                                                                 .salinity_ppt_mean = NAN,
                                                                  .reading_count = 0};
 
     if (temperature_deg_c.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
@@ -96,6 +101,7 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
       dissolved_oxygen_aggs.do_mg_per_l_mean = do_mg_per_l.getMean();
       dissolved_oxygen_aggs.quality_mean = quality.getMean();
       dissolved_oxygen_aggs.do_saturation_pct_mean = do_saturation_pct.getMean();
+      dissolved_oxygen_aggs.salinity_ppt_mean = salinity_ppt.getMean();
       dissolved_oxygen_aggs.reading_count = reading_count;
 
       if (dissolved_oxygen_aggs.temperature_deg_c_mean < TEMP_SAMPLE_MEMBER_MIN ||
@@ -114,6 +120,10 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
           dissolved_oxygen_aggs.do_saturation_pct_mean > DO_SATURATION_SAMPLE_MEMBER_MAX) {
         dissolved_oxygen_aggs.do_saturation_pct_mean = NAN;
       }
+      if (dissolved_oxygen_aggs.salinity_ppt_mean < SALINITY_PPT_MEMBER_MIN ||
+          dissolved_oxygen_aggs.salinity_ppt_mean > SALINITY_PPT_MEMBER_MAX) {
+        dissolved_oxygen_aggs.salinity_ppt_mean = NAN;
+      }
     }
 
     BmErr err = send_spotter_log_aggregate(
@@ -121,9 +131,11 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
         "%.4f,"   // temperature_deg_c
         "%.3f,"   // do_mg_per_l
         "%.3f,"   // quality
-        "%.1f\n", // do_saturation_pct
+        "%.1f"    // do_saturation_pct
+        "%.2f\n", // salinity_ppt_mean
         dissolved_oxygen_aggs.temperature_deg_c_mean, dissolved_oxygen_aggs.do_mg_per_l_mean,
-        dissolved_oxygen_aggs.quality_mean, dissolved_oxygen_aggs.do_saturation_pct_mean);
+        dissolved_oxygen_aggs.quality_mean, dissolved_oxygen_aggs.do_saturation_pct_mean,
+        dissolved_oxygen_aggs.salinity_ppt_mean);
     if (err != BmOK) {
       bm_debug("ERROR: Failed to print PME Dissolved Oxygen data to AGG log, err: %d\n", err);
     }
@@ -138,6 +150,7 @@ void PmeDissolvedOxygenSensor::aggregate(void) {
     do_mg_per_l.clear();
     quality.clear();
     do_saturation_pct.clear();
+    salinity_ppt.clear();
     reading_count = 0;
     bm_semaphore_give(_mutex);
   } else {
@@ -232,6 +245,7 @@ PmeDissolvedOxygen_t *createPmeDissolvedOxygenSub(uint64_t node_id, uint32_t sam
       new_sub->do_mg_per_l.initBuffer(averager_max_samples);
       new_sub->quality.initBuffer(averager_max_samples);
       new_sub->do_saturation_pct.initBuffer(averager_max_samples);
+      new_sub->salinity_ppt.initBuffer(averager_max_samples);
       new_sub->reading_count = 0;
 
       CURRENT_SUB = new_sub;

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define PME_DISSOLVED_OXYGEN_NUM_SAMPLE_MEMBERS 4
+#define PME_DISSOLVED_OXYGEN_NUM_SAMPLE_MEMBERS 5
 
 typedef struct pme_dissolved_oxygen_aggregations_s {
   double temperature_deg_c_mean;

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
@@ -40,9 +40,8 @@ typedef struct PmeDissolvedOxygenSensor : public AbstractSensor {
   static constexpr double QUALITY_SAMPLE_MEMBER_MAX = 1.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MIN = 0.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MAX = 150.0;
-  // TODO - confirm these
   static constexpr double SALINITY_PPT_MEMBER_MIN = 0.0;
-  static constexpr double SALINITY_PPT_MEMBER_MAX = 10000.0;
+  static constexpr double SALINITY_PPT_MEMBER_MAX = 500.0;
 
 
 public:

--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
@@ -14,6 +14,7 @@ typedef struct pme_dissolved_oxygen_aggregations_s {
   double do_mg_per_l_mean;
   double quality_mean;
   double do_saturation_pct_mean;
+  double salinity_ppt_mean;
   uint32_t reading_count;
 } pme_dissolved_oxygen_aggregations_t;
 
@@ -22,6 +23,7 @@ typedef struct PmeDissolvedOxygenSensor : public AbstractSensor {
   AveragingSampler do_mg_per_l;
   AveragingSampler quality;
   AveragingSampler do_saturation_pct;
+  AveragingSampler salinity_ppt;
   uint32_t reading_count;
   int8_t node_position;
   uint32_t last_timestamp;
@@ -38,6 +40,10 @@ typedef struct PmeDissolvedOxygenSensor : public AbstractSensor {
   static constexpr double QUALITY_SAMPLE_MEMBER_MAX = 1.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MIN = 0.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MAX = 150.0;
+  // TODO - confirm these
+  static constexpr double SALINITY_PPT_MEMBER_MIN = 0.0;
+  static constexpr double SALINITY_PPT_MEMBER_MAX = 10000.0;
+
 
 public:
   bool subscribe() override;
@@ -47,6 +53,7 @@ public:
       .do_mg_per_l_mean = NAN,
       .quality_mean = NAN,
       .do_saturation_pct_mean = NAN,
+      .salinity_ppt_mean = NAN,
       .reading_count = 0,
   };
 

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -166,7 +166,8 @@ void setup(void) {
     printf("No user-defined sensorDebugTxEnable - defaulting to: %" PRIu32 "\n",
            sensorDebugTxEnable);
   }
-
+  IOWrite(&BB_PL_BUCK_EN, 1);
+  IOWrite(&BB_VBUS_EN, 1);
   ledAllOff();
   //Set first DO measurement flag to true to trigger startup DO measurement
   firstDo = true;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -167,9 +167,6 @@ void setup(void) {
            sensorDebugTxEnable);
   }
 
-  // Ensure Vbus stable before enabling Vout
-  IOWrite(&BB_VBUS_EN, 0);
-  bm_delay(50);
   ledAllOff();
   //Set first DO measurement flag to true to trigger startup DO measurement
   firstDo = true;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -166,6 +166,8 @@ void setup(void) {
     printf("No user-defined sensorDebugTxEnable - defaulting to: %" PRIu32 "\n",
            sensorDebugTxEnable);
   }
+
+  // VBUS and 9V are not used in microDOT so we can turn these both off (they are active when LOW)
   IOWrite(&BB_PL_BUCK_EN, 1);
   IOWrite(&BB_VBUS_EN, 1);
   ledAllOff();

--- a/src/lib/sensor_sampler/sensorSampler.cpp
+++ b/src/lib/sensor_sampler/sensorSampler.cpp
@@ -53,7 +53,6 @@ static void sensorTimerCallback(TimerHandle_t timer);
   be re-enabled.
 */
 void checkSensors() {
-  // logPrint(SYSLog, LOG_LEVEL_DEBUG, "Running sensor checks.\n");
   printf("%llu | Running sensor checks.\n", uptimeGetMicroSeconds()/1000);
 
   // Check all sensors to see if they are due for a sample update
@@ -67,12 +66,10 @@ void checkSensors() {
         // and start again
         if (!xTimerIsTimerActive(sensorItem->timer) && sensorItem->sensor->initFn()) {
           xTimerStart(sensorItem->timer, 10);
-          // logPrint(SYSLog, LOG_LEVEL_INFO, "%s Re-enabled\n", sensorItem->name);
           printf("%llu | %s Re-enabled\n", uptimeGetMicroSeconds()/1000, sensorItem->name);
         }
       } else if (xTimerIsTimerActive(sensorItem->timer)) {
         xTimerStop(sensorItem->timer, 10);
-        // logPrint(SYSLog, LOG_LEVEL_ERROR, "%s Check Failed - Disabling\n", sensorItem->name);
         printf("%llu | %s Check Failed - Disabling\n", uptimeGetMicroSeconds()/1000, sensorItem->name);
       }
       // Otherwise, try to re-init if not initted
@@ -91,7 +88,6 @@ void checkSensors() {
         // Start sample timer
         configASSERT(xTimerStart(sensorItem->timer, 10));
       } else {
-        // logPrint(SYSLog, LOG_LEVEL_INFO, "Error initializing %s\n", name);
         printf("%llu | Error initializing %s\n", uptimeGetMicroSeconds() / 1000, sensorItem->name);
       }
     }
@@ -308,7 +304,6 @@ static void sensorSampleTask( void *parameters ) {
     configASSERT(sensorCheckTimer != NULL);
     xTimerStart(sensorCheckTimer, 10);
   } else {
-    // logPrint(SYSLog, LOG_LEVEL_INFO, "Sensor Checks Disabled\n");
     printf("Sensor Checks Disabled\n");
   }
 
@@ -317,7 +312,6 @@ static void sensorSampleTask( void *parameters ) {
     BaseType_t res = xTaskNotifyWait(pdFALSE, UINT32_MAX, &taskNotifyValue, portMAX_DELAY);
     if(res != pdTRUE) {
       // Error
-      // logPrint(SYSLog, LOG_LEVEL_ERROR, "Error waiting for sensor task notification\n");
       printf("Error waiting for sensor task notification\n");
       continue;
     }


### PR DESCRIPTION
## What changed?
### Change 1
Adding salinity to the bridge code that processes and forwards the microDOT data to Spotter.
This is what a new SENS_IND.csv log line will look like for a microDOT with the addition of salinity at the end:
```
091f7f891a11396f,1,pme_do_sensor,22715,1749233315.316,0.000,21.1660,7.414,0.853,nan,35.0
```
This is what a new SENS_AGG.csv log line will look like for a microDOT with the addition of salinity at the end:
```
091f7f891a11396f,1,pme_do_sensor,1749241920.984,1,22.1350,7.313,0.853,nan,35.0
```

Here we can see the reportBuilder successfully building the report and sending it to Spotter:
<img width="778" alt="Screenshot 2025-06-06 at 1 47 32 PM" src="https://github.com/user-attachments/assets/5e1defe4-cb80-42f6-891b-53d536c29c48" />



### Change 2
Turning off VBUS on the PME DO app since it is not used by the microDOT.
Here is what the logs look like now that we don't turn it on. We can see the addr 67 lines now do not show 24V anymore.
<img width="560" alt="Screenshot 2025-06-06 at 11 03 47 AM" src="https://github.com/user-attachments/assets/ab47909a-fa50-43e1-8337-d16292f96e0f" />


## How does it make Bristlemouth better?
This adds salinity to the microDOT data, allowing for back calculation to the original DO measurements.

This also turns off the unused VBUS load switch, saving a bit of leakage current.


## Where should reviewers focus?
Small changes so everything (except the file where I removed commented out code).


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
