### PR TITLE
Fix .noinit Section Misordering

### DIFF
--- a/src/bsp/common/linker/bs_stm32u575.ld
+++ b/src/bsp/common/linker/bs_stm32u575.ld
@@ -225,7 +225,12 @@ SECTIONS
   .noinit (NOLOAD):
   {
     /* place all symbols in input sections that start with .noinit */
-    KEEP(*(*.noinit*))
+    KEEP(*(.noinit.ulBootloaderMagic))
+    KEEP(*(.noinit.resetReason))
+    KEEP(*(.noinit.s_reboot_tracking))
+    KEEP(*(.noinit.client_update_reboot_info))
+    KEEP(*(.noinit))
+    KEEP(*(.noinit._reboot_info))
   } > NOINIT
 }
 

--- a/src/lib/bm_ncp/ncp_dfu.cpp
+++ b/src/lib/bm_ncp/ncp_dfu.cpp
@@ -38,7 +38,7 @@ typedef struct {
 } ncp_dfu_ctx_t;
 
 static ncp_dfu_ctx_t _ctx;
-static NcpReboootUpdateInfo_t _reboot_info __attribute__((section(".noinit")));
+static NcpReboootUpdateInfo_t _reboot_info __attribute__((section(".noinit._reboot_info")));
 
 static void _ncp_dfu_finish(bool success, BmDfuErr err, uint64_t node_id) {
   memset(&_reboot_info, 0, sizeof(_reboot_info));

--- a/src/lib/common/bootloader_helper.c
+++ b/src/lib/common/bootloader_helper.c
@@ -10,7 +10,7 @@
 typedef void (*functionPointer_t)(void);
 
 // Make sure the crash info is not re-initialized on reboot
-uint32_t ulBootloaderMagic __attribute__ ((section (".noinit")));
+uint32_t ulBootloaderMagic __attribute__ ((section (".noinit.ulBootloaderMagic")));
 
 void rebootIntoROMBootloader() {
   // Set magic value so we'll know to enter bootloader after reset

--- a/src/lib/common/reset_reason.c
+++ b/src/lib/common/reset_reason.c
@@ -1,57 +1,56 @@
-#include <stdint.h>
 #include "debug.h"
 #include "enumToStr.h"
+#include <stdint.h>
 // #include "log.h"
 #include "reset_reason.h"
 // #include "sd.h"
 #include "bsp.h"
 
 // Make sure the crash info is not re-initialized on reboot
-uint32_t ulResetReasonMagic __attribute__ ((section (".noinit")));
-ResetReason_t resetReason __attribute__((section(".noinit")));
+uint32_t ulResetReasonMagic __attribute__((section(".noinit.resetReason")));
+ResetReason_t resetReason __attribute__((section(".noinit.resetReason")));
 
 // ISR safe reset reason (no log flush)
 void resetSystemFromISR(ResetReason_t reason) {
-    ulResetReasonMagic = RESET_REASON_MAGIC;
-    resetReason = reason;
+  ulResetReasonMagic = RESET_REASON_MAGIC;
+  resetReason = reason;
 
-    // Reset the device so that all peripherals are in the default state
-    NVIC_SystemReset();
+  // Reset the device so that all peripherals are in the default state
+  NVIC_SystemReset();
 }
 
 void resetSystem(ResetReason_t reason) {
-    // Try to flush SD logs if SD card is connected
-    // if(sdIsMounted()) {
-        // printf("Flushing log buffers.\n");
-        // logFlushAll(1000);
-    // }
+  // Try to flush SD logs if SD card is connected
+  // if(sdIsMounted()) {
+  // printf("Flushing log buffers.\n");
+  // logFlushAll(1000);
+  // }
 
-    resetSystemFromISR(reason);
+  resetSystemFromISR(reason);
 }
 
 ResetReason_t checkResetReason() {
-    uint32_t cachedResetReasonMagic = ulResetReasonMagic;
-    static ResetReason_t cachedResetReason = RESET_REASON_NONE;
+  uint32_t cachedResetReasonMagic = ulResetReasonMagic;
+  static ResetReason_t cachedResetReason = RESET_REASON_NONE;
 
-    // Make sure we clear this every time
-    ulResetReasonMagic = 0;
+  // Make sure we clear this every time
+  ulResetReasonMagic = 0;
 
-    // if cached value is NONE(i.e. checkResetReason is being called for the first time since restart),
-    // check if the magic number has been set
-    if(cachedResetReason == RESET_REASON_NONE){
-        // if the magic number has been set, update the cachedResetReason to the last reset reason
-        // else set cachedResetReason to INVALID
-        if(cachedResetReasonMagic == RESET_REASON_MAGIC){
-            cachedResetReason = resetReason;
-        }
-        else{
-            cachedResetReason = RESET_REASON_INVALID;
-        }
+  // if cached value is NONE(i.e. checkResetReason is being called for the first time since restart),
+  // check if the magic number has been set
+  if (cachedResetReason == RESET_REASON_NONE) {
+    // if the magic number has been set, update the cachedResetReason to the last reset reason
+    // else set cachedResetReason to INVALID
+    if (cachedResetReasonMagic == RESET_REASON_MAGIC) {
+      cachedResetReason = resetReason;
+    } else {
+      cachedResetReason = RESET_REASON_INVALID;
     }
-    // Clear the reset reason
-    resetReason = RESET_REASON_INVALID;
+  }
+  // Clear the reset reason
+  resetReason = RESET_REASON_INVALID;
 
-    return cachedResetReason;
+  return cachedResetReason;
 }
 
 static const enumStrLUT_t resetReasonLUT[] = {
@@ -65,9 +64,6 @@ static const enumStrLUT_t resetReasonLUT[] = {
     {RESET_REASON_MICROPYTHON, "micropython"},
     {RESET_REASON_INVALID, "Invalid reset or first power on since flashing"},
     // MUST be NULL terminated list otherwise things WILL break
-    {0, NULL}
-};
+    {0, NULL}};
 
-const char * getResetReasonString() {
-    return enumToStr(resetReasonLUT, checkResetReason());
-}
+const char *getResetReasonString() { return enumToStr(resetReasonLUT, checkResetReason()); }

--- a/src/lib/memfault/memfault_platform_core.c
+++ b/src/lib/memfault/memfault_platform_core.c
@@ -42,7 +42,7 @@ static SemaphoreHandle_t s_memfault_packetizer_mutex;
 
 // Note: reboot tracking needs to be placed in a noinit region
 // because metadata across resets is tracked
-MEMFAULT_PUT_IN_SECTION(".noinit")
+MEMFAULT_PUT_IN_SECTION(".noinit.s_reboot_tracking")
 static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
 
 void memfault_platform_log(eMemfaultPlatformLogLevel level, const char *fmt, ...) {

--- a/src/lib/memfault/memfault_platform_core_u5.c
+++ b/src/lib/memfault/memfault_platform_core_u5.c
@@ -37,7 +37,7 @@ static sMfltResetReasonInfo memfault_reset_info;
 
 // Note: reboot tracking needs to be placed in a noinit region
 // because metadata across resets is tracked
-MEMFAULT_PUT_IN_SECTION(".noinit")
+MEMFAULT_PUT_IN_SECTION(".noinit.s_reboot_tracking")
 static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
 
 void memfault_platform_log(eMemfaultPlatformLogLevel level, const char *fmt, ...) {


### PR DESCRIPTION
## What changed?
Forcibly place .noinit variables in order to prevent DFU update failures from Spotter to Bridge.


## How does it make Bristlemouth better?
v0.12.2 firmware had the `.noinit` section variables in a different order causing a bug to occur when the bridge updates itself.
This ensures that the variables that currently exist in the `.noinit` section will always be in the correct order.

- v0.12.2 `.noinit`  order:
  ![Screenshot 2025-06-11 at 6 00 22 PM](https://github.com/user-attachments/assets/0ed96ad7-1bc6-4e86-b646-5c4888f6ba55)\
- v0.13.0.rc.7 `.noinit` order:  
  ![Screenshot 2025-06-11 at 5 58 07 PM](https://github.com/user-attachments/assets/dcc04502-98ec-4706-b600-c96659a01131)
- This PR `.noinit` order:
  ![Screenshot 2025-06-11 at 7 35 44 PM](https://github.com/user-attachments/assets/b59fb2a1-56df-4fd2-aa06-1dfed494faf3)

The following is an update from v0.12.2 to this commit from the Spotter console:
![Screenshot 2025-06-11 at 7 38 00 PM](https://github.com/user-attachments/assets/8793dbab-8048-47f1-b7b8-4b1cf7539348)
As can be seen, the `Update finished: fae667f759ff02e1 success: 1 err:0` string is printed out and the update is taken properly.


## Where should reviewers focus?
Testing would be nice to get cycles on this PR. Other than that the proof of what was wrong can be seen and validated above.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
