### PR TITLE
Fix bridge LPM/USART3 interaction

### DIFF
--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -360,7 +360,6 @@ static bool bm_int_gpio_callback_fromISR(const void *pinHandle, uint8_t value, v
     ncp_rx = false;
   } else {
     xSemaphoreTakeFromISR(ncp_serial_lock, &xHigherPriorityTaskWoken);
-    lpmPeripheralActiveFromISR(LPM_USART3_RX); // Active low
     ncp_rx = true;
     HAL_UART_AbortReceive(&huart3);
     HAL_UARTEx_ReceiveToIdle_DMA(&huart3, const_cast<uint8_t *>(ncpRXBuff[ncpRXCurrBuff]),
@@ -650,9 +649,6 @@ void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t len) {
       ncpRXCurrBuff = (ncpRXCurrBuff + 1) % NCP_RX_BUFF_COUNT;
     }
   }
-
-  // Exit low power mode now that RX is complete
-  lpmPeripheralInactiveFromISR(LPM_USART3_RX);
   portYIELD_FROM_ISR(higherPriorityTaskWoken);
 }
 
@@ -699,7 +695,7 @@ static void ncpPreTxCb(SerialHandle_t *handle) { // called from task context
     xSemaphoreTake(ncp_serial_lock, portMAX_DELAY);
   }
   LL_EXTI_DisableIT_0_31(LL_EXTI_LINE_0);
-  lpmPeripheralActive(LPM_USART3);
+  lpmPeripheralActive(LPM_USART3_TX);
   LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_OUTPUT);
   IOWrite(&BM_INT, 0);
   vTaskDelay(pdMS_TO_TICKS(LPM_WAKE_TIME_MS));
@@ -719,7 +715,6 @@ static void ncpPostTxCb(SerialHandle_t *handle) { // called form ISR context
   LL_GPIO_SetPinMode(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_MODE_INPUT);
   LL_EXTI_EnableIT_0_31(LL_EXTI_LINE_0);
   LL_GPIO_SetPinPull(BM_INT_GPIO_Port, BM_INT_Pin, LL_GPIO_PULL_UP);
-  // LPM_USART3_RX will get set on the next rising edge
   lpmPeripheralInactiveFromISR(LPM_USART3_TX);
   portYIELD_FROM_ISR(
       higherPriorityTaskWoken == pdTRUE || higherPriorityTaskEventHandle == pdTRUE ? pdTRUE


### PR DESCRIPTION
## What changed?
We can actually recieve in STOP1 mode when using DMA/USART3 on bridge. So we don't need to enter/exit lpm when RXing at all! But for now we should still listen to the BM_INT pin to know when to RX via DMA.

I tested going into STOP1 when TX'ing but found that it didn't work. Looks like the TX line idles low (instead of high) between some of the TX events for some reason and it isn't necessary for this fix so we can leave it for later!

### Testing:
![Screenshot 2025-06-20 at 2 22 45 PM](https://github.com/user-attachments/assets/2ea4752c-b082-4121-942f-593efae08996)
Power testing showed that the Spotter + Bridge power consumption returned to the level of v0.12.2 bridges.


## How does it make Bristlemouth better?
This makes sure the bridge goes into STOP1 mode and saves some power!


## Where should reviewers focus?
Small pr so all the changes and testing!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
