### PR TITLE
feat: spectral entropy

### DIFF
--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -21,12 +21,14 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/reportBuilderList.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/network_config_logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/topology_sampler.cpp
+    ${SRC_DIR}/lib/dsp/spectral_entropy.c
 )
 
 set(APP_INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/sensor_drivers
     ${CMAKE_CURRENT_SOURCE_DIR}/sensors
+    ${SRC_DIR}/lib/dsp
 )
 
 set(APP_LIBS

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -190,9 +190,6 @@ void BorealisSensor::aggregate(void) {
       }
     }
 
-    // TODO: calculate entropy
-    report.entropy = REPORT_NAN_ERROR_VALUE;
-
     // Add hydrotwin LDR
     if (tracking_data.ldr.size) {
       report.hydrotwin_ldr.buf = static_cast<uint8_t *>(bm_malloc(tracking_data.ldr.size));

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -114,6 +114,7 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
     spl = REPORT_NAN_ERROR_VALUE;
     max_iqr_band = REPORT_NAN_ERROR_VALUE;
     entropy = REPORT_NAN_ERROR_VALUE;
+    clear_spectral_entropy_list();
     return BmEINVAL;
   }
 

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -702,31 +702,3 @@ void BorealisSensor::parse_levels(float *spl_db, const char *levels_as_base64,
     spl_db[i] = unpack_12bit(raw_bytes, i * 3) * cstep + clow;
   }
 }
-
-void BorealisSensor::parse_level_statistics(float *stats_db, const char *stats_as_base64,
-                                            size_t b64_length) {
-  size_t out_len = 0;
-  mbedtls_base64_decode(NULL, 0, &out_len, reinterpret_cast<const uint8_t *>(stats_as_base64),
-                        b64_length);
-  uint8_t raw_bytes[out_len];
-  int err =
-      mbedtls_base64_decode(raw_bytes, sizeof(raw_bytes), &out_len,
-                            reinterpret_cast<const uint8_t *>(stats_as_base64), b64_length);
-  if (err != 0) {
-    bm_debug("Failed to decode base64 level stats. err=%d, len=%zu, b64=%.*s\n", err,
-             b64_length, (int)b64_length, stats_as_base64);
-    return;
-  }
-
-  constexpr float cstep = 0.75f;                     // dB
-  constexpr float clow = -256.0f * cstep + 185.642f; // dB
-  constexpr uint8_t num_stats = 4;                   // 25%, 50%, 75%, mean
-  uint32_t num_bands = out_len / num_stats;
-  for (size_t i = 0; i < num_bands; i++) {
-    size_t index = i * num_stats;
-    stats_db[index + 0] = raw_bytes[index + 0] * cstep + clow; // 25%
-    stats_db[index + 1] = raw_bytes[index + 1] * cstep + clow; // 50%
-    stats_db[index + 2] = raw_bytes[index + 2] * cstep + clow; // 75%
-    stats_db[index + 3] = raw_bytes[index + 3] * cstep + clow; // mean
-  }
-}

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -7,11 +7,12 @@ extern "C" {
 #include "borealisSensor.h"
 #include "bridgeLog.h"
 #include "bristlemouth.h"
+#include "ll.h"
 #include "mbedtls_base64/base64.h"
 #include "messages/config.h"
-
 #include "pubsub.h"
 #include "sensorController.h"
+#include "spectral_entropy.h"
 #include <inttypes.h>
 #include <math.h>
 #include <new>
@@ -106,22 +107,24 @@ bool BorealisSensor::subscribe() {
   return ret;
 }
 
-BmErr BorealisSensor::calculateQuantizedSpl(uint8_t const *const band_stats,
-                                            const size_t band_stats_len, uint8_t &spl,
-                                            uint8_t &max_iqr_band) {
+BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_stats,
+                                                      const size_t band_stats_len, uint8_t &spl,
+                                                      uint8_t &max_iqr_band, uint8_t &entropy) {
   if (band_stats == NULL || band_stats_len == 0) {
     spl = REPORT_NAN_ERROR_VALUE;
     max_iqr_band = REPORT_NAN_ERROR_VALUE;
+    entropy = REPORT_NAN_ERROR_VALUE;
     return BmEINVAL;
   }
 
-  const float db_step = 0.75f;
-  const float db_min = -256.0f * db_step;
-  const unsigned int num_stats = 4; // 25%, 50%, 75%, mean
+  constexpr float db_step = 0.75f;
+  constexpr float db_min = -256.0f * db_step;
+  constexpr unsigned int num_stats = 4; // 25%, 50%, 75%, mean
   const unsigned int num_bands = band_stats_len / num_stats;
 
   uint8_t max_iqr_so_far = 0;
   float spl_linear_sum = 0.0f;
+  float means[num_bands] = {0.0f};
   for (size_t band_index = 0; band_index < num_bands; band_index++) {
     size_t offset = band_index * num_stats;
 
@@ -135,12 +138,15 @@ BmErr BorealisSensor::calculateQuantizedSpl(uint8_t const *const band_stats,
     }
 
     // Sum mean SPL for all bands in linear units
-    float mean_db = band_stats[offset + 3] * db_step + db_min;
-    spl_linear_sum += powf(10.0f, mean_db / 10.0f);
+    means[band_index] = band_stats[offset + 3] * db_step + db_min;
+    spl_linear_sum += powf(10.0f, means[band_index] / 10.0f);
   }
 
   float broadband_spl_db = 10.0f * log10f(spl_linear_sum);
   spl = fmaxf(0.0f, fminf(255.0f, (broadband_spl_db - db_min) / db_step + 0.5f));
+
+  float min_entropy = calc_min_spectral_entropy_and_clear_list(num_bands, means);
+  entropy = fmaxf(0.0f, fminf(255.0f, min_entropy * 255.0f));
 
   return BmOK;
 }
@@ -177,8 +183,8 @@ void BorealisSensor::aggregate(void) {
                        err, tracking_data.stats.levels_length,
                        tracking_data.stats.levels_length, tracking_data.stats.levels);
       } else {
-        calculateQuantizedSpl(report.spl_band_stats, report.spl_band_stats_size, report.spl,
-                              report.max_iqr_band);
+        calculateQuantizedSplAndEntropy(report.spl_band_stats, report.spl_band_stats_size,
+                                        report.spl, report.max_iqr_band, report.entropy);
         report.max_iqr_band += tracking_data.stats.first_band_index;
       }
     }
