### PR TITLE
Add SHA Field When Building External Applications In Release

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -298,9 +298,18 @@ class AutoBuilder:
         if config["type"] == "ext_fw" and config["repo"] is not None:
             temp_dir = tempfile.TemporaryDirectory()
             try:
+                dir = temp_dir.name + "/" + config["args"]["app"]
                 repo = git.Repo.clone_from(
-                    config["repo"], temp_dir.name + "/" + config["args"]["app"]
+                    config["repo"],
+                    dir,
+                    depth=1,
                 )
+
+                # If specified SHA in config, checkout that SHA
+                if config["sha"] is not None:
+                    ref = str(config["sha"])
+                    repo.git.checkout(ref)
+
                 print(f"Repository successfully cloned to: {repo.working_dir}")
             except Exception as e:
                 print(f"Error cloning repository: {e}")

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -121,7 +121,9 @@
 - name: borealis
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
+  sha: 4c61e0c
   args:
     app: borealis
     bsp: bm_mote_v1.0
     build_type: Release
+  sign: false


### PR DESCRIPTION
## What changed?
Add SHA field to release CI/CD config file


## How does it make Bristlemouth better?
This would be used for applications such as `borealis_mote_firmware`.
Ensures a certain SHA is used for release rather than the latest mainline branch.
Prevents conditions where the latest mainline branch of an external repository might have code not intended for a release.


## Where should reviewers focus?
Run the script yourself with the command:
`python tools/scripts/release/auto_build.py  tools/scripts/release/configs/default.yml`
Must have access to the `borealis_mote_firmware` repository.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
