### PR TITLE
Add GNU Build IDs To Coredump To Track Coredumps To Symbol Files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,6 +163,8 @@ set(COMPILE_FLAGS
 	$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
 	$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 
+    -DMEMFAULT_USE_GNU_BUILD_ID=1
+
 	-Wformat=2
 	-Wformat-overflow
 	-Wformat-signedness

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,7 +163,7 @@ set(COMPILE_FLAGS
 	$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
 	$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 
-    -DMEMFAULT_USE_GNU_BUILD_ID=1
+    	-DMEMFAULT_USE_GNU_BUILD_ID=1
 
 	-Wformat=2
 	-Wformat-overflow


### PR DESCRIPTION
## What changed?
Build macro to utilize GNU Build IDs when generating Coredumps


## How does it make Bristlemouth better?
Properly tracks coredump to symbol files


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
