### PR TITLE
If Power Controller Is Disabled, Avoid Leaking Memory; Format Hydrotwin HDR Data Nicely

### DIFF
--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -1,7 +1,6 @@
 extern "C" {
 #include "util.h"
 }
-#include "app_config.h"
 #include "app_util.h"
 #include "bm_config.h"
 #include "bm_os.h"
@@ -14,6 +13,7 @@ extern "C" {
 #include "pubsub.h"
 #include "sensorController.h"
 #include "spectral_entropy.h"
+#include "stm32_rtc.h"
 #include "uptime.h"
 #include <inttypes.h>
 #include <math.h>
@@ -47,7 +47,7 @@ static constexpr char config_borealis_tx_entropy_threshold[] = "borealisTxEntrop
 void BorealisSensor::init(void) {
   static constexpr uint32_t MAX_SAMPLES_PER_REPORT = 2;
   uint32_t samples_per_report = 0;
-  power_config_s pwr_cfg = {};
+  m_pwr_cfg = getPowerConfigs();
 
   m_aggregation_reports = report_builder_get_transmit_aggregations();
   samples_per_report = report_builder_get_samples_per_report();
@@ -60,7 +60,7 @@ void BorealisSensor::init(void) {
                    samples_per_report, MAX_SAMPLES_PER_REPORT);
   }
 
-  if (pwr_cfg.subsampleEnabled) {
+  if (m_pwr_cfg.subsampleEnabled) {
     bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_WARNING, USE_HEADER,
                    "Subsampling enabled, be aware that BOREALIS data will only transmit last "
                    "collected level statistics message in sampleDurationsMs period remotely\n");
@@ -365,8 +365,8 @@ BmErr BorealisSensor::hydrotwinSendSpotterLog(const uint8_t *data, uint16_t data
         SensorHeaderMsg::Data header = {
             hydrotwin_message_version,
             uptimeGetMs(),
-            bm_ticks_to_ms(bm_get_tick_count()),
-            0,
+            rtcGetMicrosecondsSimple(),
+            rtcGetMicrosecondsSimple(),
         };
         err = send_spotter_log_individual(
             "hydrotwin", header,
@@ -449,8 +449,9 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
               "borealis", d.header,
               MAX_BOREALIS_READING_PERIOD_MS(borealis->m_reading_period_ms), "%.3f,%u,%.*s\n",
               d.dt, d.first_band_index, d.levels_length, d.levels);
-          // Only insert spectrum into list if aggregation reports are enabled
-          if (borealis->m_aggregation_reports) {
+          // Only insert spectrum into list if aggregation reports and power controller are enabled
+          if (borealis->m_aggregation_reports &&
+              borealis->m_pwr_cfg.bridgePowerControllerEnabled) {
             // Base64 decodes to 3/4 of input size.
             // There are two 12-bit band values per 3 bytes.
             // 3/4 * 2/3 = 1/2
@@ -497,7 +498,8 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
             bm_debug("Failed to send borealis aggregated log to spotter, reason: %d\n", err);
           }
 
-          if (!borealis->m_aggregation_reports) {
+          if (!borealis->m_aggregation_reports ||
+              !borealis->m_pwr_cfg.bridgePowerControllerEnabled) {
             // Free levels information here as it will not be aggregated
             bm_free(d.levels);
           } else {
@@ -517,7 +519,8 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
         }
 
         err = borealis->hydrotwinSendSpotterLog(data, data_len, sub_type);
-        if (borealis->m_aggregation_reports) {
+        if (borealis->m_aggregation_reports &&
+            borealis->m_pwr_cfg.bridgePowerControllerEnabled) {
           borealis->tracking_data.ldr.buf = static_cast<uint8_t *>(bm_malloc(data_len));
 
           if (borealis->tracking_data.ldr.buf) {
@@ -569,6 +572,10 @@ static void borealisLevelsDurationEval(bool default_config, uint64_t node_id,
   // Subtract 20 seconds as a buffer for BOREALIS boot, time it takes to get RTC and reporting time
   float recommended_sample_duration_s = sample_duration_ms / 1000.0 - 20.0;
   uint8_t num_level_stats_per_duration = 0;
+
+  if (!pwr_cfg.bridgePowerControllerEnabled) {
+    return;
+  }
 
   if (period_s == 0.0) {
     bridgeLogPrint(BRIDGE_SYS, BM_COMMON_LOG_LEVEL_WARNING, USE_HEADER,

--- a/src/apps/bridge/sensor_drivers/borealisSensor.h
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.h
@@ -2,6 +2,7 @@
 
 #include "FreeRTOS.h"
 #include "abstractSensor.h"
+#include "app_config.h"
 #include "bm_borealis.h"
 #include "cbor_sensor_report_encoder.h"
 #include "semphr.h"
@@ -49,6 +50,7 @@ public:
   bool m_aggregation_reports;
   uint32_t m_hydrotwin_ldr_minute;
   uint32_t m_hydrotwin_hdr_minute;
+  power_config_s m_pwr_cfg;
 
   // public static constants
   static constexpr uint8_t REPORT_NAN_ERROR_VALUE = 0xFF;

--- a/src/lib/drivers/stm32_rtc.c
+++ b/src/lib/drivers/stm32_rtc.c
@@ -163,6 +163,13 @@ BaseType_t rtcSet(const RTCTimeAndDate_t *timeAndDate) {
   return rval;
 }
 
+uint64_t rtcGetMicrosecondsSimple(void) {
+  RTCTimeAndDate_t time_and_date = {};
+  rtcGet(&time_and_date);
+
+  return rtcGetMicroSeconds(&time_and_date);
+}
+
 uint64_t rtcGetMicroSeconds(RTCTimeAndDate_t *timeAndDate){
   int i;
   uint64_t microseconds = 0;

--- a/src/lib/drivers/stm32_rtc.h
+++ b/src/lib/drivers/stm32_rtc.h
@@ -30,6 +30,7 @@ BaseType_t rtcInit();
 BaseType_t rtcSet(const RTCTimeAndDate_t *timeAndDate);
 BaseType_t rtcGet(RTCTimeAndDate_t *timeAndDate);
 BaseType_t rtcPrint(char* buffer, RTCTimeAndDate_t* timeAndDate);
+uint64_t rtcGetMicrosecondsSimple(void);
 uint64_t rtcGetMicroSeconds(RTCTimeAndDate_t *timeAndDate);
 bool logRtcGetTimeStr(char *timeStr, size_t len, bool epoch);
 bool isRTCSet();


### PR DESCRIPTION
## What changed?
Do not track data if it will never be reported.
Data will never be reported if aggregation reports are disabled or the power controller is disabled.
Formats hydrotwin HDR `SENS_IND` log statements to be more cohesive.

## How does it make Bristlemouth better?
Prevents memory leak.
Prevents confusion in users when viewing SENS_IND file.


## Where should reviewers focus?
Mainly the memory leak conditions.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
