### PR TITLE
Fixes Bug When Default Keys Are Deleted Causing The Bridge To Crash

### DIFF
--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -429,13 +429,13 @@ static void defaultTask(void *parameters) {
   };
   BridgePowerController bridge_power_controller(config);
 
+  reportBuilderInit();
+  sensorControllerInit(&bridge_power_controller);
   ncpInit(&usart3, &dfu_partition, &bridge_power_controller);
   topology_sampler_init(&bridge_power_controller);
   debug_ncp_init();
   debugBmServiceInit();
   sys_info_service_init();
-  reportBuilderInit();
-  sensorControllerInit(&bridge_power_controller);
   config_cbor_map_service_init();
   IOWrite(&ALARM_OUT, 1);
   IOWrite(&LED_BLUE, LED_OFF);

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -28,7 +28,7 @@ extern "C" {
 #include "task_priorities.h"
 #include "usart.h"
 
-static constexpr uint8_t NCP_NOTIFY_BUFF_MASK  = (1 << 0);
+static constexpr uint8_t NCP_NOTIFY_BUFF_MASK = (1 << 0);
 static constexpr uint8_t NCP_NOTIFY = (1 << 1);
 
 static constexpr uint8_t NCP_PROCESSOR_RX_QUEUE_DEPTH = 16;
@@ -670,13 +670,12 @@ static BaseType_t ncpRXBytesFromISR(SerialHandle_t *handle, uint8_t *buffer, siz
 
     BaseType_t rval = xTaskNotifyFromISR(ncpRXTaskHandle, (ncpRXCurrBuff | NCP_NOTIFY),
                                          eSetValueWithoutOverwrite, &higherPriorityTaskWoken);
+    // switch ncp buffers
+    ncpRXCurrBuff = (ncpRXCurrBuff + 1) % NCP_RX_BUFF_COUNT;
     if (rval == pdFALSE) {
-      // previous packet still pending, 😬
+      // previous packet still pending, drop the oldest and continue
       // TODO - track dropped packets?
-      configASSERT(0);
-    } else {
-      // switch ncp buffers
-      ncpRXCurrBuff = (ncpRXCurrBuff + 1) % NCP_RX_BUFF_COUNT;
+      ulTaskNotifyValueClear(ncpRXTaskHandle, ncpRXCurrBuff);
     }
     xSemaphoreGiveFromISR(ncp_serial_lock, &higherPriorityTaskWoken);
   } while (0);


### PR DESCRIPTION
## What changed?
Re-orders how modules are initialized to prevent receiving serial messages too early. This allows the baud rate to be set and negotiated properly after a commit to the configuration partition.
Previously the baud rate would get re-negotiated before setting the default configuration values and then upon the next reboot after saving those configuration values, the Bridge would be at the wrong baud rate (115200) and improperly try to parse incoming packets at a much higher baud rate (1M), causing too many events to occur and the assert on line 676 of `ncp_uart.cpp` to be invoked.


## How does it make Bristlemouth better?
Prevents edge case when deleting a default configuration on Bridge application causes the Bridge to never respond to Spotter again until a reboot.

Here is the backtrace when the ncp_uart module is initialized before the default configuration keys are saved and the Bridge is reset:

```
Thread 2 "Default" received signal SIGTRAP, Trace/breakpoint trap.
[Switching to Thread 536899960]
memfault_platform_halt_if_debugging () at ./third_party/memfault-firmware-sdk/components/core/src/arch_arm_cortex_m.c:42
42        MEMFAULT_BREAKPOINT(77);
(gdb) bt
#0  memfault_platform_halt_if_debugging () at ./third_party/memfault-firmware-sdk/components/core/src/arch_arm_cortex_m.c:42
#1  0x0802942a in prv_fault_handling_assert (pc=pc@entry=0x8020f04 <ncpRXBytesFromISR(SerialHandle_t*, uint8_t*, size_t)+196>, lr=lr@entry=0x8015a2b <serialGenericUartIRQHandler+46>, reason=reason@entry=kMfltRebootReason_Assert)
    at ./third_party/memfault-firmware-sdk/components/panics/src/memfault_fault_handling_arm.c:580
#2  0x080293f6 in memfault_fault_handling_assert (pc=0x8020f04 <ncpRXBytesFromISR(SerialHandle_t*, uint8_t*, size_t)+196>, lr=0x8015a2b <serialGenericUartIRQHandler+46>)
    at ./third_party/memfault-firmware-sdk/components/panics/src/memfault_fault_handling_arm.c:601
#3  0x08020f08 in ncpRXBytesFromISR (handle=<optimized out>, buffer=<optimized out>, len=<optimized out>) at ./lib/bm_ncp/ncp_uart.cpp:676
#4  0x08015a2a in serialGenericUartIRQHandler (handle=0x2000035c <usart3>) at ./lib/common/serial.c:285
#5  0x0802136c in USART3_IRQHandler () at ./lib/bm_ncp/ncp_uart.cpp:625
#6  0xffffffac in ?? ()
```


## Where should reviewers focus?
One of the largest issues here is the assert on line 676 of `ncp_uart.cpp`:

```C
    BaseType_t rval = xTaskNotifyFromISR(ncpRXTaskHandle, (ncpRXCurrBuff | NCP_NOTIFY),
                                         eSetValueWithoutOverwrite, &higherPriorityTaskWoken);
    if (rval == pdFALSE) {
      // previous packet still pending, 😬
      // TODO - track dropped packets?
      configASSERT(0);
    } else {
      // switch ncp buffers
      ncpRXCurrBuff = (ncpRXCurrBuff + 1) % NCP_RX_BUFF_COUNT;
    }
```

Should assert be removed? If we drop packets at an improper baud rate, the application should be able to continue chugging along without resetting.

Edit: I provided a solution for dropping the oldest packet if there is an overflow rather than asserting. This would ensure the strange resets do not occur... please provide thoughts and concerns. **NOTE: just this change actually fixes the bug as well without having to change initialization order, but the new initialization order is cleaner as it does not attempt two baud rate negotiations, one after another**

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