@@ -350,7 +356,21 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
               "borealis", d.header,
               MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms), "%.3f,%u,%.*s\n",
               d.dt, d.first_band_index, d.levels_length, d.levels);
+          // Base64 decodes to 3/4 of input size.
+          // There are two 12-bit band values per 3 bytes.
+          // 3/4 * 2/3 = 1/2
+          size_t num_bands = d.levels_length / 2;
+          float *spl_db = static_cast<float *>(bm_malloc(num_bands * sizeof(float)));
+          if (!spl_db) {
+            bm_debug("Failed to allocate memory for Borealis levels data\n");
+            err = BmENOMEM;
+            bm_free(d.levels);
+            break;
+          }
+          parse_levels(spl_db, d.levels, d.levels_length);
           bm_free(d.levels);
+          insert_spectrum_into_list(num_bands, spl_db);
+          bm_free(spl_db);
         }
       } break;
       case BOREALIS_LEVEL_STATISTICS: {
@@ -647,4 +667,66 @@ Borealis_t *createBorealisSensorSub(uint64_t node_id) {
   }
 
   return ret;
+}
+
+inline uint8_t BorealisSensor::unpack_nibble(const uint8_t *bytes, size_t nibble_index) {
+  const size_t byte_index = nibble_index / 2;
+  const size_t shift_bits = (nibble_index % 2) * 4;
+  return (bytes[byte_index] >> shift_bits) & 0xF;
+}
+
+inline uint16_t BorealisSensor::unpack_12bit(const uint8_t *bytes, size_t nibble_index) {
+  return unpack_nibble(bytes, nibble_index + 0) << 0 |
+         unpack_nibble(bytes, nibble_index + 1) << 4 |
+         unpack_nibble(bytes, nibble_index + 2) << 8;
+}
+
+void BorealisSensor::parse_levels(float *spl_db, const char *levels_as_base64,
+                                  size_t levels_length) {
+  size_t out_len = 0;
+  mbedtls_base64_decode(NULL, 0, &out_len, reinterpret_cast<const uint8_t *>(levels_as_base64),
+                        levels_length);
+  uint8_t raw_bytes[out_len];
+  int err =
+      mbedtls_base64_decode(raw_bytes, sizeof(raw_bytes), &out_len,
+                            reinterpret_cast<const uint8_t *>(levels_as_base64), levels_length);
+  if (err != 0) {
+    bm_debug("Failed to decode base64 levels: %d\n", err);
+    return;
+  }
+
+  constexpr float cstep = 0.046875f;                  // dB
+  constexpr float clow = -4096.0f * cstep + 185.642f; // dB
+  uint32_t num_bands = out_len * 2U / 3U;             // 3 bytes -> 2 12-bit values
+  for (uint32_t i = 0; i < num_bands; i++) {
+    spl_db[i] = unpack_12bit(raw_bytes, i * 3) * cstep + clow;
+  }
+}
+
+void BorealisSensor::parse_level_statistics(float *stats_db, const char *stats_as_base64,
+                                            size_t b64_length) {
+  size_t out_len = 0;
+  mbedtls_base64_decode(NULL, 0, &out_len, reinterpret_cast<const uint8_t *>(stats_as_base64),
+                        b64_length);
+  uint8_t raw_bytes[out_len];
+  int err =
+      mbedtls_base64_decode(raw_bytes, sizeof(raw_bytes), &out_len,
+                            reinterpret_cast<const uint8_t *>(stats_as_base64), b64_length);
+  if (err != 0) {
+    bm_debug("Failed to decode base64 level stats. err=%d, len=%zu, b64=%.*s\n", err,
+             b64_length, (int)b64_length, stats_as_base64);
+    return;
+  }
+
+  constexpr float cstep = 0.75f;                     // dB
+  constexpr float clow = -256.0f * cstep + 185.642f; // dB
+  constexpr uint8_t num_stats = 4;                   // 25%, 50%, 75%, mean
+  uint32_t num_bands = out_len / num_stats;
+  for (size_t i = 0; i < num_bands; i++) {
+    size_t index = i * num_stats;
+    stats_db[index + 0] = raw_bytes[index + 0] * cstep + clow; // 25%
+    stats_db[index + 1] = raw_bytes[index + 1] * cstep + clow; // 50%
+    stats_db[index + 2] = raw_bytes[index + 2] * cstep + clow; // 75%
+    stats_db[index + 3] = raw_bytes[index + 3] * cstep + clow; // mean
+  }
 }

