### PR TITLE
Fix USB detection when hwVersion is incorrect, develop

### DIFF
--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -165,12 +165,14 @@ NvmPartition *userConfigurationPartition = NULL;
 NvmPartition *systemConfigurationPartition = NULL;
 NvmPartition *hardwareConfigurationPartition = NULL;
 NvmPartition *dfu_partition_global = NULL;
-static IOPinHandle_t *usb_io = &LED_G;
+static IOPinHandle_t *usb_io = &NULL;
 
 static bool usb_is_connected() {
   uint8_t vusb = 0;
+  uint8_t vusb2 = 0;
 
-  IORead(usb_io, &vusb);
+  IORead(&VUSB_DETECT, &vusb);
+  IORead(&LED_G, &vusb2);
 
   return (bool)vusb;
 }

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -165,7 +165,7 @@ NvmPartition *userConfigurationPartition = NULL;
 NvmPartition *systemConfigurationPartition = NULL;
 NvmPartition *hardwareConfigurationPartition = NULL;
 NvmPartition *dfu_partition_global = NULL;
-static IOPinHandle_t *usb_io = &NULL;
+static IOPinHandle_t *usb_io = NULL;
 
 static bool usb_is_connected() {
   uint8_t vusb = 0;
@@ -174,7 +174,7 @@ static bool usb_is_connected() {
   IORead(&VUSB_DETECT, &vusb);
   IORead(&LED_G, &vusb2);
 
-  return (bool)vusb;
+  return (bool)(vusb | vusb2);
 }
 
 extern "C" int main(void) {


### PR DESCRIPTION
## What changed?
check both pins so that way if hwVersion is 0 but we are actually a hwVersion 7 we can still talk via USB. This makes sure that when a v7 bridge has hwVersion set to 0 it will still be able to access USB.

But this time on normal develop branch.


## How does it make Bristlemouth better?
Makes sure bridge can access USB.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
