### PR TITLE
missed a correct type interpolation in Rx-LIVE print

### DIFF
--- a/src/apps/bm_devkit/rx_live_example/user_code/rx_live_sensor.cpp
+++ b/src/apps/bm_devkit/rx_live_example/user_code/rx_live_sensor.cpp
@@ -253,7 +253,7 @@ RxLiveStatusCode RxLiveSensor::run(const uint8_t *rx_data, const size_t rx_len) 
           printf("\t\tCode Char: %c\n", parsed_tag_id.code_char);
           printf("\t\tCode Freq: %u\n", parsed_tag_id.code_freq);
           printf("\t\tCode Channel: %u\n", parsed_tag_id.code_channel);
-          printf("\t\tTag Serial no: %u\n", parsed_tag_id.tag_serial_no);
+          printf("\t\tTag Serial no: %lu\n", parsed_tag_id.tag_serial_no);
           _latest_detection = parsed_tag_id;
           return RX_CODE_DETECTION;
         } else {


### PR DESCRIPTION
## What changed?



## How does it make Bristlemouth better?



## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
