### PR TITLE
fix: clean up unhelpful comments

### DIFF
--- a/src/apps/bm_devkit/bm_loadcell/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/bm_loadcell/user_code/user_code.cpp
@@ -83,10 +83,6 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;

--- a/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/devkit_monitor/user_code/user_code.cpp
@@ -210,10 +210,6 @@ void loop(void) {
     }
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static uint32_t ledPulseTimer = uptimeGetMs();
   static uint32_t ledOnTimer = 0;
   static bool ledState = false;

--- a/src/apps/bm_devkit/hello_world/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/hello_world/user_code/user_code.cpp
@@ -1,15 +1,15 @@
 #include "user_code.h"
-#include "spotter.h"
-#include "pubsub.h"
+#include "app_util.h"
 #include "bristlefin.h"
 #include "bsp.h"
 #include "debug.h"
 #include "lwip/inet.h"
+#include "pubsub.h"
 #include "sensors.h"
+#include "spotter.h"
 #include "stm32_rtc.h"
 #include "task_priorities.h"
 #include "uptime.h"
-#include "app_util.h"
 
 #define LED_ON_TIME_MS 20
 #define LED_PERIOD_MS 1000
@@ -20,24 +20,18 @@ void setup(void) {
 
 void loop(void) {
   /* USER LOOP CODE GOES HERE */
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
-  static u_int32_t ledPulseTimer = uptimeGetMs();
-  static u_int32_t ledOnTimer = 0;
   static bool ledState = false;
+  static uint64_t ledLastScheduledOnTime = uptimeGetMs();
+  const uint64_t elapsedSinceOnTime = uptimeGetMs() - ledLastScheduledOnTime;
+
   // Turn LED1 on green every LED_PERIOD_MS milliseconds.
-  if (!ledState &&
-      ((u_int32_t)uptimeGetMs() - ledPulseTimer >= LED_PERIOD_MS)) {
+  if (!ledState && elapsedSinceOnTime >= LED_PERIOD_MS) {
+    ledLastScheduledOnTime += LED_PERIOD_MS;
     bristlefin.setLed(1, Bristlefin::LED_GREEN);
-    ledOnTimer = uptimeGetMs();
-    ledPulseTimer += LED_PERIOD_MS;
     ledState = true;
   }
   // If LED1 has been on for LED_ON_TIME_MS milliseconds, turn it off.
-  else if (ledState &&
-           ((u_int32_t)uptimeGetMs() - ledOnTimer >= LED_ON_TIME_MS)) {
+  else if (ledState && elapsedSinceOnTime >= LED_ON_TIME_MS) {
     bristlefin.setLed(1, Bristlefin::LED_OFF);
     ledState = false;
   }

--- a/src/apps/bm_devkit/nortek/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/nortek/user_code/user_code.cpp
@@ -285,10 +285,6 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;

--- a/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/rbr_coda_example/user_code/user_code.cpp
@@ -167,10 +167,6 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;

--- a/src/apps/bm_devkit/rx_live_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/rx_live_example/user_code/user_code.cpp
@@ -274,7 +274,7 @@ void loop() {
       printf("[rx-live-state] | tick: %llu, rtc: %s, rx_code: %d\n", uptimeGetMs(),
              rtcTimeBuffer, rx_code);
     }
-  } // \else
+  }
 
   if ((u_int32_t)uptimeGetMs() - _sample_timer_ms >= sample_duration_ms) {
     printf("[rx-live-state] :: GENERATING SAMPLE!\n");
@@ -298,10 +298,6 @@ void loop() {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;
@@ -317,4 +313,4 @@ void loop() {
     bristlefin.setLed(1, Bristlefin::LED_OFF);
     led1State = false;
   }
-} // \loop()
+} // loop()

--- a/src/apps/bm_devkit/sdi12_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/sdi12_example/user_code/user_code.cpp
@@ -185,10 +185,6 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;

--- a/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
@@ -109,24 +109,19 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
-  static u_int32_t ledPulseTimer = uptimeGetMs();
-  static u_int32_t ledOnTimer = 0;
-  static bool led1State = false;
+  static bool ledState = false;
+  static uint64_t ledLastScheduledOnTime = uptimeGetMs();
+  const uint64_t elapsedSinceOnTime = uptimeGetMs() - ledLastScheduledOnTime;
   // Turn LED1 on green every LED_PERIOD_MS milliseconds.
-  if (!led1State && ((u_int32_t)uptimeGetMs() - ledPulseTimer >= LED_PERIOD_MS)) {
+  if (!ledState && elapsedSinceOnTime >= LED_PERIOD_MS) {
+    ledLastScheduledOnTime += LED_PERIOD_MS;
     bristlefin.setLed(1, Bristlefin::LED_GREEN);
-    ledOnTimer = uptimeGetMs();
-    ledPulseTimer += LED_PERIOD_MS;
-    led1State = true;
+    ledState = true;
   }
   // If LED1 has been on for LED_ON_TIME_MS milliseconds, turn it off.
-  else if (led1State && ((u_int32_t)uptimeGetMs() - ledOnTimer >= LED_ON_TIME_MS)) {
+  else if (ledState && elapsedSinceOnTime >= LED_ON_TIME_MS) {
     bristlefin.setLed(1, Bristlefin::LED_OFF);
-    led1State = false;
+    ledState = false;
   }
 
   // Read a cluster of bytes if available

--- a/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/nortek/user_code/user_code.cpp
@@ -280,10 +280,6 @@ void loop(void) {
     led2State = false;
   }
 
-  /// This section demonstrates a simple non-blocking bare metal method for rollover-safe timed tasks,
-  ///   like blinking an LED.
-  /// More canonical (but more arcane) modern methods of implementing this kind functionality
-  ///   would bee to use FreeRTOS tasks or hardware timer ISRs.
   static u_int32_t ledPulseTimer = uptimeGetMs();
   static u_int32_t ledOnTimer = 0;
   static bool led1State = false;
@@ -294,7 +290,7 @@ void loop(void) {
     ledPulseTimer += LED_PERIOD_MS;
     led1State = true;
   }
-    // If LED1 has been on for LED_ON_TIME_MS milliseconds, turn it off.
+  // If LED1 has been on for LED_ON_TIME_MS milliseconds, turn it off.
   else if (led1State && ((u_int32_t)uptimeGetMs() - ledOnTimer >= LED_ON_TIME_MS)) {
     IOWrite(&LED_RED, 1);
     led1State = false;


### PR DESCRIPTION
## What changed?

Removed an unhelpful comment that was repeated in many apps.
Also simplified the periodic LED blink in hello world and serial payload example

## How does it make Bristlemouth better?

Improving the friendliness of the code so it's more welcoming and approachable.

## Where should reviewers focus?

The LED blink code feels a little overcomplicated. I just quickly simplified the 2 apps that people look at the most. I chose not to continue sweeping up around the codebase, since it could be a neverending journey. Let me know if you disagree.

I also only fixed up the whitespace in a limited way without running clang-format on these entire files. Doing so would modify some of these files on almost every line. Let me know if you think they should be formatted anyway.

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
