### PR TITLE
Bridge Turns On Port 2 When Network Powers Back On

### DIFF
--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -123,8 +123,11 @@ void BridgePowerController::powerBusAndSetSignal(bool on, bool notifyL2) {
     xEventGroupSetBits(_busPowerEventGroup, signal_to_set);
     if (notifyL2) {
       bm_l2_netif_set_power(on);
+      // Must turn port 2 off if powering up the network,
+      // port 2 is not used on the bridge and disabling the port will provide
+      // power savings
       if (on) {
-        bm_l2_netif_enable_disable_port(2, !on);
+        bm_l2_netif_enable_disable_port(2, false);
       }
     }
     bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge bus power: %d\n",

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -123,8 +123,8 @@ void BridgePowerController::powerBusAndSetSignal(bool on, bool notifyL2) {
     xEventGroupSetBits(_busPowerEventGroup, signal_to_set);
     if (notifyL2) {
       bm_l2_netif_set_power(on);
-      if (!on) {
-        bm_l2_netif_enable_disable_port(2, on);
+      if (on) {
+        bm_l2_netif_enable_disable_port(2, !on);
       }
     }
     bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge bus power: %d\n",

--- a/src/apps/bridge/bridgePowerController.cpp
+++ b/src/apps/bridge/bridgePowerController.cpp
@@ -123,6 +123,9 @@ void BridgePowerController::powerBusAndSetSignal(bool on, bool notifyL2) {
     xEventGroupSetBits(_busPowerEventGroup, signal_to_set);
     if (notifyL2) {
       bm_l2_netif_set_power(on);
+      if (!on) {
+        bm_l2_netif_enable_disable_port(2, on);
+      }
     }
     bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge bus power: %d\n",
                    static_cast<int>(on));


### PR DESCRIPTION


## What changed?
Ensure port 2 is disabled when bridge power controller turns the network back on


## How does it make Bristlemouth better?
Saves power by disabling port 2.


## Where should reviewers focus?
The sequence of port power events that occurs here is as follows (from initialization):

1. Enable adin driver and turn on both ports bcl_init-> bristlemouth_init -> adin2111_init->adin_netdevice_enable
2. Disable port 2 bm_l2_netif_enable_disable_port
3. Wait 2 minutes for bridge initialization to finish and turn off the network power in the power controller module (bm_l2_netif_set_power->adin_netdevice_disable )
4.  Power up Bristlemouth network from the power controller module (bm_l2_netif_set_power-> adin_netdevice_enable )
  a. This is where the bug occurs, we turn on both ports here

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
