### PR TITLE
Feature/serial bridge subscribe

### DIFF
--- a/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_bridge/user_code/user_code.cpp
@@ -1,16 +1,46 @@
+#include "bm_os.h"
 #include "bm_serial.h"
+#include "bristlefin.h"
 #include "cobs.h"
 #include "payload_uart.h"
 #include "pubsub.h"
+#include "sensors.h"
 #include "task_priorities.h"
+#include <inttypes.h>
 #include <string.h>
 
+typedef enum {
+  BM_NONE,
+  BM_SUB,
+} __attribute__((__packed__)) bm_serial_tx_message_t;
+typedef struct {
+  uint8_t type;
+  uint32_t length;
+  uint8_t data[0];
+} bm_serial_tx_t;
 static bm_serial_callbacks_t callbacks;
 static constexpr size_t rx_buf_size = 2048;
 static uint8_t rx_buffer[rx_buf_size];
 static size_t rx_idx = 0;
 static constexpr size_t packet_buf_size = rx_buf_size;
 static uint8_t packet_buffer[rx_buf_size];
+
+static bool tx_cb(const uint8_t *buff, size_t len, bm_serial_message_t message) {
+  (void)message;
+  PLUART::write((uint8_t *)buff, len);
+  return true;
+}
+
+static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
+                           const uint8_t *data, uint16_t data_len, uint8_t type,
+                           uint8_t version) {
+  printf("Publishing To Topic: %s\n", topic);
+  bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version);
+}
+
+static bool sub_cb(const char *topic, uint16_t topic_len) {
+  return bm_sub_wl(topic, topic_len, sub_message_cb);
+}
 
 static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
                    const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