--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -110,10 +110,10 @@ bool BorealisSensor::subscribe() {
 BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_stats,
                                                       const size_t band_stats_len, uint8_t &spl,
                                                       uint8_t &max_iqr_band, uint8_t &entropy) {
+  spl = REPORT_NAN_ERROR_VALUE;
+  max_iqr_band = REPORT_NAN_ERROR_VALUE;
+  entropy = REPORT_NAN_ERROR_VALUE;
   if (band_stats == NULL || band_stats_len == 0) {
-    spl = REPORT_NAN_ERROR_VALUE;
-    max_iqr_band = REPORT_NAN_ERROR_VALUE;
-    entropy = REPORT_NAN_ERROR_VALUE;
     clear_spectral_entropy_list();
     return BmEINVAL;
   }
@@ -125,7 +125,13 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
 
   uint8_t max_iqr_so_far = 0;
   float spl_linear_sum = 0.0f;
-  float means[num_bands] = {0.0f};
+  float *means = static_cast<float *>(bm_malloc(num_bands * sizeof(float)));
+  if (means == NULL) {
+    bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_ERROR, USE_HEADER,
+                   "Failed to allocate for Borealis level stats means\n");
+    clear_spectral_entropy_list();
+    return BmENOMEM;
+  }
   for (size_t band_index = 0; band_index < num_bands; band_index++) {
     size_t offset = band_index * num_stats;
 
@@ -149,6 +155,7 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
   float min_entropy = calc_min_spectral_entropy_and_clear_list(num_bands, means);
   entropy = fmaxf(0.0f, fminf(255.0f, min_entropy * 255.0f));
 
+  bm_free(means);
   return BmOK;
 }
 

--- a/src/apps/bridge/sensor_drivers/borealisSensor.h
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.h
@@ -77,8 +77,6 @@ private:
   static inline uint8_t unpack_nibble(const uint8_t *bytes, size_t nibble_index);
   static inline uint16_t unpack_12bit(const uint8_t *bytes, size_t nibble_index);
   static void parse_levels(float *spl_db, const char *levels_as_base64, size_t levels_length);
