### PR TITLE
Add New Configuration Parameters

### DIFF
--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -70,6 +70,11 @@ void AanderaaConductivitySensor::configureSensor(void) {
 
   checkAssignProductionConfigs();
 
+  get_config_uint(BM_CFG_PARTITION_SYSTEM,
+                  SENSOR_SERIAL_NUMBER,
+                  strlen(SENSOR_SERIAL_NUMBER),
+                  &_serialNumber);
+
   // set lower priveledge level
   sendCommand(CMD_SET_PASSKEY_1);
 
@@ -370,19 +375,24 @@ bool AanderaaConductivitySensor::checkAssignEpochValues(void) {
  */
 void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
   AanderaaConductivityUint detected_serial_number = 0;
+  uint32_t serial_number_err = 0;
 
   if (!str) {
     return;
   }
 
   checkTypeAndAssign(str, strlen(str), &detected_serial_number);
+
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), &serial_number_err);
+  bool serial_numbers_match = detected_serial_number == _serialNumber;
+  
   debug_printf("Detected serial number: %" PRIu32 "\n", detected_serial_number);
-  if (detected_serial_number != _serialNumber) {
+  if (!serial_number_err && !serial_numbers_match) {
     spotter_log(0, AANDERAA_CONDUCTIVITY_LOG, USE_TIMESTAMP,
                 "Err: Detected 5990 serial number %" PRIu32 " does not match"
                 "production serial number: %" PRIu32 "\n", detected_serial_number, _serialNumber);
     set_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), 1);
-  } else {
+  } else if (serial_numbers_match) {
     remove_key(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM));
   }
 }
@@ -425,6 +435,10 @@ void AanderaaConductivitySensor::checkAssignProductionConfigs(void) {
   ProductionConfigs prev_read_configs = {};
   ProductionConfigs read_configs = {};
 
+  if (hasProductionConfigs(production_configs)) {
+      return;
+  }
+
   // Ensure robust readings for serial number
   do {
     prev_read_configs = read_configs;
@@ -437,12 +451,6 @@ void AanderaaConductivitySensor::checkAssignProductionConfigs(void) {
     }
   } while (prev_read_configs.serial_number != read_configs.serial_number &&
            prev_read_configs.cell_coef != read_configs.cell_coef);
-
-  _serialNumber = read_configs.serial_number;
-
-  if (hasProductionConfigs(production_configs)) {
-      return;
-  }
 
   debug_printf("Saving production configs!\n");
   set_config_uint(BM_CFG_PARTITION_SYSTEM,

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -39,7 +39,6 @@ void AanderaaConductivitySensor::init() {
   debug_printf("sensorDepthM: %f\n", _sensorDepthM);
   // convert depth in meters to pressure in kPa; Pressure = 10 * depth
   _pressureKpa = _sensorDepthM * 10.0f;
-  debug_printf("Calculated pressure for depth %.2f m is %f kPa\n", _sensorDepthM, _pressureKpa);
 
   PLUART::init(USER_TASK_PRIORITY);
   // Baud set to 9600, which is expected by the Aanderaa conductivity sensor
@@ -108,7 +107,9 @@ void AanderaaConductivitySensor::configureSensor(void) {
   sendCommand(CMD_ENABLE_DERIVEDPARAMETERS_YES);
 
   // set pressure command
-  debug_printf("Calculated pressure for depth %.2f m is %.2f kPa\n", _sensorDepthM, _pressureKpa);
+  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+              "Calculated pressure for depth %.2f m is %f kPa\n",
+              _sensorDepthM, _pressureKpa);
   AanderaaConductivityString pressure_cmd;
   snprintf(pressure_cmd, sizeof(pressure_cmd), CMD_SET_PRESSURE, _pressureKpa);
   sendCommand(pressure_cmd);
@@ -236,20 +237,25 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
   // read sys config referenceConductivity
   get_config_float(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY), &_referenceConductivity);
 
+  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+              "Calibrating salinity sensor...\n");
+
   if (isnan(_referenceConductivity)) {
     return;
   }
 
     // if _referenceConductivity is within expected range --- Minimum = 0.000 S/m (0.000 mS/cm) and Maximum = 7.500 S/m (75.000 mS/cm)
   if (_referenceConductivity < 0.000f || _referenceConductivity > 75.000f) {
-    debug_printf("Reference conductivity is out of range. Skipping cellCoef adjustment\n");
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+                "Reference conductivity is out of range. Skipping cellCoef adjustment\n");
     return;
   } 
 
   uint32_t calib_count = 0;
   get_config_uint(BM_CFG_PARTITION_SYSTEM, CAL_COUNT, strlen(CAL_COUNT), &calib_count);
 
-  debug_printf("Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n", _referenceConductivity);
+  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+              "Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n", _referenceConductivity);
 
   // Wake up the sensor and stop readings
   sendCommand(CMD_WAKE);
@@ -264,13 +270,17 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
   if (_cellCoef == 0.000000f || _measuredConductivity == 0.000f) {
     /* calibration failed but the loop() in user_code.cpp will run this function again to
      * attempt doing it again and then remove referenceConductivity from the configs */
-    debug_printf("Calibration failed because cellCoef or measuredConductivity is zero\n");
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+                "Calibration failed because cellCoef or measuredConductivity is zero\n");
   } else {
   // calculate new cellCoef
-    debug_printf("old cellCoef: %f\n", _cellCoef);
+    
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+                "old cellCoef: %f\n", _cellCoef);
     // Formula -> NEW cellCoef = stored cellCoef * (referenceConductivity / measuredConductivity)
     _cellCoef = _cellCoef * (_referenceConductivity / _measuredConductivity);
-    debug_printf("new cellCoef: %f\n", _cellCoef);
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+                "new cellCoef: %f\n", _cellCoef);
 
     // write new cellCoef to sensor
     AanderaaConductivityString calibrate_cmd;

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -11,12 +11,11 @@
 #include "task_priorities.h"
 #include "uptime.h"
 #include <string>
-#include "uptime.h"
 
 extern "C" {
 #include "bm_rtc.h"
 }
-#if __has_include ("debug.h")
+#if __has_include("debug.h")
 #include "debug.h"
 #else
 #define debug_printf printf
@@ -30,7 +29,7 @@ void AanderaaConductivitySensor::init() {
 
   // reading period in seconds
   get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_INTERVAL_S, strlen(SENSOR_INTERVAL_S),
-                   &_readingPeriodS);
+                  &_readingPeriodS);
   debug_printf("readingPeriodS: %" PRIu32 "\n", _readingPeriodS);
 
   // sensor depth in meters