@@ -28,7 +58,17 @@ void setup() {
 
   memset(&callbacks, 0, sizeof(bm_serial_callbacks_t));
   callbacks.pub_fn = pub_cb;
+  callbacks.sub_fn = sub_cb;
+  callbacks.tx_fn = tx_cb;
   bm_serial_set_callbacks(&callbacks);
+  bristlefin.enableVbus();
+  // ensure Vbus stable before enable Vout with a 5ms delay.
+  vTaskDelay(pdMS_TO_TICKS(5));
+  // enable Vout, 12V by default.
+  bristlefin.enableVout();
+  // enable 5V out.
+  bristlefin.enable5V();
+  bristlefin.enable3V();
 }
 
 static void reset() {

--- a/src/apps/bristleback_apps/serial_bridge/CMakeLists.txt
+++ b/src/apps/bristleback_apps/serial_bridge/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(APP_DIR ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
+set(SERIAL_BRIDGE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../common/serial_bridge)
 
 set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
+    ${SERIAL_BRIDGE_DIR}/serial_bridge.cpp
 )
 
 set(APP_INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/user_code
+    ${SERIAL_BRIDGE_DIR}
 )
 
 set(APP_LIBS

--- a/src/apps/bristleback_apps/serial_bridge/CMakeLists.txt
+++ b/src/apps/bristleback_apps/serial_bridge/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(APP_DIR ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
+
+set(APP_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
+)
+
+set(APP_INCLUDES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/user_code
+)
+
+set(APP_LIBS
+)
+
+set(APP_DEFINES
+    APP_NAME="${APP_NAME}"
+    # Add network stress test functions
+    STRESS_TEST_ENABLE
+)
+
+# Send APP_DEFINES to parent scope (otherwise we can't append to the
+# list above)
+set(APP_DEFINES "${APP_DEFINES}" PARENT_SCOPE)
+set(APP_LIBS "${APP_LIBS}" PARENT_SCOPE)
+set(APP_FILES "${APP_FILES}" PARENT_SCOPE)
+set(APP_INCLUDES "${APP_INCLUDES}" PARENT_SCOPE)

--- a/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
@@ -1,52 +1,115 @@
+#include "user_code.h"
 #include "bm_os.h"
 #include "bm_serial.h"
-#include "bristlefin.h"
 #include "cobs.h"
 #include "payload_uart.h"
 #include "pubsub.h"
-#include "sensors.h"
 #include "task_priorities.h"
-#include <inttypes.h>
 #include <string.h>
 
-typedef enum {
-  BM_NONE,
-  BM_SUB,
-} __attribute__((__packed__)) bm_serial_tx_message_t;
-typedef struct {
-  uint8_t type;
-  uint32_t length;
-  uint8_t data[0];
-} bm_serial_tx_t;
-static bm_serial_callbacks_t callbacks;
-static constexpr size_t rx_buf_size = 2048;
-static uint8_t rx_buffer[rx_buf_size];
-static size_t rx_idx = 0;
-static constexpr size_t packet_buf_size = rx_buf_size;
-static uint8_t packet_buffer[rx_buf_size];
+static constexpr size_t RX_BUF_SIZE = 2048;
 
+struct BmSerialBridgeCtx {
+  bm_serial_callbacks_t callbacks;
+  struct {
+    size_t idx;
+    uint8_t buffer[RX_BUF_SIZE];
+  } rx;
+  struct {
+    uint8_t buffer[RX_BUF_SIZE];
+  } packet;
+};
+
+static struct BmSerialBridgeCtx_t ctx; //Serial Bridge Context
+
+/*!
+ @brief Serial Transmit Callback For bm_serial Library
+
+ @details Raw bytes (buff) are passed from the bm_serial library to this
+          function, which will output data to the PLUART interface.
+
+ @param buff Buffer to transmit serially
+ @param len Length of buffer to transmit
+ @param message Unused
+
+ @return true always
+ */
 static bool tx_cb(const uint8_t *buff, size_t len, bm_serial_message_t message) {
   (void)message;
   PLUART::write((uint8_t *)buff, len);
   return true;
 }
 
+/*!
+ @brief Subscription Callback When Topic Of Interest Is Published To Network
+
+ @details Passes topic information and data serially to serially connected
+          device.
+
+ @param node_id Node ID which published the message
+ @param topic Topic message was published on
+ @param topic_len topic length
+ @param data Data associated with topic, can be NULL
+ @param data_len Length of data
+ @param type Topic type
+ @param version Topic version
+ */
 static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
                            const uint8_t *data, uint16_t data_len, uint8_t type,
                            uint8_t version) {
-  printf("Publishing To Topic: %s\n", topic);
-  bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version);
+  if (bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version) != BM_SERIAL_OK) {
+    printf("Failed to publish message to serial device\n");
+
+  } else {
+    printf("Publishing To Topic: %s\n", topic);
+  }
 }
 
+/*!
+ @brief Subscription Callback For bm_serial Library
+
+ @details When serial message is received for this type of message, subscribe
+          to the topic of interest on the Bristlemouth network and pass it
+          the received data through to the serially connected device.
+
+ @param topic Topic to subscribe to
+ @param topic_len Length of topic
+
+ @return True on success, false on failure
+ */
 static bool sub_cb(const char *topic, uint16_t topic_len) {
   return bm_sub_wl(topic, topic_len, sub_message_cb);
 }
 
+/*!
+ @brief Publish Callback For bm_serial Library
+
+ @details Handles publishing data to bristlemouth network from serially
+          connected device.
+
+ @param topic Topic to publish to
+ @param topic_len Length of topic
+ @param node_id Unused
+ @param payload Data to publish can be NULL
+ @param len Length of data
+ @param type Topic type
+ @param version Topic version
+
+ @return 
+ */
 static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
                    const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
   (void)node_id;
   printf("publishing %u bytes to %.*s\n", len, topic_len, topic);
   return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
