### PR TITLE
Fix/pressure conversion in do calc

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.c
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/do_calc.c
@@ -10,7 +10,7 @@ double doConcMg(double t, double p, double s) {
 }
 
 double doConcUmol(double t, double p, double s) {
-  double Ptotal = p / 101325.0; // convert Pa to atm
+  double Ptotal = p / 1013.25; // convert mbar to atm
   double pWSat = saturatedWaterVaporPressure(t, s);
   double pO2measured = pO2(Ptotal - pWSat);
   double pO2reference = pO2(1.0 - pWSat);

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -102,7 +102,7 @@ uint32_t loadLastWipeEpoch() {
  * - Enables the PLUART, effectively turning on the UART.
  */
 void PmeSensor::init() {
-  bm_delay(10000); //boot delay to allow for user to connect for viewing
+  bm_delay(12000); //boot delay to allow for user to connect for viewing
   _DOTparser.init();
   _WIPEparser.init();
   lastWipeEpochS = loadLastWipeEpoch();


### PR DESCRIPTION
## What changed?
Fixed a pressure conversion in the saturation pct calculations. Also delayed the first measurement by an additioanl 2 second to make sure the DO has recieved a pressure reading from spotter which come every 10 seconds.


## How does it make Bristlemouth better?
Calculates saturation pct properly and a increases reliabilty of calculating the saturation pct.

Here is an example reading from before the change. We ca see the saturation pct is way off. The saturation pct is -7701.6 in this case:
<img width="790" alt="Screenshot 2025-06-11 at 12 07 30 PM" src="https://github.com/user-attachments/assets/4da03df4-d311-4cd0-b4ec-702c7a1b7431" />

and here is one from after and the saturation pct is within the 0-150 we expect (its the 101.9 value in the list):
<img width="600" alt="Screenshot 2025-06-11 at 12 06 22 PM" src="https://github.com/user-attachments/assets/e8f25e24-0f09-45f9-9474-a8d1c9e9b85f" />


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
