### PR TITLE
remove wiper aggregations

### DIFF
--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -180,9 +180,6 @@ static void runController(void *param) {
             PmeDissolvedOxygenSensor *pme_dissolved_oxygen =
                 static_cast<PmeDissolvedOxygenSensor *>(curr);
             pme_dissolved_oxygen->aggregate();
-          } else if (curr->type == SENSOR_TYPE_PME_WIPE) {
-            PmeWipeSensor *pme_wiper = static_cast<PmeWipeSensor *>(curr);
-            pme_wiper->aggregate();
           } else if (curr->type == SENSOR_TYPE_BOREALIS) {
             BorealisSensor *level_statistics = static_cast<BorealisSensor *>(curr);
             level_statistics->aggregate();
@@ -316,7 +313,7 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
           if (pme_dissolved_oxygen_sub) {
             abstractSensorAddSensorSub(pme_dissolved_oxygen_sub);
           }
-          PmeWipe_t *pme_wiper_sub = createPmeWipeSub(reply.node_id, sample_duration_ms);
+          PmeWipe_t *pme_wiper_sub = createPmeWipeSub(reply.node_id);
           if (pme_wiper_sub) {
             abstractSensorAddSensorSub(pme_wiper_sub);
           }

--- a/src/apps/bridge/sensor_drivers/pmeWipeSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeWipeSensor.cpp
@@ -19,8 +19,6 @@
 #include "util.h"
 #include <new>
 
-static PmeWipe_t *CURRENT_SUB;
-
 bool PmeWipeSensor::subscribe() {
   bool rval = false;
   char *sub = static_cast<char *>(bm_malloc(BM_TOPIC_MAX_LEN));
@@ -71,91 +69,7 @@ void PmeWipeSensor::pmeWipeSubCallback(uint64_t node_id, const char *topic, uint
   }
 }
 
-void PmeWipeSensor::aggregate(void) {
-  char *log_buff = static_cast<char *>(bm_malloc(SENSOR_LOG_BUF_SIZE));
-  configASSERT(log_buff);
-  if (bm_semaphore_take(_mutex, BM_MAX_DELAY_UINT32) == BmOK) {
-    pme_wipe_aggregations_t wipe_aggs = {
-        .wipe_time_sec_mean = NAN,
-        .start1_mA_mean = NAN,
-        .avg_mA_mean = NAN,
-        .start2_mA_mean = NAN,
-        .final_mA_mean = NAN,
-        .rsource_mean = NAN,
-        .reading_count = 0,
-    };
-
-    if (wipe_time_sec.getNumSamples() >= MIN_READINGS_FOR_AGGREGATION) {
-      wipe_aggs.wipe_time_sec_mean = wipe_time_sec.getMean();
-      wipe_aggs.start1_mA_mean = start1_mA.getMean();
-      wipe_aggs.avg_mA_mean = avg_mA.getMean();
-      wipe_aggs.start2_mA_mean = start2_mA.getMean();
-      wipe_aggs.final_mA_mean = final_mA.getMean();
-      wipe_aggs.rsource_mean = rsource.getMean();
-      wipe_aggs.reading_count = reading_count;
-    }
-
-    BmErr err = send_spotter_log_aggregate(
-        "pme_wiper", wipe_aggs.reading_count, "%.3f,%.3f,%.3f,%.3f,%.3f,%.3f\n",
-        wipe_aggs.wipe_time_sec_mean, wipe_aggs.start1_mA_mean, wipe_aggs.avg_mA_mean,
-        wipe_aggs.start2_mA_mean, wipe_aggs.final_mA_mean, wipe_aggs.rsource_mean);
-    if (err != BmOK) {
-      bm_debug("ERROR: Failed to print PME Wiper data to AGG log, err: %d\n", err);
-    }
-
-    // TODO - figure out if we want to add to the report builder and how we will do it!
-    // reportBuilderAddToQueue(node_id, SENSOR_TYPE_PME_WIPE, static_cast<void *>(&wipe_aggs),
-    //                         sizeof(pme_wipe_aggregations_t), REPORT_BUILDER_SAMPLE_MESSAGE);
-
-    // Clear the buffers
-    memset(log_buff, 0, SENSOR_LOG_BUF_SIZE);
-    wipe_time_sec.clear();
-    start1_mA.clear();
-    avg_mA.clear();
-    start2_mA.clear();
-    final_mA.clear();
-    rsource.clear();
-    reading_count = 0;
-    bm_semaphore_give(_mutex);
-  } else {
-    bm_debug("Failed to take mutex for PME Wiper Sensor after getting a new reading\n");
-  }
-  bm_free(log_buff);
-}
-
-static BmErr pmeWiperCfgGetCb(uint8_t *payload) {
-  BmErr err = BmENODATA;
-  if (payload && CURRENT_SUB) {
-    BmConfigValue *msg = reinterpret_cast<BmConfigValue *>(payload);
-    size_t size = sizeof(AbstractSensor::m_reading_period_ms);
-    err = bcmp_config_decode_value(UINT32, msg->data, msg->data_length,
-                                   &CURRENT_SUB->m_reading_period_ms, &size);
-    if (err == BmOK) {
-      uint32_t averager_max_samples =
-          (CURRENT_SUB->m_reading_period_ms / CURRENT_SUB->agg_period_ms) +
-          PmeWipeSensor::N_SAMPLES_PAD;
-
-      // We can re-init the buffers here now that we have the reading period
-      // This will free the current buffer and re-malloc a new one
-      // so any data that may have been in the buffer will be lost
-      bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-                     "Updating the PME Wiper buffers with max samples: %" PRIu32 "\n",
-                     averager_max_samples);
-      CURRENT_SUB->wipe_time_sec.initBuffer(averager_max_samples);
-      CURRENT_SUB->start1_mA.initBuffer(averager_max_samples);
-      CURRENT_SUB->avg_mA.initBuffer(averager_max_samples);
-      CURRENT_SUB->start2_mA.initBuffer(averager_max_samples);
-      CURRENT_SUB->final_mA.initBuffer(averager_max_samples);
-      CURRENT_SUB->rsource.initBuffer(averager_max_samples);
-    } else {
-      bm_debug("Failed to decode PME Wiper config get, err: %d\n", err);
-    }
-    CURRENT_SUB = NULL;
-  }
-  return err;
-}
-
-PmeWipe_t *createPmeWipeSub(uint64_t node_id, uint32_t sample_duration_ms) {
+PmeWipe_t *createPmeWipeSub(uint64_t node_id) {
   PmeWipe_t *new_sub = static_cast<PmeWipe_t *>(bm_malloc(sizeof(PmeWipe_t)));
   if (new_sub) {
     new_sub = new (new_sub) PmeWipe_t();
@@ -167,26 +81,6 @@ PmeWipe_t *createPmeWipeSub(uint64_t node_id, uint32_t sample_duration_ms) {
       new_sub->type = SENSOR_TYPE_PME_WIPE;
       new_sub->next = NULL;
       new_sub->agg_period_ms = PmeWipeSensor::DEFAULT_PME_WIPER_READING_PERIOD_MS;
-
-      // This is the default value
-      uint32_t averager_max_samples = static_cast<uint32_t>(
-          ceil((sample_duration_ms / new_sub->agg_period_ms) + PmeWipeSensor::N_SAMPLES_PAD));
-
-      new_sub->wipe_time_sec.initBuffer(averager_max_samples);
-      new_sub->start1_mA.initBuffer(averager_max_samples);
-      new_sub->avg_mA.initBuffer(averager_max_samples);
-      new_sub->start2_mA.initBuffer(averager_max_samples);
-      new_sub->final_mA.initBuffer(averager_max_samples);
-      new_sub->rsource.initBuffer(averager_max_samples);
-      new_sub->reading_count = 0;
-
-      CURRENT_SUB = new_sub;
-      BmErr err = BmOK;
-      if (!bcmp_config_get(node_id, BM_CFG_PARTITION_SYSTEM,
-                           strlen(AppConfig::PME_WIPER_READING_PERIOD_MS),
-                           AppConfig::PME_WIPER_READING_PERIOD_MS, &err, pmeWiperCfgGetCb)) {
-        bm_debug("Failed to send PME Wiper config get\n");
-      }
 
     } else {
       bm_free(new_sub);

--- a/src/apps/bridge/sensor_drivers/pmeWipeSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/pmeWipeSensor.cpp
@@ -46,12 +46,6 @@ void PmeWipeSensor::pmeWipeSubCallback(uint64_t node_id, const char *topic, uint
     if (bm_semaphore_take(wipe_sensor->_mutex, BM_MAX_DELAY_UINT32) == BmOK) {
       static PmeWipeMsg::Data wipe_data;
       if (PmeWipeMsg::decode(wipe_data, data, data_len) == CborNoError) {
-        wipe_sensor->wipe_time_sec.addSample(wipe_data.wipe_time_sec);
-        wipe_sensor->start1_mA.addSample(wipe_data.start1_mA);
-        wipe_sensor->avg_mA.addSample(wipe_data.avg_mA);
-        wipe_sensor->start2_mA.addSample(wipe_data.start2_mA);
-        wipe_sensor->final_mA.addSample(wipe_data.final_mA);
-        wipe_sensor->rsource.addSample(wipe_data.rsource);
 
         wipe_sensor->reading_count++;
         BmErr err = wipe_sensor->send_spotter_log_individual(

--- a/src/apps/bridge/sensor_drivers/pmeWipeSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeWipeSensor.h
@@ -37,7 +37,6 @@ typedef struct PmeWipeSensor : public AbstractSensor {
 
 public:
   bool subscribe() override;
-  void aggregate(void);
 
 private:
   static void pmeWipeSubCallback(uint64_t node_id, const char *topic,
@@ -48,4 +47,4 @@ private:
   static constexpr char subtag[] = "/pme/wipe_data";
 } PmeWipe_t;
 
-PmeWipe_t *createPmeWipeSub(uint64_t node_id, uint32_t sample_duration_ms);
+PmeWipe_t *createPmeWipeSub(uint64_t node_id);

--- a/src/apps/bridge/sensor_drivers/pmeWipeSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeWipeSensor.h
@@ -20,12 +20,6 @@ typedef struct pme_wipe_aggregations_s {
 
 typedef struct PmeWipeSensor : public AbstractSensor {
   uint32_t agg_period_ms;
-  AveragingSampler wipe_time_sec;
-  AveragingSampler start1_mA;
-  AveragingSampler avg_mA;
-  AveragingSampler start2_mA;
-  AveragingSampler final_mA;
-  AveragingSampler rsource;
   uint32_t reading_count;
   int8_t node_position;
   uint32_t last_timestamp;


### PR DESCRIPTION
## What changed?
Removing aggregations of PME wiper data since the default interval is 4 hours, we are not going to be wiping more than once per sample duration.

### Testing:
I increased the wiper frequency to make sure we got some and here we can see several wipe logs in the SENS_IND, but none appearing in the SENS_AGG:
<img width="712" alt="Screenshot 2025-06-18 at 3 29 25 PM" src="https://github.com/user-attachments/assets/fc2727fd-477e-4e9f-aa77-4ce7b418f927" />



## How does it make Bristlemouth better?
This will prevent a bunch of nananananananananan logs in the aggregations file.


## Where should reviewers focus?
Small change so everything.


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