@@ -69,9 +68,7 @@ void AanderaaConductivitySensor::configureSensor(void) {
 
   checkAssignProductionConfigs();
 
-  get_config_uint(BM_CFG_PARTITION_SYSTEM,
-                  SENSOR_SERIAL_NUMBER,
-                  strlen(SENSOR_SERIAL_NUMBER),
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_SERIAL_NUMBER, strlen(SENSOR_SERIAL_NUMBER),
                   &_serialNumber);
 
   // set lower priveledge level
@@ -108,8 +105,7 @@ void AanderaaConductivitySensor::configureSensor(void) {
 
   // set pressure command
   spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-              "Calculated pressure for depth %.2f m is %f kPa\n",
-              _sensorDepthM, _pressureKpa);
+              "Calculated pressure for depth %.2f m is %f kPa\n", _sensorDepthM, _pressureKpa);
   AanderaaConductivityString pressure_cmd;
   snprintf(pressure_cmd, sizeof(pressure_cmd), CMD_SET_PRESSURE, _pressureKpa);
   sendCommand(pressure_cmd);
@@ -128,7 +124,8 @@ void AanderaaConductivitySensor::configureSensor(void) {
         debug_printf("%.*s\n", read_len, _payload_buffer);
         if (_sensorBmLogEnable) {
           spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-                     "tick: %" PRIu64 ", line: %.*s\n", uptimeGetMs(), read_len, _payload_buffer);
+                      "tick: %" PRIu64 ", line: %.*s\n", uptimeGetMs(), read_len,
+                      _payload_buffer);
         }
         clearPayloadBuffer();
       }
@@ -143,13 +140,9 @@ void AanderaaConductivitySensor::clearPayloadBuffer(void) {
   memset(_payload_buffer, 0, sizeof(_payload_buffer));
 }
 
-void AanderaaConductivitySensor::resetSensor(void) {
-  sendCommand(CMD_RESET);
-}
+void AanderaaConductivitySensor::resetSensor(void) { sendCommand(CMD_RESET); }
 
-void AanderaaConductivitySensor::startStreaming(void) {
-  sendCommand(CMD_START);
-}
+void AanderaaConductivitySensor::startStreaming(void) { sendCommand(CMD_START); }
 
 bool AanderaaConductivitySensor::getData(AanderaaConductivityMsg::Data &d) {
   bool success = false;
@@ -163,55 +156,58 @@ bool AanderaaConductivitySensor::getData(AanderaaConductivityMsg::Data &d) {
 
     if (_sensorBmLogEnable) {
       spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-                 "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtc_time_str,
-                 read_len, _payload_buffer);
+                  "tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtc_time_str,
+                  read_len, _payload_buffer);
     }
     spotter_log_console(0, "salinity | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
-              rtc_time_str, read_len, _payload_buffer);
-    debug_printf("conductivity | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtc_time_str,
-           read_len, _payload_buffer);
+                        rtc_time_str, read_len, _payload_buffer);
+    debug_printf("conductivity | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(),
+                 rtc_time_str, read_len, _payload_buffer);
 
-    if (read_len > 10 && _payload_buffer[0] == 0x13 && _payload_buffer[1] == 0x11){
-        // Skip the \x13\x11 header bytes
-        char *data_start = &_payload_buffer[2];
-        // Skip the first two tab-separated fields
-        for (int i = 0; i < 2; i++) {
-          data_start = strchr(data_start, '\t');
-          if (i == 0) {
-            validateSerialNumber(data_start);
-          }
-          if (data_start) {
-            data_start++; // Move past the tab
-          } else {
-            debug_printf("Failed to find expected tabs in data\n");
-            return success;
-          }
+    if (read_len > 10 && _payload_buffer[0] == 0x13 && _payload_buffer[1] == 0x11) {
+      // Skip the \x13\x11 header bytes
+      char *data_start = &_payload_buffer[2];
+      // Skip the first two tab-separated fields
+      for (int i = 0; i < 2; i++) {
+        data_start = strchr(data_start, '\t');
+        if (i == 0) {
+          validateSerialNumber(data_start);
         }
-
-        if (_parser.parseLine(data_start, read_len - (data_start - _payload_buffer))) {
-          Value conductivity = _parser.getValue(0);
-          Value temperature = _parser.getValue(1);
-          Value salinity = _parser.getValue(2);
-          Value water_density = _parser.getValue(3);
-          Value sound_speed = _parser.getValue(4);
-
-          d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
-          d.header.reading_uptime_millis = uptimeGetMs();
-          d.conductivity_ms_cm = conductivity.data.double_val;
-          d.temperature_deg_c = temperature.data.double_val;
-          d.salinity_psu = salinity.data.double_val;
-          d.water_density_kg_m3 = water_density.data.double_val;
-          d.sound_speed_m_s = sound_speed.data.double_val;
-          d.depth_m = _sensorDepthM;
-          success = true;
-
-          debug_printf("conductivity: %.3f mS/cm, temperature: %.3f C, salinity: %.3f PSU, water density: %.3f kg/m3, sound speed: %.3f m/s, depth: %.3f m\n", d.conductivity_ms_cm, d.temperature_deg_c, d.salinity_psu, d.water_density_kg_m3, d.sound_speed_m_s, d.depth_m);
+        if (data_start) {
+          data_start++; // Move past the tab
         } else {
-          debug_printf("Failed to parse 5 double values from conductivity data\n");
+          debug_printf("Failed to find expected tabs in data\n");
+          return success;
         }
-        clearPayloadBuffer();
       }
+
+      if (_parser.parseLine(data_start, read_len - (data_start - _payload_buffer))) {
+        Value conductivity = _parser.getValue(0);
+        Value temperature = _parser.getValue(1);
+        Value salinity = _parser.getValue(2);
+        Value water_density = _parser.getValue(3);
+        Value sound_speed = _parser.getValue(4);
+
+        d.header.reading_time_utc_ms = rtcGetMicroSeconds(&time_and_date) / 1000;
+        d.header.reading_uptime_millis = uptimeGetMs();
+        d.conductivity_ms_cm = conductivity.data.double_val;
+        d.temperature_deg_c = temperature.data.double_val;
+        d.salinity_psu = salinity.data.double_val;
+        d.water_density_kg_m3 = water_density.data.double_val;
+        d.sound_speed_m_s = sound_speed.data.double_val;
+        d.depth_m = _sensorDepthM;
+        success = true;
+
+        debug_printf("conductivity: %.3f mS/cm, temperature: %.3f C, salinity: %.3f PSU, water "
+                     "density: %.3f kg/m3, sound speed: %.3f m/s, depth: %.3f m\n",
+                     d.conductivity_ms_cm, d.temperature_deg_c, d.salinity_psu,
+                     d.water_density_kg_m3, d.sound_speed_m_s, d.depth_m);
+      } else {
+        debug_printf("Failed to parse 5 double values from conductivity data\n");
+      }
+      clearPayloadBuffer();
     }
+  }
   return success;
 }
 
@@ -235,7 +231,8 @@ bool AanderaaConductivitySensor::getData(AanderaaConductivityMsg::Data &d) {
  */
 void AanderaaConductivitySensor::calibrateCellCoef(void) {
   // read sys config referenceConductivity
-  get_config_float(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY), &_referenceConductivity);
+  get_config_float(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY,
+                   strlen(EXTERNAL_REFERENCE_CONDUCTIVITY), &_referenceConductivity);
 
   spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
               "Calibrating salinity sensor...\n");
@@ -244,18 +241,20 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
     return;
   }
 
