### PR TITLE
Update Port Monitor String Formatting Bug

### DIFF
--- a/src/lib/common/port_monitor.c
+++ b/src/lib/common/port_monitor.c
@@ -48,8 +48,8 @@ static void port_monitor_timer_handler(BmTimer timer) {
       if (port_num != 1) {
         const char *fmt_disable_str =
             "Disabling network port %d on node: %" PRIx64 ", it never came online\n";
-        spotter_log(0, port_monitor_log, USE_TIMESTAMP, fmt_disable_str, port_num);
-        spotter_log_console(0, fmt_disable_str, node_id(), port_num);
+        spotter_log(0, port_monitor_log, USE_TIMESTAMP, fmt_disable_str, port_num, node_id());
+        spotter_log_console(0, fmt_disable_str, port_num, node_id());
         bm_l2_netif_enable_disable_port(port_num, false);
       } else {
         // Port 1 cannot be solely disabled, it will also disable port 2 please
@@ -57,8 +57,8 @@ static void port_monitor_timer_handler(BmTimer timer) {
         // https://www.analog.com/media/en/technical-documentation/data-sheets/adin2111.pdf
         const char *fmt_err_str = "Could not disable network port %d on node: %" PRIx64
                                   ", unable to disable due to hardware restrictions\n";
-        spotter_log(0, port_monitor_log, USE_TIMESTAMP, fmt_err_str, node_id(), port_num);
-        spotter_log_console(0, fmt_err_str, port_num);
+        spotter_log(0, port_monitor_log, USE_TIMESTAMP, fmt_err_str, port_num, node_id());
+        spotter_log_console(0, fmt_err_str, port_num, node_id());
       }
     }
   }


### PR DESCRIPTION
## What changed?
Fixed formatting bug in port_monitor.c Spotter logging


## How does it make Bristlemouth better?
Prevents undefined behavior when formatting a string to send to Spotter.
Provides clarity on Spotter logs of what Node ID has disabled what port.


## Where should reviewers focus?
Rubber stamp and another set of eyes.
![image](https://github.com/user-attachments/assets/16e58d57-6023-4f1d-b142-af01cfe22d05)
![image](https://github.com/user-attachments/assets/3efb24c3-391b-4ca4-bcbe-60a170b56844)

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
