### PR TITLE
Utilize Git SHA For bm_protocol When Building External Apps

### DIFF
--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -7,7 +7,7 @@
 
 set(GIT_CMD git)
 set(GIT_ARGS_SHA describe --match ForceNone --abbrev=8 --always)
-execute_process(COMMAND ${GIT_CMD} ${GIT_ARGS_SHA}
+execute_process(COMMAND ${GIT_CMD} -C ${CMAKE_CURRENT_LIST_DIR} ${GIT_ARGS_SHA}
                 OUTPUT_VARIABLE GIT_SHA
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
## What changed?
Obtains Git SHA for `bm_protocol` repository when building external apps.


## How does it make Bristlemouth better?
Ensures consistency with external apps utilizing the `bm_protocol`  repository commit hash when obtaining system versioning information.


## Where should reviewers focus?
This can be tested on a Borealis.
The following is what the generated `version.c` file looked like before in Borealis:
![image](https://github.com/user-attachments/assets/53876d69-9de4-49b7-9b74-d502589771e7)

This is what the `version.c` file looks like after this update in Borealis:
![image](https://github.com/user-attachments/assets/184428bb-cd43-4933-8ec4-dd3f71c7d20f)


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