-    // if _referenceConductivity is within expected range --- Minimum = 0.000 S/m (0.000 mS/cm) and Maximum = 7.500 S/m (75.000 mS/cm)
+  // if _referenceConductivity is within expected range --- Minimum = 0.000 S/m (0.000 mS/cm) and Maximum = 7.500 S/m (75.000 mS/cm)
   if (_referenceConductivity < 0.000f || _referenceConductivity > 75.000f) {
     spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
                 "Reference conductivity is out of range. Skipping cellCoef adjustment\n");
     return;
-  } 
+  }
 
   uint32_t calib_count = 0;
   get_config_uint(BM_CFG_PARTITION_SYSTEM, CAL_COUNT, strlen(CAL_COUNT), &calib_count);
 
-  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-              "Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n", _referenceConductivity);
+  spotter_log(
+      0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+      "Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n",
+      _referenceConductivity);
 
   // Wake up the sensor and stop readings
   sendCommand(CMD_WAKE);
@@ -273,14 +272,14 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
     spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
                 "Calibration failed because cellCoef or measuredConductivity is zero\n");
   } else {
-  // calculate new cellCoef
-    
-    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-                "old cellCoef: %f\n", _cellCoef);
+    // calculate new cellCoef
+
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP, "old cellCoef: %f\n",
+                _cellCoef);
     // Formula -> NEW cellCoef = stored cellCoef * (referenceConductivity / measuredConductivity)
     _cellCoef = _cellCoef * (_referenceConductivity / _measuredConductivity);
-    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-                "new cellCoef: %f\n", _cellCoef);
+    spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP, "new cellCoef: %f\n",
+                _cellCoef);
 
     // write new cellCoef to sensor
     AanderaaConductivityString calibrate_cmd;
@@ -291,10 +290,7 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
     // Set calibration configuration parameters
     calib_count++;
     remove_key(BM_CFG_PARTITION_SYSTEM, LAST_CAL_TIME_EPOCH_S, strlen(LAST_CAL_TIME_EPOCH_S));
-    set_config_float(BM_CFG_PARTITION_SYSTEM,
-                     CELL_COEF,
-                     strlen(CELL_COEF),
-                     _cellCoef);
+    set_config_float(BM_CFG_PARTITION_SYSTEM, CELL_COEF, strlen(CELL_COEF), _cellCoef);
     set_config_uint(BM_CFG_PARTITION_SYSTEM, CAL_COUNT, strlen(CAL_COUNT), calib_count);
     checkAssignEpochValues();
 
@@ -302,7 +298,8 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
     resetSensor();
   }
   // remove referenceConductivity from the config
-  remove_key(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY));
+  remove_key(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY,
+             strlen(EXTERNAL_REFERENCE_CONDUCTIVITY));
   save_config(BM_CFG_PARTITION_SYSTEM, true);
 }
 
@@ -327,10 +324,8 @@ bool AanderaaConductivitySensor::checkAssignEpochValues(void) {
 
   float cell_coef;
   uint32_t first_cal_time_s, last_cal_time_s;
-  bool has_calibration = get_config_float(BM_CFG_PARTITION_SYSTEM,
-                                          CELL_COEF,
-                                          strlen(CELL_COEF),
-                                          &cell_coef);
+  bool has_calibration =
+      get_config_float(BM_CFG_PARTITION_SYSTEM, CELL_COEF, strlen(CELL_COEF), &cell_coef);
   if (!has_calibration) {
     return false;
   }
@@ -338,31 +333,23 @@ bool AanderaaConductivitySensor::checkAssignEpochValues(void) {
   // Calibration is set, check if configurations exist for calibration time
   bool ret = false;
   uint32_t epoch_s = (uint32_t)US_TO_S(bm_rtc_get_micro_seconds(&rtc_time));
-  bool has_first_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM,
-                                            FIRST_CAL_TIME_EPOCH_S,
-                                            strlen(FIRST_CAL_TIME_EPOCH_S),
-                                            &first_cal_time_s);
-  bool has_last_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM,
-                                           LAST_CAL_TIME_EPOCH_S,
-                                           strlen(LAST_CAL_TIME_EPOCH_S),
-                                           &last_cal_time_s);
+  bool has_first_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM, FIRST_CAL_TIME_EPOCH_S,
+                                            strlen(FIRST_CAL_TIME_EPOCH_S), &first_cal_time_s);
+  bool has_last_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM, LAST_CAL_TIME_EPOCH_S,
+                                           strlen(LAST_CAL_TIME_EPOCH_S), &last_cal_time_s);
 
   if (!has_first_cal_time) {
     debug_printf("Setting first cal time %" PRIu32 "\n", epoch_s);
-    set_config_uint(BM_CFG_PARTITION_SYSTEM,
-                    FIRST_CAL_TIME_EPOCH_S,
-                    strlen(FIRST_CAL_TIME_EPOCH_S),
-                    epoch_s);
+    set_config_uint(BM_CFG_PARTITION_SYSTEM, FIRST_CAL_TIME_EPOCH_S,
+                    strlen(FIRST_CAL_TIME_EPOCH_S), epoch_s);
     ret = true;
     save_config(BM_CFG_PARTITION_SYSTEM, false);
   }
 
   if (!has_last_cal_time) {
     debug_printf("Setting last cal time %" PRIu32 "\n", epoch_s);
-    set_config_uint(BM_CFG_PARTITION_SYSTEM,
-                    LAST_CAL_TIME_EPOCH_S,
-                    strlen(LAST_CAL_TIME_EPOCH_S),
-                    epoch_s);
+    set_config_uint(BM_CFG_PARTITION_SYSTEM, LAST_CAL_TIME_EPOCH_S,
+                    strlen(LAST_CAL_TIME_EPOCH_S), epoch_s);
     ret = true;
     save_config(BM_CFG_PARTITION_SYSTEM, false);
   }
@@ -393,14 +380,16 @@ void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
 
   checkTypeAndAssign(str, strlen(str), &detected_serial_number);
 
-  get_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), &serial_number_err);
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM),
+                  &serial_number_err);
   bool serial_numbers_match = detected_serial_number == _serialNumber;
