### PR TITLE
feat: compare borealis stats to configured tx thresholds

### DIFF
--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -20,6 +20,11 @@ extern "C" {
 
 #define MAX_BOREALIS_READING_PERIOD_MS(period) (period + 1000U)
 
+// Only for 8-bit values in levels statistics, NOT for 12-bit values in levels
+static constexpr float db_step_8bit = 0.75f;
+static constexpr float db_min_8bit = -256.0f * db_step_8bit;
+
+static constexpr float borealis_db_offset = 185.642f;
 static struct BorealisSensor *s_current_sub = NULL;
 static SemaphoreHandle_t s_config_callback_handshake = NULL;
 static constexpr char subtag_spectrum[] = "/aos/borealis/spectrum";
@@ -27,6 +32,9 @@ static constexpr char subtag_levels[] = "/aos/borealis/levels";
 static constexpr char subtag_level_statistics[] = "/aos/borealis/level_statistics";
 static constexpr char subtag_recstatus[] = "/aos/borealis/recstatus";
 static constexpr char subtag_hydrotwin_ldr[] = "/hydrotwin/ai/low-data-rate";
+static constexpr char config_borealis_tx_spl_threshold[] = "borealisTxSplThreshold";
+static constexpr char config_borealis_tx_max_iqr_threshold[] = "borealisTxMaxIqrThreshold";
+static constexpr char config_borealis_tx_entropy_threshold[] = "borealisTxEntropyThreshold";
 
 /*!
  @brief Initialize Borealis Sensor Module
@@ -118,8 +126,6 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
     return BmEINVAL;
   }
 
-  constexpr float db_step = 0.75f;
-  constexpr float db_min = -256.0f * db_step;
   constexpr unsigned int num_stats = 4; // 25%, 50%, 75%, mean
   const unsigned int num_bands = band_stats_len / num_stats;
 
@@ -145,18 +151,40 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
     }
 
     // Sum mean SPL for all bands in linear units
-    means[band_index] = band_stats[offset + 3] * db_step + db_min;
+    means[band_index] = band_stats[offset + 3] * db_step_8bit + db_min_8bit;
     spl_linear_sum += powf(10.0f, means[band_index] / 10.0f);
   }
 
   float broadband_spl_db = 10.0f * log10f(spl_linear_sum);
-  spl = fmaxf(0.0f, fminf(255.0f, (broadband_spl_db - db_min) / db_step + 0.5f));
+  spl = fmaxf(0.0f, fminf(255.0f, (broadband_spl_db - db_min_8bit) / db_step_8bit + 0.5f));
 
   float min_entropy = calc_min_spectral_entropy_and_clear_list(num_bands, means);
   entropy = fmaxf(0.0f, fminf(255.0f, min_entropy * 255.0f));
 
   bm_free(means);
   return BmOK;
+}
+
+/*!
+  @brief Determine whether to send extended data based on configured thresholds
+  @return true if the data exceeds configured thresholds, false otherwise
+*/
+bool BorealisSensor::exceedsConfiguredThresholds(uint8_t spl, uint8_t max_iqr,
+                                                 uint8_t entropy) {
+  float spl_threshold = 0.0f;
+  get_config_float(BM_CFG_PARTITION_SYSTEM, config_borealis_tx_spl_threshold,
+                   strlen(config_borealis_tx_spl_threshold), &spl_threshold);
+  float max_iqr_threshold = 0.0f;
+  get_config_float(BM_CFG_PARTITION_SYSTEM, config_borealis_tx_max_iqr_threshold,
+                   strlen(config_borealis_tx_max_iqr_threshold), &max_iqr_threshold);
+  float entropy_threshold = 1.0f;
+  get_config_float(BM_CFG_PARTITION_SYSTEM, config_borealis_tx_entropy_threshold,
+                   strlen(config_borealis_tx_entropy_threshold), &entropy_threshold);
+
+  bool spl_exceeds = spl * db_step_8bit + db_min_8bit + borealis_db_offset >= spl_threshold;
+  bool max_iqr_exceeds = max_iqr * db_step_8bit >= max_iqr_threshold;
+  bool entropy_exceeds = entropy <= entropy_threshold * 255.0f;
+  return (spl_exceeds || max_iqr_exceeds || entropy_exceeds);
 }
 
 /*!
@@ -167,8 +195,6 @@ BmErr BorealisSensor::calculateQuantizedSplAndEntropy(uint8_t const *const band_
  */
 void BorealisSensor::aggregate(void) {
   if (xSemaphoreTake(_mutex, portMAX_DELAY) == pdTRUE) {
-    // TODO: logic needs to be implemented around if this is going to be extended
-    bool is_extended = true;
     size_t decoded_byte_len = 0;
     BorealisAggregationData_t report = {};
     report.max_iqr = tracking_data.stats.max_iqr;
@@ -177,10 +203,9 @@ void BorealisSensor::aggregate(void) {
                           (const unsigned char *)tracking_data.stats.levels,
                           tracking_data.stats.levels_length);
 
+    report.is_extended = false;
     report.spl_band_stats = static_cast<uint8_t *>(bm_malloc(decoded_byte_len));
     if (report.spl_band_stats) {
-      report.is_extended = is_extended;
-
       int err = mbedtls_base64_decode(
           report.spl_band_stats, decoded_byte_len, (size_t *)&report.spl_band_stats_size,
           (const unsigned char *)tracking_data.stats.levels, tracking_data.stats.levels_length);
@@ -194,6 +219,8 @@ void BorealisSensor::aggregate(void) {
         calculateQuantizedSplAndEntropy(report.spl_band_stats, report.spl_band_stats_size,
                                         report.spl, report.max_iqr_band, report.entropy);
         report.max_iqr_band += tracking_data.stats.first_band_index;
+        report.is_extended =
+            exceedsConfiguredThresholds(report.spl, report.max_iqr, report.entropy);
       }
     }
 
@@ -700,9 +727,10 @@ void BorealisSensor::parse_levels(float *spl_db, const char *levels_as_base64,
     return;
   }
 
-  constexpr float cstep = 0.046875f;                  // dB
-  constexpr float clow = -4096.0f * cstep + 185.642f; // dB
-  uint32_t num_bands = out_len * 2U / 3U;             // 3 bytes -> 2 12-bit values
+  // These constants are for 12-bit values, unlike the 8-bit ones at the top of this file.
+  constexpr float cstep = 0.046875f;                            // dB
+  constexpr float clow = -4096.0f * cstep + borealis_db_offset; // dB
+  uint32_t num_bands = out_len * 2U / 3U;                       // 3 bytes -> 2 12-bit values
   for (uint32_t i = 0; i < num_bands; i++) {
     spl_db[i] = unpack_12bit(raw_bytes, i * 3) * cstep + clow;
   }

--- a/src/apps/bridge/sensor_drivers/borealisSensor.h
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.h
@@ -71,6 +71,7 @@ private:
   static void borealisSubCallback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                   const uint8_t *data, uint16_t data_len, uint8_t type,
                                   uint8_t version);
+  static bool exceedsConfiguredThresholds(uint8_t spl, uint8_t max_iqr, uint8_t entropy);
   static BmErr calculateQuantizedSplAndEntropy(uint8_t const *const band_stats,
                                                const size_t band_stats_len, uint8_t &spl,
                                                uint8_t &max_iqr_band, uint8_t &entropy);

--- a/src/lib/dsp/spectral_entropy.c
+++ b/src/lib/dsp/spectral_entropy.c
@@ -1,6 +1,7 @@
 #include "spectral_entropy.h"
 #include "bm_os.h"
 #include "ll.h"
+#include <float.h>
 #include <math.h>
 
 typedef struct _SpectralEntropyArgs {
@@ -23,13 +24,13 @@ static float min_entropy = 1.0;
  * @param mean_db Array of mean dB SPL for a sample duration.
  *                If NULL, do not prewhiten the spectra.
  * @return Normalized spectral entropy (range 0 to 1).
- *         If there's an error return NAN.
+ *         If there's an error return FLT_MAX.
  */
 static float compute_spectral_entropy(const unsigned int num_bands, float const *const spl_db,
                                       float const *const mean_db) {
   float *linear_power = bm_malloc(num_bands * sizeof(float));
   if (linear_power == NULL) {
-    return NAN;
+    return FLT_MAX;
   }
   float sum_power = 0.0f;
 
@@ -47,7 +48,7 @@ static float compute_spectral_entropy(const unsigned int num_bands, float const 
   // Protect against division by zero
   if (sum_power <= 0.0f) {
     bm_free(linear_power);
-    return NAN;
+    return FLT_MAX;
   }
 
   // Compute the entropy: H = -sum(p * log(p))


### PR DESCRIPTION
## What changed?

When building a sample report for borealis, check the broadband SPL, max interquartile range, and entropy against configured "likelihood of signal" thresholds for sending larger messages.

Note: This PR is currently built on the spectral entropy branch which should be merged independently first.

## How does it make Bristlemouth better?

This enables Spotter Sound customers to tune their satellite data costs to their budget and desire for real-time spectral data.

## Where should reviewers focus?

The `exceedsConfiguredThresholds` method — its config usage and the math.

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
