### PR TITLE
Fix/hydrotwin SENS_IND column

### DIFF
--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -369,10 +369,10 @@ BmErr BorealisSensor::hydrotwinSendSpotterLog(const uint8_t *data, uint16_t data
       } else if (type == HYDROTWIN_HDR) {
         static constexpr uint8_t hydrotwin_message_version = 1;
         SensorHeaderMsg::Data header = {
-            hydrotwin_message_version,
-            uptimeGetMs(),
-            rtcGetMicrosecondsSimple(),
-            rtcGetMicrosecondsSimple(),
+            .version = hydrotwin_message_version,
+            .reading_time_utc_ms = rtcGetMicrosecondsSimple() / 1000,
+            .reading_uptime_millis = uptimeGetMs(),
+            .sensor_reading_time_ms = rtcGetMicrosecondsSimple() / 1000,
         };
         err = send_spotter_log_individual(
             "hydrotwin", header,


### PR DESCRIPTION
## What changed?
Fix SENS_IND timestamp columns for Hydrotwin HDR messages.


## How does it make Bristlemouth better?
Ensures consistency between sensors on Spotter SD card logs.


## Where should reviewers focus?
The following is a Hydrotwin HDR message SENS_IND output after this change:

```
d9188504eff10d72,1,hydrotwin,190020,1754315539.683,1754315539.683,hAEaaJEdPoIYHAmjCBgcFRgcEQk=
```
[0002_SENS_IND.csv](https://github.com/user-attachments/files/21584811/0002_SENS_IND.csv)

The following is what the SENS_IND output looked like before this change:

```
4b5316bd9602fe4b,1,hydrotwin,1754073143925000,116.872,1754073143925.000,hAEaaI1AIoIYHAmkBRgbBwEVAREJ
```
[0000_SENS_IND.csv](https://github.com/user-attachments/files/21584818/0000_SENS_IND.csv)



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