+}
+
+/*!
+ @brief Reset RX Buffer
+ */
+static void serial_rx_reset() {
+  ctx.rx.idx = 0;
+  memset(ctx.rx.buffer, 0, RX_BUF_SIZE);
 }
 
 void setup() {
@@ -56,11 +119,11 @@ void setup() {
   PLUART::setUseLineBuffer(false);
   PLUART::enable();
 
-  memset(&callbacks, 0, sizeof(bm_serial_callbacks_t));
-  callbacks.pub_fn = pub_cb;
-  callbacks.sub_fn = sub_cb;
-  callbacks.tx_fn = tx_cb;
-  bm_serial_set_callbacks(&callbacks);
+  memset(&ctx.callbacks, 0, sizeof(bm_serial_callbacks_t));
+  ctx.callbacks.pub_fn = pub_cb;
+  ctx.callbacks.sub_fn = sub_cb;
+  ctx.callbacks.tx_fn = tx_cb;
+  bm_serial_set_callbacks(&ctx.callbacks);
   IOWrite(&BB_VBUS_EN, 0);
   // ensure Vbus stable before enable Vout with a 5ms delay.
   vTaskDelay(pdMS_TO_TICKS(5));
@@ -68,24 +131,20 @@ void setup() {
   IOWrite(&BB_PL_BUCK_EN, 0);
 }
 
-static void reset() {
-  rx_idx = 0;
-  memset(rx_buffer, 0, rx_buf_size);
-}
-
 void loop() {
   while (PLUART::byteAvailable()) {
     const uint8_t b = PLUART::readByte();
-    rx_buffer[rx_idx++] = b;
-    if (rx_idx >= rx_buf_size) {
+    ctx.rx.buffer[ctx.rx.idx++] = b;
+    if (ctx.rx.idx >= RX_BUF_SIZE) {
       printf("buffer full, resetting\n");
-      reset();
+      serial_rx_reset();
     } else {
       if (b == 0) {
         cobs_decode_result result =
-            cobs_decode(packet_buffer, packet_buf_size, rx_buffer, rx_idx - 1);
+            cobs_decode(ctx.packet.buffer, RX_BUF_SIZE, ctx.rx.buffer, ctx.rx.idx - 1);
         if (result.status == COBS_DECODE_OK) {
-          bm_serial_packet_t *packet = reinterpret_cast<bm_serial_packet_t *>(packet_buffer);
+          bm_serial_packet_t *packet =
+              reinterpret_cast<bm_serial_packet_t *>(ctx.packet.buffer);
           bm_serial_error_e err = bm_serial_process_packet(packet, result.out_len);
           if (err != BM_SERIAL_OK) {
             printf("packet processing error: %d\n", err);
@@ -93,7 +152,7 @@ void loop() {
         } else {
           printf("cobs decode error: %d\n", result.status);
         }
-        reset();
+        serial_rx_reset();
       }
     }
   }

--- a/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
@@ -78,7 +78,7 @@ static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_l
  @return True on success, false on failure
  */
 static bool sub_cb(const char *topic, uint16_t topic_len) {
-  return bm_sub_wl(topic, topic_len, sub_message_cb);
+  return bm_sub_wl(topic, topic_len, sub_message_cb) == BmOK;
 }
 
 /*!

--- a/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
@@ -1,129 +1,11 @@
 #include "user_code.h"
-#include "bm_os.h"
-#include "bm_serial.h"
-#include "cobs.h"
-#include "payload_uart.h"
-#include "pubsub.h"
-#include "task_priorities.h"
+#include "bsp.h"
+#include "io.h"
+#include "serial_bridge.h"
 #include <string.h>
 
-static constexpr size_t RX_BUF_SIZE = 2048;
-
-struct BmSerialBridgeCtx {
-  bm_serial_callbacks_t callbacks;
-  struct {
-    size_t idx;
-    uint8_t buffer[RX_BUF_SIZE];
-  } rx;
-  struct {
-    uint8_t buffer[RX_BUF_SIZE];
-  } packet;
-};
-
-static struct BmSerialBridgeCtx_t ctx; //Serial Bridge Context
-
-/*!
- @brief Serial Transmit Callback For bm_serial Library
-
- @details Raw bytes (buff) are passed from the bm_serial library to this
-          function, which will output data to the PLUART interface.
-
- @param buff Buffer to transmit serially
- @param len Length of buffer to transmit
- @param message Unused
-
- @return true always
- */
-static bool tx_cb(const uint8_t *buff, size_t len, bm_serial_message_t message) {
-  (void)message;
-  PLUART::write((uint8_t *)buff, len);
-  return true;
-}
-
-/*!
- @brief Subscription Callback When Topic Of Interest Is Published To Network
-
- @details Passes topic information and data serially to serially connected
-          device.
-
- @param node_id Node ID which published the message
- @param topic Topic message was published on
- @param topic_len topic length
- @param data Data associated with topic, can be NULL
- @param data_len Length of data
- @param type Topic type
- @param version Topic version
- */
-static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
-                           const uint8_t *data, uint16_t data_len, uint8_t type,
-                           uint8_t version) {
-  if (bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version) != BM_SERIAL_OK) {
-    printf("Failed to publish message to serial device\n");
-
-  } else {
-    printf("Publishing To Topic: %s\n", topic);
-  }
-}
-
-/*!
- @brief Subscription Callback For bm_serial Library
-
- @details When serial message is received for this type of message, subscribe
-          to the topic of interest on the Bristlemouth network and pass it
-          the received data through to the serially connected device.
-
- @param topic Topic to subscribe to
- @param topic_len Length of topic
-
- @return True on success, false on failure
- */
-static bool sub_cb(const char *topic, uint16_t topic_len) {
-  return bm_sub_wl(topic, topic_len, sub_message_cb) == BmOK;
-}
-
-/*!
- @brief Publish Callback For bm_serial Library
-
- @details Handles publishing data to bristlemouth network from serially
-          connected device.
-
- @param topic Topic to publish to
- @param topic_len Length of topic
- @param node_id Unused
- @param payload Data to publish can be NULL
- @param len Length of data
- @param type Topic type
- @param version Topic version
-
- @return 
- */
-static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
-                   const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
-  (void)node_id;
-  printf("publishing %u bytes to %.*s\n", len, topic_len, topic);
-  return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
-}
-
-/*!
- @brief Reset RX Buffer
- */
-static void serial_rx_reset() {
-  ctx.rx.idx = 0;
-  memset(ctx.rx.buffer, 0, RX_BUF_SIZE);
-}
-
 void setup() {
-  PLUART::init(USER_TASK_PRIORITY);
-  PLUART::setBaud(115200);
-  PLUART::setUseByteStreamBuffer(true);
-  PLUART::setUseLineBuffer(false);
-  PLUART::enable();
-
-  memset(&ctx.callbacks, 0, sizeof(bm_serial_callbacks_t));
-  ctx.callbacks.pub_fn = pub_cb;
-  ctx.callbacks.sub_fn = sub_cb;
-  ctx.callbacks.tx_fn = tx_cb;
-  bm_serial_set_callbacks(&ctx.callbacks);
+  serial_bridge_init();
   IOWrite(&BB_VBUS_EN, 0);
   // ensure Vbus stable before enable Vout with a 5ms delay.
   vTaskDelay(pdMS_TO_TICKS(5));
@@ -131,29 +13,4 @@ void setup() {
   IOWrite(&BB_PL_BUCK_EN, 0);
 }
 
-void loop() {
-  while (PLUART::byteAvailable()) {
-    const uint8_t b = PLUART::readByte();
-    ctx.rx.buffer[ctx.rx.idx++] = b;
-    if (ctx.rx.idx >= RX_BUF_SIZE) {
-      printf("buffer full, resetting\n");
-      serial_rx_reset();
-    } else {
-      if (b == 0) {
-        cobs_decode_result result =
-            cobs_decode(ctx.packet.buffer, RX_BUF_SIZE, ctx.rx.buffer, ctx.rx.idx - 1);
-        if (result.status == COBS_DECODE_OK) {
-          bm_serial_packet_t *packet =
-              reinterpret_cast<bm_serial_packet_t *>(ctx.packet.buffer);
-          bm_serial_error_e err = bm_serial_process_packet(packet, result.out_len);
-          if (err != BM_SERIAL_OK) {
-            printf("packet processing error: %d\n", err);
-          }
-        } else {
-          printf("cobs decode error: %d\n", result.status);
-        }
-        serial_rx_reset();
-      }
-    }
-  }
-}
+void loop() { serial_bridge_handle(); }

--- a/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_bridge/user_code/user_code.cpp
@@ -1,0 +1,100 @@
+#include "bm_os.h"
+#include "bm_serial.h"
+#include "bristlefin.h"
+#include "cobs.h"
+#include "payload_uart.h"
+#include "pubsub.h"
+#include "sensors.h"
+#include "task_priorities.h"
+#include <inttypes.h>
+#include <string.h>
+
+typedef enum {
+  BM_NONE,
+  BM_SUB,
+} __attribute__((__packed__)) bm_serial_tx_message_t;
+typedef struct {
+  uint8_t type;
+  uint32_t length;
+  uint8_t data[0];
+} bm_serial_tx_t;
+static bm_serial_callbacks_t callbacks;
+static constexpr size_t rx_buf_size = 2048;
+static uint8_t rx_buffer[rx_buf_size];
+static size_t rx_idx = 0;
+static constexpr size_t packet_buf_size = rx_buf_size;
+static uint8_t packet_buffer[rx_buf_size];
+
+static bool tx_cb(const uint8_t *buff, size_t len, bm_serial_message_t message) {
+  (void)message;
+  PLUART::write((uint8_t *)buff, len);
+  return true;
+}
+
+static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
+                           const uint8_t *data, uint16_t data_len, uint8_t type,
+                           uint8_t version) {
+  printf("Publishing To Topic: %s\n", topic);
+  bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version);
+}
+
+static bool sub_cb(const char *topic, uint16_t topic_len) {
+  return bm_sub_wl(topic, topic_len, sub_message_cb);
+}
+
+static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
+                   const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
+  (void)node_id;
+  printf("publishing %u bytes to %.*s\n", len, topic_len, topic);
+  return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
+}
+
+void setup() {
+  PLUART::init(USER_TASK_PRIORITY);
+  PLUART::setBaud(115200);
+  PLUART::setUseByteStreamBuffer(true);
+  PLUART::setUseLineBuffer(false);
+  PLUART::enable();
+
+  memset(&callbacks, 0, sizeof(bm_serial_callbacks_t));
+  callbacks.pub_fn = pub_cb;
+  callbacks.sub_fn = sub_cb;
+  callbacks.tx_fn = tx_cb;
+  bm_serial_set_callbacks(&callbacks);
+  IOWrite(&BB_VBUS_EN, 0);
+  // ensure Vbus stable before enable Vout with a 5ms delay.
+  vTaskDelay(pdMS_TO_TICKS(5));
+  // enable Vout, 12V by default.
+  IOWrite(&BB_PL_BUCK_EN, 0);
+}
+
+static void reset() {
+  rx_idx = 0;
+  memset(rx_buffer, 0, rx_buf_size);
+}
+
+void loop() {
+  while (PLUART::byteAvailable()) {
+    const uint8_t b = PLUART::readByte();
+    rx_buffer[rx_idx++] = b;
+    if (rx_idx >= rx_buf_size) {
+      printf("buffer full, resetting\n");
+      reset();
+    } else {
+      if (b == 0) {
+        cobs_decode_result result =
+            cobs_decode(packet_buffer, packet_buf_size, rx_buffer, rx_idx - 1);
+        if (result.status == COBS_DECODE_OK) {
+          bm_serial_packet_t *packet = reinterpret_cast<bm_serial_packet_t *>(packet_buffer);
+          bm_serial_error_e err = bm_serial_process_packet(packet, result.out_len);
+          if (err != BM_SERIAL_OK) {
+            printf("packet processing error: %d\n", err);
+          }
+        } else {
+          printf("cobs decode error: %d\n", result.status);
+        }
+        reset();
+      }
+    }
+  }
+}

--- a/src/apps/bristleback_apps/serial_bridge/user_code/user_code.h
+++ b/src/apps/bristleback_apps/serial_bridge/user_code/user_code.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void setup();
+void loop();

--- a/src/apps/common/serial_bridge/serial_bridge.cpp
+++ b/src/apps/common/serial_bridge/serial_bridge.cpp
@@ -140,9 +140,7 @@ void serial_bridge_init(void) {
 
  @param args Unused
  */
-void serial_bridge_handle(void *args) {
-  (void)args;
-
+void serial_bridge_handle(void) {
   while (PLUART::byteAvailable()) {
     const uint8_t b = PLUART::readByte();
     ctx.rx.buffer[ctx.rx.idx++] = b;

--- a/src/apps/common/serial_bridge/serial_bridge.cpp
+++ b/src/apps/common/serial_bridge/serial_bridge.cpp
@@ -1,0 +1,170 @@
+#include "serial_bridge.h"
+#include "bm_os.h"
+#include "bm_serial.h"
+#include "cobs.h"
+#include "payload_uart.h"
+#include "pubsub.h"
+#include "task_priorities.h"
+
+static constexpr size_t RX_BUF_SIZE = 2048;
+
+struct BmSerialBridgeCtx {
+  bm_serial_callbacks_t callbacks; // bm_serial callback struct
+  struct {
+    size_t idx;                  // rx buffer current idx
+    uint8_t buffer[RX_BUF_SIZE]; // uart rx buffer
+  } rx;
+  struct {
+    uint8_t buffer[RX_BUF_SIZE]; // cobs decoded packet buffer
+  } packet;
+};
+
+static struct BmSerialBridgeCtx ctx; //Serial Bridge Context
+
+/*!
+ @brief Serial Transmit Callback For bm_serial Library
+
+ @details Raw bytes (buff) are passed from the bm_serial library to this
+          function, which will output data to the PLUART interface.
+
+ @param buff Buffer to transmit serially
+ @param len Length of buffer to transmit
+ @param message Unused
+
+ @return true always
+ */
+static bool tx_cb(const uint8_t *buff, size_t len, bm_serial_message_t message) {
+  (void)message;
+  PLUART::write((uint8_t *)buff, len);
+  return true;
+}
+
+/*!
+ @brief Subscription Callback When Topic Of Interest Is Published To Network
+
+ @details Passes topic information and data serially to serially connected
+          device.
+
+ @param node_id Node ID which published the message
+ @param topic Topic message was published on
+ @param topic_len topic length
+ @param data Data associated with topic, can be NULL
+ @param data_len Length of data
+ @param type Topic type
+ @param version Topic version
+ */
+static void sub_message_cb(uint64_t node_id, const char *topic, uint16_t topic_len,
+                           const uint8_t *data, uint16_t data_len, uint8_t type,
+                           uint8_t version) {
+  if (bm_serial_pub(node_id, topic, topic_len, data, data_len, type, version) != BM_SERIAL_OK) {
+    printf("Failed to publish message to serial device\n");
+
+  } else {
+    printf("Publishing To Topic: %s\n", topic);
+  }
+}
+
+/*!
+ @brief Subscription Callback For bm_serial Library
+
+ @details When serial message is received for this type of message, subscribe
+          to the topic of interest on the Bristlemouth network and pass it
+          the received data through to the serially connected device.
+
+ @param topic Topic to subscribe to
+ @param topic_len Length of topic
+
+ @return True on success, false on failure
+ */
+static bool sub_cb(const char *topic, uint16_t topic_len) {
+  return bm_sub_wl(topic, topic_len, sub_message_cb) == BmOK;
+}
+
+/*!
+ @brief Publish Callback For bm_serial Library
+
+ @details Handles publishing data to bristlemouth network from serially
+          connected device.
+
+ @param topic Topic to publish to
+ @param topic_len Length of topic
+ @param node_id Unused
+ @param payload Data to publish can be NULL
+ @param len Length of data
+ @param type Topic type
+ @param version Topic version
+
+ @return 
+ */
+static bool pub_cb(const char *topic, uint16_t topic_len, uint64_t node_id,
+                   const uint8_t *payload, size_t len, uint8_t type, uint8_t version) {
+  (void)node_id;
+  printf("publishing %u bytes to %.*s\n", len, topic_len, topic);
+  return bm_pub_wl(topic, topic_len, payload, len, type, version) == BmOK;
+}
+
+/*!
+ @brief Reset RX Buffer
+ */
+static void serial_rx_reset() {
+  ctx.rx.idx = 0;
+  memset(ctx.rx.buffer, 0, RX_BUF_SIZE);
+}
+
+/*!
+ @brief Initialize Serial Bridge Interface
+ */
+void serial_bridge_init(void) {
+  PLUART::init(USER_TASK_PRIORITY);
+
+  PLUART::setBaud(115200);
+  PLUART::setUseByteStreamBuffer(true);
+  PLUART::setUseLineBuffer(false);
+  PLUART::enable();
+
+  memset(&ctx.callbacks, 0, sizeof(bm_serial_callbacks_t));
+  ctx.callbacks.pub_fn = pub_cb;
+  ctx.callbacks.sub_fn = sub_cb;
+  ctx.callbacks.tx_fn = tx_cb;
+  bm_serial_set_callbacks(&ctx.callbacks);
+}
+
+/*!
+ @brief Handle Serial Bridge Incoming Data
+
+ @details This should be handled at a high rate. It can be handled in a task
+          or this function itself can be used as a task handler. This function
+          reads incoming UART data from the PLUART peripheral and COBS decodes
+          it. It is then passed to the bm_serial module to be processed and
+          handled accordingly.
+
+ @param args Unused
+ */
+void serial_bridge_handle(void *args) {
+  (void)args;
+
+  while (PLUART::byteAvailable()) {
+    const uint8_t b = PLUART::readByte();
+    ctx.rx.buffer[ctx.rx.idx++] = b;
+    if (ctx.rx.idx >= RX_BUF_SIZE) {
+      printf("buffer full, resetting\n");
+      serial_rx_reset();
+    } else {
+      if (b == 0) {
+        cobs_decode_result result =
+            cobs_decode(ctx.packet.buffer, RX_BUF_SIZE, ctx.rx.buffer, ctx.rx.idx - 1);
+        if (result.status == COBS_DECODE_OK) {
+          bm_serial_packet_t *packet =
+              reinterpret_cast<bm_serial_packet_t *>(ctx.packet.buffer);
+          bm_serial_error_e err = bm_serial_process_packet(packet, result.out_len);
+          if (err != BM_SERIAL_OK) {
+            printf("packet processing error: %d\n", err);
+          }
+        } else {
+          printf("cobs decode error: %d\n", result.status);
+        }
+        serial_rx_reset();
+      }
+    }
+  }
+}

--- a/src/apps/common/serial_bridge/serial_bridge.h
+++ b/src/apps/common/serial_bridge/serial_bridge.h
@@ -1,0 +1,7 @@
+#ifndef __SERIAL_BRIDGE_H__
+#define __SERIAL_BRIDGE_H__
+
+void serial_bridge_init(void);
+void serial_bridge_handle(void);
+
+#endif


### PR DESCRIPTION
## What changed?
Added subscription capability to serial bridge application.
Adds serial bridge application to Bristleback.

## How does it make Bristlemouth better?
Expands the serial bridge application to allow companion devices to subscribe to topics.


## Where should reviewers focus?
Mainly the diff in the serial bridge apps!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
