### PR TITLE
fix: allow PME DO quality value greater than 1

### DIFF
--- a/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
+++ b/src/apps/bridge/sensor_drivers/pmeDissolvedOxygenSensor.h
@@ -37,7 +37,7 @@ typedef struct PmeDissolvedOxygenSensor : public AbstractSensor {
   static constexpr double DO_SAMPLE_MEMBER_MIN = -1.0;
   static constexpr double DO_SAMPLE_MEMBER_MAX = 100.0;
   static constexpr double QUALITY_SAMPLE_MEMBER_MIN = 0.0;
-  static constexpr double QUALITY_SAMPLE_MEMBER_MAX = 1.0;
+  static constexpr double QUALITY_SAMPLE_MEMBER_MAX = 2.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MIN = 0.0;
   static constexpr double DO_SATURATION_SAMPLE_MEMBER_MAX = 150.0;
   static constexpr double SALINITY_PPT_MEMBER_MIN = 0.0;


### PR DESCRIPTION
## What changed?

Changed bad data max threshold for quality value from PME DO sensor from 1.0 to 2.0, based on conversations with PME.

## How does it make Bristlemouth better?

Allows data to flow through the pipeline when Q > 1.0. Such data points previously would have been dropped and replaced with error signals.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