-  
+
   // Only set and log the key if it has not been set yet or if the config does not exist
   if ((!_serialNumberErrSet || !serial_number_err) && !serial_numbers_match) {
     spotter_log(0, AANDERAA_CONDUCTIVITY_LOG, USE_TIMESTAMP,
                 "Err: Detected 5990 serial number %" PRIu32 " does not match"
-                " production serial number: %" PRIu32 "\n", detected_serial_number, _serialNumber);
+                " production serial number: %" PRIu32 "\n",
+                detected_serial_number, _serialNumber);
     set_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), 1);
     _serialNumberErrSet = true;
   } else if (serial_numbers_match) {
@@ -417,14 +406,12 @@ void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
  @return true if both production configurations exist, false otherwise
  */
 bool AanderaaConductivitySensor::hasProductionConfigs(ProductionConfigs &production_configs) {
-  bool has_serial_number = get_config_uint(BM_CFG_PARTITION_SYSTEM,
-                                           SENSOR_SERIAL_NUMBER,
-                                           strlen(SENSOR_SERIAL_NUMBER),
-                                           &production_configs.serial_number);
-  bool has_cell_coef = get_config_float(BM_CFG_PARTITION_SYSTEM,
-                                       FACTORY_CELL_COEF,
-                                       strlen(FACTORY_CELL_COEF),
-                                       &production_configs.cell_coef);
+  bool has_serial_number =
+      get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_SERIAL_NUMBER,
+                      strlen(SENSOR_SERIAL_NUMBER), &production_configs.serial_number);
+  bool has_cell_coef =
+      get_config_float(BM_CFG_PARTITION_SYSTEM, FACTORY_CELL_COEF, strlen(FACTORY_CELL_COEF),
+                       &production_configs.cell_coef);
 
   return has_serial_number && has_cell_coef;
 }
@@ -448,31 +435,27 @@ void AanderaaConductivitySensor::checkAssignProductionConfigs(void) {
   ProductionConfigs read_configs = {};
 
   if (hasProductionConfigs(production_configs)) {
-      return;
+    return;
   }
 
   // Ensure robust readings for serial number
   do {
     prev_read_configs = read_configs;
     if (sendCommand(CMD_GET_SERIAL_NUMBER, &read_configs.serial_number) == BmOK) {
-        debug_printf("Serial number is %" PRIu32 "\n", read_configs.serial_number);
+      debug_printf("Serial number is %" PRIu32 "\n", read_configs.serial_number);
     }
     if (sendCommand(CMD_GET_CELL_COEF, &read_configs.cell_coef) == BmOK) {
 
-        debug_printf("cellCoef is %0.4f\n", read_configs.cell_coef);
+      debug_printf("cellCoef is %0.4f\n", read_configs.cell_coef);
     }
   } while (prev_read_configs.serial_number != read_configs.serial_number &&
            prev_read_configs.cell_coef != read_configs.cell_coef);
 
   debug_printf("Saving production configs!\n");
-  set_config_uint(BM_CFG_PARTITION_SYSTEM,
-                  SENSOR_SERIAL_NUMBER,
-                  strlen(SENSOR_SERIAL_NUMBER),
+  set_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_SERIAL_NUMBER, strlen(SENSOR_SERIAL_NUMBER),
                   read_configs.serial_number);
-  set_config_float(BM_CFG_PARTITION_SYSTEM,
-                  FACTORY_CELL_COEF,
-                  strlen(FACTORY_CELL_COEF),
-                  read_configs.cell_coef);
+  set_config_float(BM_CFG_PARTITION_SYSTEM, FACTORY_CELL_COEF, strlen(FACTORY_CELL_COEF),
+                   read_configs.cell_coef);
   save_config(BM_CFG_PARTITION_SYSTEM, false);
 }
 
@@ -483,12 +466,12 @@ void AanderaaConductivitySensor::checkAssignProductionConfigs(void) {
  @param length the length of the output string
  @param value pointer to store the parsed unsigned integer value
  */
-void AanderaaConductivitySensor::checkTypeAndAssign(const char *output,
-    uint16_t length,
+void AanderaaConductivitySensor::checkTypeAndAssign(
+    const char *output, uint16_t length,
     AanderaaConductivitySensor::AanderaaConductivityUint *value) {
   (void)length;
 
-  if (value)  {
+  if (value) {
     *value = (uint32_t)strtoul(output, NULL, 10);
   }
 }
@@ -501,12 +484,11 @@ void AanderaaConductivitySensor::checkTypeAndAssign(const char *output,
  @param value pointer to store the parsed float value
  */
 void AanderaaConductivitySensor::checkTypeAndAssign(
-    const char *output,
-    uint16_t length,
+    const char *output, uint16_t length,
     AanderaaConductivitySensor::AanderaaConductivityFloat *value) {
   (void)length;
 
-  if (value)  {
+  if (value) {
     *value = strtof(output, NULL);
   }
 }
@@ -519,10 +501,9 @@ void AanderaaConductivitySensor::checkTypeAndAssign(
  @param value pointer to string buffer to store the copied string
  */
 void AanderaaConductivitySensor::checkTypeAndAssign(
-    const char *output,
-    uint16_t length,
+    const char *output, uint16_t length,
     AanderaaConductivitySensor::AanderaaConductivityString *value) {
-  if (value)  {
+  if (value) {
     size_t copy_len = bm_min(length, sizeof(AanderaaConductivityString) - 1);
     strncpy(*value, output, copy_len);
     (*value)[copy_len] = '\0';
@@ -568,8 +549,7 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command, uint32_t time
  @return BmEBADMSG if sensor responds with error acknowledgment ('*')
  */
 template <typename T>
-BmErr AanderaaConductivitySensor::sendCommand(const char *command,
-                                              T *value,
+BmErr AanderaaConductivitySensor::sendCommand(const char *command, T *value,
                                               uint32_t timeout_ms) {
   BmErr err = BmEINVAL;
 
@@ -601,9 +581,9 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command,
       if (_payload_buffer[buf_idx] == '!') {
         err = BmOK;
         break;
-      } 
+      }
     }
-    
+
     if (_payload_buffer[buf_idx] == '\n') {
       debug_printf("command response: %.*s\n", buf_idx, _payload_buffer);
 
@@ -614,7 +594,7 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command,
         last_tab++;
         last_tab[strcspn(last_tab, "\r\n")] = '\0';
         checkTypeAndAssign(last_tab, strlen(last_tab), value);
-      } 
+      }
 
       // Acknowledge for message reports '*' followed by a string for a failure and
       // '#' for success, see section 5.5 in TD321 Operation Manual

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -378,6 +378,9 @@ void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
   checkTypeAndAssign(str, strlen(str), &detected_serial_number);
   debug_printf("Detected serial number: %" PRIu32 "\n", detected_serial_number);
   if (detected_serial_number != _serialNumber) {
+    spotter_log(0, AANDERAA_CONDUCTIVITY_LOG, USE_TIMESTAMP,
+                "Err: Detected 5990 serial number %" PRIu32 " does not match"
+                "production serial number: %" PRIu32 "\n", detected_serial_number, _serialNumber);
     set_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), 1);
   } else {
     remove_key(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM));

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -386,14 +386,16 @@ void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
   get_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), &serial_number_err);
   bool serial_numbers_match = detected_serial_number == _serialNumber;
   
-  debug_printf("Detected serial number: %" PRIu32 "\n", detected_serial_number);
-  if (!serial_number_err && !serial_numbers_match) {
+  // Only set and log the key if it has not been set yet or if the config does not exist
+  if ((!_serialNumberErrSet || !serial_number_err) && !serial_numbers_match) {
     spotter_log(0, AANDERAA_CONDUCTIVITY_LOG, USE_TIMESTAMP,
                 "Err: Detected 5990 serial number %" PRIu32 " does not match"
-                "production serial number: %" PRIu32 "\n", detected_serial_number, _serialNumber);
+                " production serial number: %" PRIu32 "\n", detected_serial_number, _serialNumber);
     set_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), 1);
+    _serialNumberErrSet = true;
   } else if (serial_numbers_match) {
     remove_key(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM));
+    _serialNumberErrSet = false;
   }
 }
 

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -6,12 +6,16 @@
 #include "app_util.h"
 #include "configuration.h"
 #include "payload_uart.h"
