### PR TITLE
make sure everything is using sensorBmLogEnable instead of pmeLogEnable

### DIFF
--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/pme_do_sensor.cpp
@@ -20,7 +20,7 @@
 #define LAST_WIPE_EPOCH_KEY "lastWipeEpochS"
 #define FW_VERSION_KEY "fwVersion"
 
-extern uint32_t pmeLogEnable;
+extern uint32_t sensorBmLogEnable;
 extern uint32_t sensorDebugTxEnable;
 
 uint32_t lastWipeEpochS = 0;
@@ -233,7 +233,7 @@ bool PmeSensor::getDoData(PmeDissolvedOxygenMsg::Data &d, float salinityPpt) {
                 d.do_saturation_pct, d.temperature_deg_c, salinityPpt,
                 salinityFactor(d.temperature_deg_c, salinityPpt), d.quality);
         // Make spotter_log conditional on system config
-        if (pmeLogEnable == 1) {
+        if (sensorBmLogEnable == 1) {
           // Modified for new data output
           spotter_log(0, PME_DO_RAW_LOG, USE_TIMESTAMP, DOT_stats);
         }
@@ -291,7 +291,7 @@ bool PmeSensor::getWipeData(PmeWipeMsg::Data &w) {
     char rtc_time_str[32] = {};
     rtcPrint(rtc_time_str, NULL);
 
-    if (pmeLogEnable) {
+    if (sensorBmLogEnable) {
       spotter_log(0, PME_WIPE_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", %s, line: %.*s\n",
                   uptimeGetMs(), _SNpayload_buffer, wipe_read_len, _WIPEpayload_buffer);
     }

--- a/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/pme_do_sensor/user_code/user_code.cpp
@@ -41,8 +41,8 @@
 - Follow as bm_pub_wl is developed
 */
 
-uint32_t pmeLogEnable = 1;
-bool pmeLogEnableCfg = false;
+uint32_t sensorBmLogEnable = 1;
+bool sensorBmLogEnableCfg = false;
 uint32_t pmeDOTIntervalS = 600;
 bool pmeDOTIntervalSCfg = false;
 uint32_t pmeWipeIntervalS = 14400;
@@ -113,8 +113,8 @@ void debugTx(void) {}
 void setup(void) {
   // Load system configuration & initialize if not configured by user
   if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_LOG_ENABLE,
-                      strlen(SENSOR_BM_LOG_ENABLE), &pmeLogEnable)) {
-    pmeLogEnableCfg = true;
+                      strlen(SENSOR_BM_LOG_ENABLE), &sensorBmLogEnable)) {
+    sensorBmLogEnableCfg = true;
   }
   if (get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_BM_DOT_INTERVAL_S,
                       strlen(SENSOR_BM_DOT_INTERVAL_S), &pmeDOTIntervalS)) {
@@ -143,10 +143,10 @@ void setup(void) {
   pmeWipeTopicStrLen = createPmeWipeDataTopic();
   lastWipeEpochS = loadLastWipeEpoch();
   printf("Last wipe time: %lu\n", lastWipeEpochS);
-  if (pmeLogEnableCfg == true) {
-    printf("User-defined pmeLogEnable found: %" PRIu32 "\n", pmeLogEnable);
+  if (sensorBmLogEnableCfg == true) {
+    printf("User-defined sensorBmLogEnable found: %" PRIu32 "\n", sensorBmLogEnable);
   } else {
-    printf("No user-defined pmeLogEnable - defaulting to: %" PRIu32 "\n", pmeLogEnable);
+    printf("No user-defined sensorBmLogEnable - defaulting to: %" PRIu32 "\n", sensorBmLogEnable);
   }
 
   if (pmeDOTIntervalSCfg == true) {


### PR DESCRIPTION
## What changed?
Changed variable names and prints to reference the correct  `sensorBmLogEnable` config and no longer refer to the `pmeLogEnable`.


## How does it make Bristlemouth better?
Makes sure the config and prints are matching.


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
