### PR TITLE
fix: remove bridge handling of borealis recording status

### DIFF
--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -39,7 +39,6 @@ static constexpr char config_borealis_tx_spl_threshold[] = "borealisTxSplThresho
 static constexpr char config_borealis_tx_max_iqr_threshold[] = "borealisTxMaxIqrThreshold";
 static constexpr char config_borealis_tx_entropy_threshold[] = "borealisTxEntropyThreshold";
 
-
 /*!
  @brief Initialize Borealis Sensor Module
 
@@ -503,17 +502,6 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
           err = BmOK;
         } else {
           err = BmEBADMSG;
-        }
-      } break;
-      case BOREALIS_RECORDING_STATUS: {
-        struct borealis_recording_status d;
-        if (borealis_recording_status_decode(&d, (uint8_t *)data, data_len) == CborNoError) {
-          err = borealis->send_spotter_log_individual(
-              "borealis", d.header,
-              MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms),
-              "%.u,%.3f,%.3f,%.*s\n", d.flags, d.seconds_written, d.seconds_free,
-              d.filename_length, d.filename);
-          bm_free(d.filename);
         }
       } break;
       case HYDROTWIN_LDR: {


### PR DESCRIPTION
## What changed?

Removed bridge handler of borealis recording status messages. These are already logged on Spotter's SD card in borealis.log.

## How does it make Bristlemouth better?

Recording status is noise in the context of the SENS_IND.csv log of acoustic spectral data, especially for production validation tooling.

## Where should reviewers focus?

I removed it entirely rather than leave a case with a no-op comment. Disagree?

## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