-#include "serial.h"
 #include "spotter.h"
 #include "stm32_rtc.h"
 #include "task_priorities.h"
 #include "uptime.h"
+#include <string>
+#include "uptime.h"
 
+extern "C" {
+#include "bm_rtc.h"
+}
 #if __has_include ("debug.h")
 #include "debug.h"
 #else
@@ -59,11 +63,15 @@ void AanderaaConductivitySensor::configureSensor(void) {
   sendCommand(CMD_STOP);
 
   // passkey command
-  sendCommand(CMD_SET_PASSKEY_1);
+  sendCommand(CMD_SET_PASSKEY_1000);
 
   // enable sleep
   sendCommand(CMD_ENABLE_SLEEP_YES);
 
+  checkAssignProductionConfigs();
+
+  // set lower priveledge level
+  sendCommand(CMD_SET_PASSKEY_1);
 
   // set interval, define default interval
   AanderaaConductivityString interval_cmd;
@@ -163,6 +171,9 @@ bool AanderaaConductivitySensor::getData(AanderaaConductivityMsg::Data &d) {
         // Skip the first two tab-separated fields
         for (int i = 0; i < 2; i++) {
           data_start = strchr(data_start, '\t');
+          if (i == 0) {
+            validateSerialNumber(data_start);
+          }
           if (data_start) {
             data_start++; // Move past the tab
           } else {
@@ -198,62 +209,248 @@ bool AanderaaConductivitySensor::getData(AanderaaConductivityMsg::Data &d) {
   return success;
 }
 
+/*!
+ @brief Calibrate the Aanderaa 5990
+
+ @details This API is expected to be polled after the 5990 has been
+          configured. It monitors the referenceConductivity configuration
+          parameter. Once set the calibration process begins. This process
+          invokes the following steps:
+            1. Wakes up the 5990
+            2. Stops the 5990 from reporting data
+            3. Sets the passkey to 1000
+            4. Reads the current cellCoef and conductivity reading on the 5990
+            5. Calculates the updated cellCoef value
+            6. Writes the updated cellCoef value to the sensor
+            7. Saves the configuration on the device
+            8. Sets the calibration related configuration parameters on the mote
+            9. Resets the 5990
+            10. Saves the system configuration partition on the mote and reboots
+ */
 void AanderaaConductivitySensor::calibrateCellCoef(void) {
   // read sys config referenceConductivity
   get_config_float(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY), &_referenceConductivity);
 
-  if (!isnan(_referenceConductivity)) {
+  if (isnan(_referenceConductivity)) {
+    return;
+  }
+
     // if _referenceConductivity is within expected range --- Minimum = 0.000 S/m (0.000 mS/cm) and Maximum = 7.500 S/m (75.000 mS/cm)
-    if (_referenceConductivity < 0.000f || _referenceConductivity > 75.000f) {
-      debug_printf("Reference conductivity is out of range. Skipping cellCoef adjustment\n");
-      return;
-    } else {
-      debug_printf("Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n", _referenceConductivity);
-	  clearPayloadBuffer();
-	  uint16_t read_len = 0;
-      PLUART::write((uint8_t *)"\r\n", strlen("\r\n"));
-      vTaskDelay(pdMS_TO_TICKS(500));
-
-      PLUART::write((uint8_t *)CMD_SET_PASSKEY_1000, strlen(CMD_SET_PASSKEY_1000));
-	  if (PLUART::lineAvailable()) {
-      	read_len = PLUART::readLine(_payload_buffer, sizeof(_payload_buffer));
-	  	if (read_len > 0) {
-        	debug_printf("Read line for passkey 1000: %.*s\n", read_len, _payload_buffer);
-     	 }
-	  }
-      vTaskDelay(pdMS_TO_TICKS(500));
-
-      // read cellCoef
-      sendCommand(CMD_GET_CELL_COEF, &_cellCoef);
-
-      // read conductivity
-      sendCommand(CMD_GET_CONDUCTIVITY, &_measuredConductivity);
-
-      if (_cellCoef == 0.000000f || _measuredConductivity == 0.000f) {
-        /* calibration failed but the loop() in user_code.cpp will run this function again to
-         * attempt doing it again and then remove referenceConductivity from the configs */
-        debug_printf("Calibration failed because cellCoef or measuredConductivity is zero\n");
-        return;
-      } else {
-      // calculate new cellCoef
-        debug_printf("old cellCoef: %f\n", _cellCoef);
-        // Formula -> NEW cellCoef = stored cellCoef * (referenceConductivity / measuredConductivity)
-        _cellCoef = _cellCoef * (_referenceConductivity / _measuredConductivity);
-        debug_printf("new cellCoef: %f\n", _cellCoef);
-
-        // write new cellCoef to sensor
-        char calibrate_cmd[32];
-        snprintf(calibrate_cmd, sizeof(calibrate_cmd), CMD_SET_CELL_COEF, _cellCoef);
-        PLUART::write((uint8_t *)calibrate_cmd, strlen(calibrate_cmd));
-
-        // reset sensor
-        resetSensor();
-        // remove referenceConductivity from the config
-        remove_key(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY));
-        save_config(BM_CFG_PARTITION_SYSTEM, true);
-      }
-    }
+  if (_referenceConductivity < 0.000f || _referenceConductivity > 75.000f) {
+    debug_printf("Reference conductivity is out of range. Skipping cellCoef adjustment\n");
+    return;
   } 
+
+  uint32_t calib_count = 0;
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, CAL_COUNT, strlen(CAL_COUNT), &calib_count);
+
+  debug_printf("Reference conductivity %f mS/cm is within range. Proceeding with cellCoef adjustment\n", _referenceConductivity);
+
+  // Wake up the sensor and stop readings
+  sendCommand(CMD_WAKE);
+  sendCommand(CMD_STOP);
+  sendCommand(CMD_SET_PASSKEY_1000);
+
+  // read cellCoef
+  sendCommand(CMD_GET_CELL_COEF, &_cellCoef);
+  // read conductivity
+  sendCommand(CMD_GET_CONDUCTIVITY, &_measuredConductivity);
+
+  if (_cellCoef == 0.000000f || _measuredConductivity == 0.000f) {
+    /* calibration failed but the loop() in user_code.cpp will run this function again to
+     * attempt doing it again and then remove referenceConductivity from the configs */
+    debug_printf("Calibration failed because cellCoef or measuredConductivity is zero\n");
+  } else {
+  // calculate new cellCoef
+    debug_printf("old cellCoef: %f\n", _cellCoef);
+    // Formula -> NEW cellCoef = stored cellCoef * (referenceConductivity / measuredConductivity)
+    _cellCoef = _cellCoef * (_referenceConductivity / _measuredConductivity);
+    debug_printf("new cellCoef: %f\n", _cellCoef);
+
+    // write new cellCoef to sensor
+    AanderaaConductivityString calibrate_cmd;
+    snprintf(calibrate_cmd, sizeof(calibrate_cmd), CMD_SET_CELL_COEF, _cellCoef);
+    sendCommand(calibrate_cmd);
+    sendCommand(CMD_SAVE, _saveTimeMs);
+
+    // Set calibration configuration parameters
+    calib_count++;
+    remove_key(BM_CFG_PARTITION_SYSTEM, LAST_CAL_TIME_EPOCH_S, strlen(LAST_CAL_TIME_EPOCH_S));
+    set_config_float(BM_CFG_PARTITION_SYSTEM,
+                     CELL_COEF,
+                     strlen(CELL_COEF),
+                     _cellCoef);
+    set_config_uint(BM_CFG_PARTITION_SYSTEM, CAL_COUNT, strlen(CAL_COUNT), calib_count);
+    checkAssignEpochValues();
+
+    // reset sensor
+    resetSensor();
+  }
+  // remove referenceConductivity from the config
+  remove_key(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY, strlen(EXTERNAL_REFERENCE_CONDUCTIVITY));
+  save_config(BM_CFG_PARTITION_SYSTEM, true);
+}
+
+/*!
+ @brief Check and Assign Calibration Epoch Time Values
+
+ @details Verifies the cellCoef configuration exists and the RTC time is set.
+          Assigns the current RTC epoch time if calibration timestamp values
+          are missing. This function sets both firstCalTimeEpochS and
+          lastCalTimeEpochS timestamps.
+
+ @see lastCalTimeEpochS
+ @see firstCalTimeEpochS
+
+ @return true if new calibration times were assigned, false otherwise
+ */
+bool AanderaaConductivitySensor::checkAssignEpochValues(void) {
+  RtcTimeAndDate rtc_time = {};
+  if (bm_rtc_get(&rtc_time) != BmOK) {
+    return false;
+  }
+
+  float cell_coef;
+  uint32_t first_cal_time_s, last_cal_time_s;
+  bool has_calibration = get_config_float(BM_CFG_PARTITION_SYSTEM,
+                                          CELL_COEF,
+                                          strlen(CELL_COEF),
+                                          &cell_coef);
+  if (!has_calibration) {
+    return false;
+  }
+
+  // Calibration is set, check if configurations exist for calibration time
+  bool ret = false;
+  uint32_t epoch_s = (uint32_t)US_TO_S(bm_rtc_get_micro_seconds(&rtc_time));
+  bool has_first_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM,
+                                            FIRST_CAL_TIME_EPOCH_S,
+                                            strlen(FIRST_CAL_TIME_EPOCH_S),
+                                            &first_cal_time_s);
+  bool has_last_cal_time = get_config_uint(BM_CFG_PARTITION_SYSTEM,
+                                           LAST_CAL_TIME_EPOCH_S,
+                                           strlen(LAST_CAL_TIME_EPOCH_S),
+                                           &last_cal_time_s);
+
+  if (!has_first_cal_time) {
+    debug_printf("Setting first cal time %" PRIu32 "\n", epoch_s);
+    set_config_uint(BM_CFG_PARTITION_SYSTEM,
+                    FIRST_CAL_TIME_EPOCH_S,
+                    strlen(FIRST_CAL_TIME_EPOCH_S),
+                    epoch_s);
+    ret = true;
+    save_config(BM_CFG_PARTITION_SYSTEM, false);
+  }
+
+  if (!has_last_cal_time) {
+    debug_printf("Setting last cal time %" PRIu32 "\n", epoch_s);
+    set_config_uint(BM_CFG_PARTITION_SYSTEM,
+                    LAST_CAL_TIME_EPOCH_S,
+                    strlen(LAST_CAL_TIME_EPOCH_S),
+                    epoch_s);
+    ret = true;
+    save_config(BM_CFG_PARTITION_SYSTEM, false);
+  }
+
+  return ret;
+}
+
+/*!
+ @brief Validate Sensor Serial Number Against Stored Production Serial Number
+
+ @details Compares the detected serial number from sensor data with the stored
+          production serial number (sensorSerialNum). If a mismatch is detected,
+          sets errDetectedSensorSerialNum. If the serial numbers match, removes
+          the configuration parameter errDetectedSensorSerialNum.
+
+ @see sensorSerialNum
+ @see errDetectedSensorSerialNum
+
+ @param str pointer to string containing the serial number to validate
+ */
+void AanderaaConductivitySensor::validateSerialNumber(const char *str) {
+  AanderaaConductivityUint detected_serial_number = 0;
+
+  if (!str) {
+    return;
+  }
+
+  checkTypeAndAssign(str, strlen(str), &detected_serial_number);
+  debug_printf("Detected serial number: %" PRIu32 "\n", detected_serial_number);
+  if (detected_serial_number != _serialNumber) {
+    set_config_uint(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM), 1);
+  } else {
+    remove_key(BM_CFG_PARTITION_SYSTEM, ERR_SERIAL_NUM, strlen(ERR_SERIAL_NUM));
+  }
+}
+
+/*!
+ @brief Check if Production Configuration Values Exist and Populate Output Structure
+
+ @param production_configs structure to populate with production config values
+
+ @return true if both production configurations exist, false otherwise
+ */
+bool AanderaaConductivitySensor::hasProductionConfigs(ProductionConfigs &production_configs) {
+  bool has_serial_number = get_config_uint(BM_CFG_PARTITION_SYSTEM,
+                                           SENSOR_SERIAL_NUMBER,
+                                           strlen(SENSOR_SERIAL_NUMBER),
+                                           &production_configs.serial_number);
+  bool has_cell_coef = get_config_float(BM_CFG_PARTITION_SYSTEM,
+                                       FACTORY_CELL_COEF,
+                                       strlen(FACTORY_CELL_COEF),
+                                       &production_configs.cell_coef);
+
+  return has_serial_number && has_cell_coef;
+}
+
+/*!
+ @brief Check and Assign Production Configuration Values from Sensor
+
+ @details Reads the serial number and cell coefficient directly from the sensor
+          hardware and stores them as production configuration values if they don't
+          already exist. Uses a loop to ensure multiple readings are the
+          same in a row to reduce the chance of a glitch on the UART line from
+          ruining the reading. The serial number is also cached in the
+          _serialNumber member variable.
+
+ @see factoryCellCoef
+ @see sensorSerialNum
+ */
+void AanderaaConductivitySensor::checkAssignProductionConfigs(void) {
+  ProductionConfigs production_configs = {};
+  ProductionConfigs prev_read_configs = {};
+  ProductionConfigs read_configs = {};
+
+  // Ensure robust readings for serial number
+  do {
+    prev_read_configs = read_configs;
+    if (sendCommand(CMD_GET_SERIAL_NUMBER, &read_configs.serial_number) == BmOK) {
+        debug_printf("Serial number is %" PRIu32 "\n", read_configs.serial_number);
+    }
+    if (sendCommand(CMD_GET_CELL_COEF, &read_configs.cell_coef) == BmOK) {
+
+        debug_printf("cellCoef is %0.4f\n", read_configs.cell_coef);
+    }
+  } while (prev_read_configs.serial_number != read_configs.serial_number &&
+           prev_read_configs.cell_coef != read_configs.cell_coef);
+
+  _serialNumber = read_configs.serial_number;
+
+  if (hasProductionConfigs(production_configs)) {
+      return;
+  }
+
+  debug_printf("Saving production configs!\n");
+  set_config_uint(BM_CFG_PARTITION_SYSTEM,
+                  SENSOR_SERIAL_NUMBER,
+                  strlen(SENSOR_SERIAL_NUMBER),
+                  read_configs.serial_number);
+  set_config_float(BM_CFG_PARTITION_SYSTEM,
+                  FACTORY_CELL_COEF,
+                  strlen(FACTORY_CELL_COEF),
+                  read_configs.cell_coef);
+  save_config(BM_CFG_PARTITION_SYSTEM, false);
 }
 
 /*!

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -28,7 +28,7 @@ extern "C" {
 #define CMD_SET_INTERVAL "Set Interval(%" PRIu32 ")\r\n"
 #define CMD_SAVE "Save\r\n"
 #define CMD_RESET "Reset\r\n"
-#define ACK "#\r\n"
+#define ACK "#"
 #define CMD_WAKE "\r\n"
 #define CMD_GET_ALL "Get_All\r\n"
 #define CMD_GET_ALL_PARAMS "Get_All Parameters\r\n"
@@ -36,6 +36,7 @@ extern "C" {
 #define CMD_SET_CELL_COEF "Set CellCoef(%f)\r\n"
 #define CMD_GET_CELL_COEF "Get CellCoef\r\n"
 #define CMD_GET_CONDUCTIVITY "Get Conductivity\r\n"
+#define CMD_GET_SERIAL_NUMBER "Get Serial Number\r\n"
 
 class AanderaaConductivitySensor {
 public:
@@ -48,6 +49,8 @@ public:
   void resetSensor(void);
   void startStreaming(void);
   void calibrateCellCoef(void);
+  bool checkAssignEpochValues(void);
+
 
   static constexpr char AANDERAA_CONDUCTIVITY_RAW_LOG[] = "aanderaa_salinity_raw.log";
 
@@ -55,6 +58,11 @@ private:
   typedef uint32_t AanderaaConductivityUint;
   typedef float AanderaaConductivityFloat;
   typedef char AanderaaConductivityString[32];
+
+  typedef struct {
+    AanderaaConductivityUint serial_number;
+    AanderaaConductivityFloat cell_coef;
+  } ProductionConfigs;
 
   static constexpr uint32_t BAUD_RATE = 9600;
   static constexpr char LINE_TERM = '\n';
@@ -66,6 +74,14 @@ private:
   static constexpr char SENSOR_DEPTH_M[] = "sensorDepthM";
   static constexpr char SENSOR_INTERVAL_S[] = "readingPeriodS";
   static constexpr char EXTERNAL_REFERENCE_CONDUCTIVITY[] = "referenceConductivity";
+  static constexpr char CELL_COEF[] = "cellCoef";
+  static constexpr char LAST_CAL_TIME_EPOCH_S[] = "lastCalTimeEpochS";
+  static constexpr char CAL_COUNT[] = "calibrationCount";
+  static constexpr char SENSOR_SERIAL_NUMBER[] = "sensorSerialNum";
+  static constexpr char ERR_SERIAL_NUM[] = "errDetectedSensorSerialNum";
+
+  static constexpr char FIRST_CAL_TIME_EPOCH_S[] = "firstCalTimeEpochS";
+  static constexpr char FACTORY_CELL_COEF[] = "factoryCellCoef";
 
   uint32_t _sensorBmLogEnable = 0;
   float _sensorDepthM = 0.0f;
@@ -73,6 +89,7 @@ private:
   uint32_t _readingPeriodS = 2;
   OrderedSeparatorLineParser _parser;
   char _payload_buffer[2048];
+  AanderaaConductivityUint _serialNumber;
 
   float _cellCoef = 0.000000f;
   float _referenceConductivity = NAN;
@@ -81,6 +98,11 @@ private:
   // The save procedure may take up to 20 seconds according to Table 5-2 in the
   // TD321 Operation Manual
   static constexpr uint16_t _saveTimeMs = 20000;
+
+  void validateSerialNumber(const char *str);
+
+  bool hasProductionConfigs(ProductionConfigs &production_configs);
+  void checkAssignProductionConfigs(void);
 
   void checkTypeAndAssign(const char *output, uint16_t length, AanderaaConductivityUint *value);
   void checkTypeAndAssign(const char *output, uint16_t length,

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -53,6 +53,7 @@ public:
 
 
   static constexpr char AANDERAA_CONDUCTIVITY_RAW_LOG[] = "aanderaa_salinity_raw.log";
+  static constexpr char AANDERAA_CONDUCTIVITY_LOG[] = "aanderaa_salinity.log";
 
 private:
   typedef uint32_t AanderaaConductivityUint;

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -91,6 +91,7 @@ private:
   OrderedSeparatorLineParser _parser;
   char _payload_buffer[2048];
   AanderaaConductivityUint _serialNumber;
+  bool _serialNumberErrSet = false;
 
   float _cellCoef = 0.000000f;
   float _referenceConductivity = NAN;

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/user_code.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/user_code.cpp
@@ -60,5 +60,6 @@ void loop(void) {
   }
 
   vTaskDelay(pdMS_TO_TICKS(10));
+  aanderaa_conductivity_sensor.checkAssignEpochValues();
   aanderaa_conductivity_sensor.calibrateCellCoef();
 }


### PR DESCRIPTION
## What changed?
Adds the following configuration parameters:
- cellCoef
  - The current cellCoef value of the 5990
- lastestCalTimeEpochS
  - The latest time cellCoef has been set on the device
- calibrationCount
  - The number of times the device went through calibration of the cellCoef parameter
- sensorSerialNum
  - The production serial number of the device
- errDetectedSensorSerialNum
  - If the current serial number does not match the production serial number, this error is thrown
- firstCalTimeEpochS
  - The first epoch time the sensor was calibrated
- factoryCellCoef
  - The cellCoef parameter before any the user or production line has calibrated the sensor


## How does it make Bristlemouth better?
This:

- Reflects a device's calibration settings in the system configs
  - cellCoef
  - Epoch time in seconds of first and last calibration
- Informs the user if they swapped the 5990 sensor by setting a system configuration
- Informs the backend of the serial number expected from the sensor, which is written to a system configuration
- If epoch values cannot be set during calibration (because RTC is zero), the sensor will wait until the RTC is set before assigning these values.

## Where should reviewers focus?
Currently the `errDetectedSensorSerialNum` config is set and a **log statement is sent to the XXXX_aanderaa_salinity.log** file when the detected serial number does not match the production serial number of the attached 5990 if either of the following is true:

- The error has not been set since boot
- The configuration does not exist

Is this desirable? This mainly is in reference to the **log statement is sent to the XXXX_aanderaa_salinity.log** file, do we want this log statement to appear only once? Or once during every boot? When the detected 5990 serial number does not match the production.

How do the rest of the workflows look for the calibration configurations?

## Testing

### Production configuration recognition
Initial boot of the device the following events will occur:

1. The 5990 boots up
2. The serial number and cellCoef values are read directly from the device
3. `sensorSerialNum` and `factoryCellCoef` are not set, the firmware recognizes this and sets the configs:
  ```
  command: Get Serial Number
  command response: Serial Number 5990    74      74
  command response: #
  sendCommand err: 0
  Serial number is 74
  command: Get CellCoef
  command response: CellCoef      5990    74      3.995771E+01
  command response: #
  sendCommand err: 0
  cellCoef is 39.9577
  Saving production configs!
  Successfully erased sector
  Successfully erased sector
  Successfully erased sector
  ```

Evaluating the configs from a Sofar Spotter buoy gives the following result:

```
bm cfg status 9baba44dd734e4ad s
...
Succesfull status request send
2025-10-30T00:10:32.320Z [BRIDGE_CFG] [INFO] Response msg -- Node Id: 9baba44dd734e4ad, Partition: system, Commit Status: 0
2025-10-30T00:10:32.320Z [BRIDGE_CFG] [INFO] Num Keys: 3
2025-10-30T00:10:32.320Z [BRIDGE_CFG] [INFO] Key 0: disableUnusedPortsTimeMs
2025-10-30T00:10:32.320Z [BRIDGE_CFG] [INFO] Key 1: sensorSerialNum
2025-10-30T00:10:32.320Z [BRIDGE_CFG] [INFO] Key 2: factoryCellCoef
2025-10-30T00:10:32.328Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 0
2025-10-30T00:10:32.328Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 74
2025-10-30T00:10:32.335Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 39.957710
```

Calibrating the sensor from the Spotter console with the following command:

```
bm cfg set 9baba44dd734e4ad s f referenceConductivity 0.050
```

Will result in the following configuration status:

```
Succesfull status request send
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Response msg -- Node Id: 9baba44dd734e4ad, Partition: system, Commit Status: 0
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Num Keys: 7
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 0: disableUnusedPortsTimeMs
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 1: sensorSerialNum
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 2: factoryCellCoef
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 3: cellCoef
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 4: calibrationCount
2025-10-31T10:58:34.308Z [BRIDGE_CFG] [INFO] Key 5: firstCalTimeEpochS
2025-10-31T10:58:34.312Z [BRIDGE_CFG] [INFO] Key 6: lastCalTimeEpochS
2025-10-31T10:58:34.320Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 0
2025-10-31T10:58:34.320Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 74
2025-10-31T10:58:34.328Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 39.957710
2025-10-31T10:58:34.328Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 25.613918
2025-10-31T10:58:34.335Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1
2025-10-31T10:58:34.339Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908296
2025-10-31T10:58:34.343Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908296
```

The `cellCoef`, `calibrationCount`, `firstTimeEpochS` and `lastCalTimeEpochS` are all new parameters added upon first calibration.

Running the calibration again will output the following results:

```
Succesfull status request send
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Response msg -- Node Id: 9baba44dd734e4ad, Partition: system, Commit Status: 0
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Num Keys: 7
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 0: disableUnusedPortsTimeMs
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 1: sensorSerialNum
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 2: factoryCellCoef
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 3: cellCoef
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 4: calibrationCount
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 5: firstCalTimeEpochS
2025-10-31T11:02:49.804Z [BRIDGE_CFG] [INFO] Key 6: lastCalTimeEpochS
2025-10-31T11:02:49.812Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 0
2025-10-31T11:02:49.816Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 74
2025-10-31T11:02:49.824Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 39.957710
2025-10-31T11:02:49.824Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 265.804840
2025-10-31T11:02:49.832Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 2
2025-10-31T11:02:49.835Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908296
2025-10-31T11:02:49.839Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908563
```

Notice the updates in `cellCoef`, `calibrationCount` and `lastCalTimeEpochS`

When swapping the installed 5990 with another 5990 (which has a different serial number) the following configuration output is observed:

```
Succesfull status request send
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Response msg -- Node Id: 9baba44dd734e4ad, Partition: system, Commit Status: 1
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Num Keys: 8
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 0: disableUnusedPortsTimeMs
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 1: sensorSerialNum
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 2: factoryCellCoef
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 3: cellCoef
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 4: calibrationCount
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 5: firstCalTimeEpochS
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 6: lastCalTimeEpochS
2025-10-31T11:44:01.871Z [BRIDGE_CFG] [INFO] Key 7: errDetectedSensorSerialNum
2025-10-31T11:44:01.878Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 0
2025-10-31T11:44:01.882Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 74
2025-10-31T11:44:01.890Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 39.957710
2025-10-31T11:44:01.890Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 265.804840
2025-10-31T11:44:01.898Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 2
2025-10-31T11:44:01.902Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908296
2025-10-31T11:44:01.906Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908563
2025-10-31T11:44:01.910Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1
```

Note the `errDetectedSensorSerialNum` config.
The following is the output for the `XXXX_aanderaa_salinity.log file` when this error is set.

```
2025-10-31T11:46:30.457Z | Err: Detected 5990 serial number 88 does not match production serial number: 74
```

Upon attaching the original production sensor the following output can be observed:

```
Succesfull status request send
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Response msg -- Node Id: 9baba44dd734e4ad, Partition: system, Commit Status: 0
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Num Keys: 7
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 0: disableUnusedPortsTimeMs
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 1: sensorSerialNum
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 2: factoryCellCoef
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 3: cellCoef
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 4: calibrationCount
2025-10-31T11:56:26.113Z [BRIDGE_CFG] [INFO] Key 5: firstCalTimeEpochS
2025-10-31T11:56:26.117Z [BRIDGE_CFG] [INFO] Key 6: lastCalTimeEpochS
2025-10-31T11:56:26.121Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 0
2025-10-31T11:56:26.125Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 74
2025-10-31T11:56:26.132Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 39.957710
2025-10-31T11:56:26.132Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 265.804840
2025-10-31T11:56:26.140Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 2
2025-10-31T11:56:26.144Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908296
2025-10-31T11:56:26.148Z [BRIDGE_CFG] [INFO] Node ID: 9baba44dd734e4ad Partition: system Value: 1761908563
```

Note the `errDetectedSensorSerialNum` config  value has been deleted.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