-  static void parse_level_statistics(float *stats_db, const char *stats_as_base64,
-                                     size_t b64_length);
 } Borealis_t;
 
 Borealis_t *createBorealisSensorSub(uint64_t node_id);

--- a/src/apps/bridge/sensor_drivers/borealisSensor.h
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.h
@@ -71,9 +71,14 @@ private:
   static void borealisSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                   const uint8_t *data, uint16_t data_len, uint8_t type,
                                   uint8_t version);
-  static BmErr calculateQuantizedSpl(uint8_t const *const band_stats,
-                                     const size_t band_stats_len, uint8_t &spl,
-                                     uint8_t &max_iqr_band);
+  static BmErr calculateQuantizedSplAndEntropy(uint8_t const *const band_stats,
+                                               const size_t band_stats_len, uint8_t &spl,
+                                               uint8_t &max_iqr_band, uint8_t &entropy);
+  static inline uint8_t unpack_nibble(const uint8_t *bytes, size_t nibble_index);
+  static inline uint16_t unpack_12bit(const uint8_t *bytes, size_t nibble_index);
+  static void parse_levels(float *spl_db, const char *levels_as_base64, size_t levels_length);
+  static void parse_level_statistics(float *stats_db, const char *stats_as_base64,
+                                     size_t b64_length);
 } Borealis_t;
 
 Borealis_t *createBorealisSensorSub(uint64_t node_id);

--- a/src/lib/dsp/spectral_entropy.c
+++ b/src/lib/dsp/spectral_entropy.c
@@ -83,15 +83,17 @@ static BmErr compute_entropies_and_find_minimum(void *data, void *arg) {
   return BmOK;
 }
 
