### PR TITLE
Feature/bm bridge lock removal

### DIFF
--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -355,9 +355,6 @@ static bool bm_int_gpio_callback_fromISR(const void *pinHandle, uint8_t value, v
 
   if (!value) {
     lpmPeripheralActiveFromISR(LPM_USART3_RX); // Active low
-    HAL_UART_AbortReceive(&huart3);
-    HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
-                                 NCP_BUFF_LEN);
   }
 
   return xHigherPriorityTaskWoken;
@@ -447,6 +444,9 @@ void ncpInit(SerialHandle_t *ncpUartHandle, NvmPartition *dfu_partition,
   IORegisterCallback(&BM_INT, bm_int_gpio_callback_fromISR, NULL);
 
   serialEnable(ncpSerialHandle);
+  HAL_UART_AbortReceive(&huart3);
+  HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
+                               NCP_BUFF_LEN);
   ncpBaudRateDiscovery();
   ncp_dfu_check_for_update();
   bm_serial_send_reboot_info(getNodeId(), checkResetReason(), getGitSHA(),
@@ -598,7 +598,7 @@ static void ncpBaudRateDiscovery(void) {
 #ifndef DEBUG_USE_USART3
 extern "C" void USART3_IRQHandler(void) {
   HAL_UART_IRQHandler(&huart3);
-  if (HAL_UART_GetError(&huart3) == HAL_UART_ERROR_FE) {
+  if (HAL_UART_GetError(&huart3) != HAL_UART_ERROR_NONE) {
     HAL_UART_DMAStop(&huart3);
     HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
                                  NCP_BUFF_LEN);
@@ -641,6 +641,8 @@ void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t len) {
     }
   }
 
+  HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
+                               NCP_BUFF_LEN);
   // Exit low power mode now that RX is complete
   lpmPeripheralInactiveFromISR(LPM_USART3_RX);
   portYIELD_FROM_ISR(higherPriorityTaskWoken);

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -37,11 +37,9 @@ static constexpr uint16_t NCP_BUFF_LEN = 2048;
 static volatile uint8_t ncpRXCurrBuff = 0;
 static volatile uint8_t ncpRXBuff[NCP_RX_BUFF_COUNT][NCP_BUFF_LEN];
 static volatile uint32_t ncpRXBuffLen[NCP_RX_BUFF_COUNT];
-static volatile bool ncp_rx = false;
 
 static QueueHandle_t ncp_processor_queue_handle;
 static QueueHandle_t ncp_tx_queue_handle;
-static SemaphoreHandle_t ncp_serial_lock = NULL;
 static SemaphoreHandle_t ncp_baud_rate_discovery_lock = NULL;
 static SemaphoreHandle_t tx_complete_lock = NULL;
 
@@ -355,13 +353,8 @@ static bool bm_int_gpio_callback_fromISR(const void *pinHandle, uint8_t value, v
 
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
 
-  if (value) {
-    xSemaphoreGiveFromISR(ncp_serial_lock, &xHigherPriorityTaskWoken);
-    ncp_rx = false;
-  } else {
-    xSemaphoreTakeFromISR(ncp_serial_lock, &xHigherPriorityTaskWoken);
+  if (!value) {
     lpmPeripheralActiveFromISR(LPM_USART3_RX); // Active low
-    ncp_rx = true;
     HAL_UART_AbortReceive(&huart3);
     HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
                                  NCP_BUFF_LEN);
@@ -392,9 +385,6 @@ void ncpInit(SerialHandle_t *ncpUartHandle, NvmPartition *dfu_partition,
   ncp_tx_queue_handle =
       xQueueCreate(NCP_PROCESSOR_TX_QUEUE_DEPTH, sizeof(ProcessorQueueItem_t));
   configASSERT(ncp_tx_queue_handle);
-
-  ncp_serial_lock = xSemaphoreCreateBinary();
-  configASSERT(ncp_serial_lock);
 
   tx_complete_lock = xSemaphoreCreateBinary();
   configASSERT(tx_complete_lock);
@@ -608,7 +598,7 @@ static void ncpBaudRateDiscovery(void) {
 #ifndef DEBUG_USE_USART3
 extern "C" void USART3_IRQHandler(void) {
   HAL_UART_IRQHandler(&huart3);
-  if (HAL_UART_GetError(&huart3) == HAL_UART_ERROR_FE && ncp_rx) {
+  if (HAL_UART_GetError(&huart3) == HAL_UART_ERROR_FE) {
     HAL_UART_DMAStop(&huart3);
     HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
                                  NCP_BUFF_LEN);
@@ -695,9 +685,6 @@ static inline BaseType_t postTxEventHandle(SerialHandle_t *handle,
 
 static void ncpPreTxCb(SerialHandle_t *handle) { // called from task context
   configASSERT(handle);
-  if (ncp_rx) {
-    xSemaphoreTake(ncp_serial_lock, portMAX_DELAY);
-  }
   LL_EXTI_DisableIT_0_31(LL_EXTI_LINE_0);
   lpmPeripheralActive(LPM_USART3);
   LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_OUTPUT);

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -687,11 +687,15 @@ static inline BaseType_t postTxEventHandle(SerialHandle_t *handle,
 
 static void ncpPreTxCb(SerialHandle_t *handle) { // called from task context
   configASSERT(handle);
-  LL_EXTI_DisableIT_0_31(LL_EXTI_LINE_0);
-  lpmPeripheralActive(LPM_USART3);
-  LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_OUTPUT);
-  IOWrite(&BM_INT, 0);
-  vTaskDelay(pdMS_TO_TICKS(LPM_WAKE_TIME_MS));
+  uint8_t pin_level = 0;
+  IORead(&BM_INT, &pin_level);
+  if (pin_level) {
+    LL_EXTI_DisableIT_0_31(LL_EXTI_LINE_0);
+    lpmPeripheralActive(LPM_USART3);
+    LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_OUTPUT);
+    IOWrite(&BM_INT, 0);
+    vTaskDelay(pdMS_TO_TICKS(LPM_WAKE_TIME_MS));
+  }
 }
 
 static void ncpPostTxCb(SerialHandle_t *handle) { // called form ISR context
@@ -705,9 +709,11 @@ static void ncpPostTxCb(SerialHandle_t *handle) { // called form ISR context
   } else {
     xSemaphoreGiveFromISR(ncp_ctx.negotiating_lock, NULL);
   }
-  LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_INPUT);
-  LL_EXTI_EnableIT_0_31(LL_EXTI_LINE_0);
-  LL_GPIO_SetPinPull(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_PULL_UP);
+  if (LL_GPIO_GetPinMode(BM_INT_GPIO_Port, BM_INT_Pin) == LL_GPIO_MODE_OUTPUT) {
+    LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_INPUT);
+    LL_EXTI_EnableIT_0_31(LL_EXTI_LINE_0);
+    LL_GPIO_SetPinPull(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_PULL_UP);
+  }
   // LPM_USART3_RX will get set on the next rising edge
   lpmPeripheralInactiveFromISR(LPM_USART3_TX);
   portYIELD_FROM_ISR(


### PR DESCRIPTION
## What changed?
Allows receiving/transmitting messages over UART to occur at the same time.

## How does it make Bristlemouth better?
Optimize throughput and reduce complexity by removing semaphore.


## Where should reviewers focus?
Review the testing data:
Data Gaps:
    - From a 16 hour test with a system that has two SOFT modules reporting:
    ![Screenshot 2025-06-11 at 11 12 07 AM](https://github.com/user-attachments/assets/efe8ec4c-c5ae-4ab1-8fe6-cf8ed209d577)
    - No decrease in performance here, but no increase either (will have to implement some ack/nack scheme for improved integrity), but reduces code complexity



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
