### PR TITLE
fix: print overflow because topic not null terminated

### DIFF
--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -120,7 +120,7 @@ static bm_serial_callbacks_t bm_serial_callbacks;
 static void ncp_uart_pub_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
                             const uint8_t *data, uint16_t data_len, uint8_t type,
                             uint8_t version) {
-  printf("Publishing To Topic: %s\n", topic);
+  printf("Publishing To Topic: %.*s\n", topic_len, topic);
   bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version);
 }
 


### PR DESCRIPTION
## What changed?

Small bug fix. When printing a published topic on the bridge, the `%s` format specifier was printing garbage data at the end because the topic is not null terminated. I changed it to `%.*s` and passed the topic length.

Before:
![Screenshot 2025-06-06 at 5 13 58 PM](https://github.com/user-attachments/assets/e07ec121-b6b9-4ba4-a332-4be4d8e6d575)


After:
![Screenshot 2025-06-06 at 5 13 36 PM](https://github.com/user-attachments/assets/c4ede18c-2d6f-43b6-9f5a-d60117a7bbf4)



## How does it make Bristlemouth better?

Avoid overflows FTW.

## Where should reviewers focus?

It's a tiny change.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