-float calc_min_spectral_entropy_and_clear_list(const unsigned int num_bands,
-                                               float const *const means) {
-  min_entropy = 1.0;
-  SpectralEntropyArgs arg = {.num_bands = num_bands, .means = means};
-  ll_traverse(&spectra, compute_entropies_and_find_minimum, &arg);
-
+void clear_spectral_entropy_list(void) {
   while (spectra.head != NULL) {
     ll_remove(&spectra, spectra.head->id);
   }
+}
 
+float calc_min_spectral_entropy_and_clear_list(const unsigned int num_bands,
+                                               float const *const means) {
+  min_entropy = 1.0f;
+  SpectralEntropyArgs arg = {.num_bands = num_bands, .means = means};
+  ll_traverse(&spectra, compute_entropies_and_find_minimum, &arg);
+  clear_spectral_entropy_list();
   return min_entropy;
 }

--- a/src/lib/dsp/spectral_entropy.c
+++ b/src/lib/dsp/spectral_entropy.c
@@ -1,0 +1,97 @@
+#include "spectral_entropy.h"
+#include "bm_os.h"
+#include "ll.h"
+#include <math.h>
+
+typedef struct _SpectralEntropyArgs {
+  unsigned int num_bands;
+  float const *const means;
+} SpectralEntropyArgs;
+
+static LL spectra = {0};
+static float min_entropy = 1.0;
+
+/**
+ * @brief Computes the normalized spectral entropy.
+ *
+ * Converts an array of SPL values (in dB) to a linear scale,
+ * computes the probability distribution across the bands,
+ * and then calculates the entropy.
+ * The result is normalized by dividing by ln(num_bands).
+ *
+ * @param spl_db Array of third-octave band SPL values in decibels.
+ * @param mean_db Array of mean dB SPL for a sample duration.
+ *                If NULL, do not prewhiten the spectra.
+ * @return Normalized spectral entropy (range 0 to 1).
+ *         If there's an error return NAN.
+ */
+static float compute_spectral_entropy(const unsigned int num_bands, float const *const spl_db,
+                                      float const *const mean_db) {
+  float *linear_power = bm_malloc(num_bands * sizeof(float));
+  if (linear_power == NULL) {
+    return NAN;
+  }
+  float sum_power = 0.0f;
+
+  // Convert SPL in dB to linear power scale: power ∝ 10^(dB/10)
+  for (unsigned int i = 0; i < num_bands; i++) {
+    linear_power[i] = powf(10.0f, spl_db[i] / 10.0f);
+    if (mean_db) {
+      // Prewhiten using the given means
+      float linear_mean = powf(10.0f, mean_db[i] / 10.0f);
+      linear_power[i] /= linear_mean;
+    }
+    sum_power += linear_power[i];
+  }
+
+  // Protect against division by zero
+  if (sum_power <= 0.0f) {
+    bm_free(linear_power);
+    return NAN;
+  }
+
+  // Compute the entropy: H = -sum(p * log(p))
+  float entropy = 0.0f;
+  for (unsigned int i = 0; i < num_bands; i++) {
+    float p = linear_power[i] / sum_power;
+    // Only add if p > 0 to avoid log(0)
+    if (p > 0.0f) {
+      entropy -= p * logf(p);
+    }
+  }
+  bm_free(linear_power);
+
+  // Normalize the entropy between 0 and 1
+  return entropy / logf(num_bands);
+}
+
+void insert_spectrum_into_list(const unsigned int num_bands, float *const spl_db) {
+  size_t data_size = num_bands * sizeof(float);
+  LLItem *item = NULL;
+  static uint32_t id = 0;
+  item = ll_create_item(item, spl_db, data_size, id++);
+  ll_item_add(&spectra, item);
+}
+
+static BmErr compute_entropies_and_find_minimum(void *data, void *arg) {
+  float *const band_levels = (float *const)data;
+  SpectralEntropyArgs *args = (SpectralEntropyArgs *)arg;
+  const float entropy = compute_spectral_entropy(args->num_bands, band_levels, args->means);
+  if (entropy < min_entropy) {
+    min_entropy = entropy;
+  }
+  return BmOK;
+}
+
+float calc_min_spectral_entropy_and_clear_list(const unsigned int num_bands,
+                                               float const *const means) {
+  min_entropy = 1.0;
+  SpectralEntropyArgs arg = {.num_bands = num_bands, .means = means};
+  ll_traverse(&spectra, compute_entropies_and_find_minimum, &arg);
+
+  while (spectra.head != NULL) {
+    ll_remove(&spectra, spectra.head->id);
+  }
+
+  return min_entropy;
+}

--- a/src/lib/dsp/spectral_entropy.h
+++ b/src/lib/dsp/spectral_entropy.h
@@ -5,7 +5,7 @@ extern "C" {
 #endif
 
 void insert_spectrum_into_list(const unsigned int num_bands, float *const spl_db);
-
+void clear_spectral_entropy_list(void);
 float calc_min_spectral_entropy_and_clear_list(const unsigned int num_bands,
                                                float const *const means);
 

--- a/src/lib/dsp/spectral_entropy.h
+++ b/src/lib/dsp/spectral_entropy.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void insert_spectrum_into_list(const unsigned int num_bands, float *const spl_db);
+
+float calc_min_spectral_entropy_and_clear_list(const unsigned int num_bands,
+                                               float const *const means);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## What changed?

- Added spectral entropy module in a new lib/dsp directory
- On each received levels message (once per second) bridge inserts the levels into a growing list for later spectral entropy calculations
- When aggregating after each sample duration:
  - bridge passes the means from the borealis level stats to the spectral entropy module, which
  - computes prewhitened spectral entropy across the list of all received levels
  - and returns the _*minimum*_ spectral entropy from the entire sample duration.

## How does it make Bristlemouth better?

The minimum spectral entropy from a sample duration will be one measure of signal that will allow Spotter Sound customers to control their satellite data expenditures.

The idea of using spectral entropy as a measure of likelihood of signal in acoustic data comes from [Automatic detection of marine mammals using information entropy](https://doi.org/10.1121/1.2982368) by Christine Erbe & Andrew R. King, published in Volume 124, Issue 5 of the Journal of the Acoustical Society of America, November 2008. The paper is very vague about how to perform the calculations, so this is our own implementation.

Customers can configure an entropy threshold on the Bridge. If the minimum spectral entropy from a particular sample duration is below the configured threshold, then there is more likely to be a signal of interest (more tonal, less like white noise), and Spotter will send a larger message with more detailed statistics per third-octave band over the sample duration.

If, on the other hand, the minimum spectral entropy from a sample period is above the configured threshold, then the sample duration was consistently noisy enough that it's less likely to contain a signal of interest. In this case, Spotter will send a smaller message to save on telemetry costs.

## Where should reviewers focus?

- Memory handling in the BOREALIS_LEVELS case of borealisSubCallback starting around line 359 of borealisSensor.cpp
- Memory handling in the list usage in the spectral entropy module
- Please don't hesitate to ask questions about the calculations.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
