### PR TITLE
Log microDOT OS version to pme_sys.log on init

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -136,6 +136,8 @@ void PmeSensor::init() {
     printf("~~~                 OS: %s                 ~~~\n", _OSpayload_buffer);
     printf("~~~            Begin transmission            ~~~\n"
            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n");
+    spotter_log(0, PME_SYS_LOG, USE_TIMESTAMP, "S/N: %s, microDOT OS version: %s\n",
+                _SNpayload_buffer, _OSpayload_buffer);
   } else {
     printf("!!! No microDOT S/N received - is the device connected?\n");
   }

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 
 #define LAST_WIPE_EPOCH_KEY "lastWipeEpochS"
+#define FW_VERSION_KEY "fwVersion"
 
 extern uint32_t pmeLogEnable;
 extern uint32_t sensorDebugTxEnable;
@@ -86,6 +87,28 @@ uint32_t loadLastWipeEpoch() {
   return lastWipeEpochS;
 }
 
+// Update the saved firmware version config if the microDOT OS version has changed
+void PmeSensor::saveFirmwareVersion(const char *os_version) {
+  size_t fw_version_len = MAX_STR_LEN_BYTES;
+  char fw_version[MAX_STR_LEN_BYTES + 1] = {0};
+  get_config_string(BM_CFG_PARTITION_SYSTEM, FW_VERSION_KEY, strlen(FW_VERSION_KEY), fw_version,
+                    &fw_version_len);
+  size_t os_version_len = strnlen(os_version, MAX_STR_LEN_BYTES);
+  if (os_version_len > MAX_STR_LEN_BYTES) {
+    os_version_len = MAX_STR_LEN_BYTES;
+  }
+  if (os_version_len != fw_version_len ||
+      strncmp(fw_version, os_version, os_version_len) != 0) {
+    printf("microDOT OS version does not match fwVersion config (%s), updating config\n",
+           fw_version);
+    set_config_string(BM_CFG_PARTITION_SYSTEM, FW_VERSION_KEY, strlen(FW_VERSION_KEY),
+                      os_version, os_version_len);
+    save_config(BM_CFG_PARTITION_SYSTEM, false);
+  } else {
+    printf("microDOT OS version matches fwVersion config\n");
+  }
+}
+
 /**
  * @brief Initializes the PME DOT Sensor and wiper
  *
@@ -138,6 +161,7 @@ void PmeSensor::init() {
            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n");
     spotter_log(0, PME_SYS_LOG, USE_TIMESTAMP, "S/N: %s, microDOT OS version: %s\n",
                 _SNpayload_buffer, _OSpayload_buffer);
+    saveFirmwareVersion(_OSpayload_buffer);
   } else {
     printf("!!! No microDOT S/N received - is the device connected?\n");
   }

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
@@ -25,6 +25,8 @@ public:
   static constexpr char PME_WIPE_RAW_LOG[] = "pme_wipe_raw.log";
 
 private:
+  static void saveFirmwareVersion(const char *version);
+
   static constexpr ValueType DOT_PARSER_VALUE_TYPE[] = {TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,
                                                         TYPE_DOUBLE, TYPE_DOUBLE};
   static constexpr ValueType WIPE_PARSER_VALUE_TYPE[] = {TYPE_DOUBLE, TYPE_DOUBLE, TYPE_DOUBLE,

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.h
@@ -20,6 +20,7 @@ public:
   void flush(void);
   void setBarometricPressure(double pressure);
 
+  static constexpr char PME_SYS_LOG[] = "pme_sys.log";
   static constexpr char PME_DO_RAW_LOG[] = "pme_do_raw.log";
   static constexpr char PME_WIPE_RAW_LOG[] = "pme_wipe_raw.log";
 

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -71,9 +71,6 @@ static constexpr char SENSOR_BM_WIPE_INTERVAL_S[] = "pmeWipeIntervalS";
 static constexpr char SENSOR_DEBUG_TX_ENABLE[] = "sensorDebugTxEnable";
 static constexpr char SALINITY_PPT[] = "salinityPpt";
 
-// Make this sys cfg available when supported by backend
-// static constexpr char fwVersion = "0.13.0-rc.7";
-
 // Variables for measurements and timing
 static uint32_t lastWipeEpochS = 0;
 static uint64_t lastDoMeasurementUptimeSec = 0;

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -65,7 +65,7 @@ bool firstDo;
 
 // Defines the max buffer size for the pme sensor message
 static constexpr uint32_t pmeSensorDataMsgMaxSize = 256;
-static constexpr char SENSOR_BM_LOG_ENABLE[] = "pmeLogEnable";
+static constexpr char SENSOR_BM_LOG_ENABLE[] = "sensorBmLogEnable";
 static constexpr char SENSOR_BM_DOT_INTERVAL_S[] = "pmeDOTIntervalS";
 static constexpr char SENSOR_BM_WIPE_INTERVAL_S[] = "pmeWipeIntervalS";
 static constexpr char SENSOR_DEBUG_TX_ENABLE[] = "sensorDebugTxEnable";


### PR DESCRIPTION
## What changed?

Log the microDOT OS version to pme_sys.log and store the latest version in the fwVersion config.

## How does it make Bristlemouth better?

Increases visibility into component versions to help debugging system issues.

## Where should reviewers focus?

Checking and saving the fwVersion config. We only want to write if it has changed.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
