### PR TITLE
Fix/aanderaa salinity low power activation time

### DIFF
--- a/src/apps/bridge/app_config.h
+++ b/src/apps/bridge/app_config.h
@@ -23,7 +23,7 @@ constexpr const char *SOFT_READING_PERIOD_MS = "softReadingPeriodMs";
 constexpr const char *RBR_CODA_READING_PERIOD_MS = "rbrCodaReadingPeriodMs";
 constexpr const char *TICKS_SAMPLING_ENABLED = "ticksSamplingEnabled";
 constexpr const char *TURBIDITY_READING_PERIOD_MS = "turbidityReadingPeriodMs";
-constexpr const char *AANDERAA_CONDUCTIVITY_READING_PERIOD_MS = "conductivityReadingPeriodMs";
+constexpr const char *AANDERAA_SALINITY_READING_PERIOD_MS = "salinityReadingPeriodMs";
 constexpr const char *HARDWARE_VERSION = "hwVersion";
 #ifdef RAW_PRESSURE_ENABLE
 constexpr const char *RBR_RAW_DIFFERENTIAL_SIGNAL_PERIOD_S = "rbrRawSampleS";

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -64,7 +64,7 @@ static const SensorSubscriptionCtx<AanderaaConductivity_t> aanderaa_conductivity
     .sensor_type = SENSOR_TYPE_AANDERAA_CONDUCTIVITY,
     .reading_period =
         {
-            .config_key = AppConfig::AANDERAA_CONDUCTIVITY_READING_PERIOD_MS,
+            .config_key = AppConfig::AANDERAA_SALINITY_READING_PERIOD_MS,
             .ms = &_ctx.aanderaa_conductivity_reading_period_ms,
             .default_ms = AanderaaConductivitySensor::get_default_reading_period_ms(),
         },

--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
@@ -227,7 +227,7 @@ void AanderaaConductivitySensor::setup_sensor_pointers(report_builder_element_t 
 BmErr AanderaaConductivitySensor::send_spotter_log_individual(
     const AanderaaConductivityMsg::Data &m) {
   BmErr err = AbstractSensor::send_spotter_log_individual(
-      "aanderaa_salinity", m.header, DEFAULT_AANDERAA_CONDUCTIVITY_READING_PERIOD_MS + 1000U,
+      "aanderaa_salinity", m.header, DEFAULT_AANDERAA_SALINITY_READING_PERIOD_MS + 1000U,
       "%.4f,"   // conductivity_ms_cm
       "%.3f,"   // temperature_deg_c
       "%.3f,"   // salinity_psu

--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.h
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.h
@@ -150,7 +150,7 @@ private:
   static constexpr uint32_t AANDERAA_CONDUCTIVITY_NUM_SAMPLE_MEMBERS = 7;
   static constexpr uint8_t MIN_READINGS_FOR_AGGREGATION = 3;
   static constexpr char subtag[] = "/sofar/aanderaa_conductivity_data";
-  static constexpr uint32_t DEFAULT_AANDERAA_CONDUCTIVITY_READING_PERIOD_MS = 30000;
+  static constexpr uint32_t DEFAULT_AANDERAA_SALINITY_READING_PERIOD_MS = 30000;
 
   BmErr send_spotter_log_individual(const AanderaaConductivityMsg::Data &m);
   BmErr send_spotter_log_aggregate(const AanderaaConductivityAggregations &agg);
@@ -198,7 +198,7 @@ public:
    * @return Default reading period in milliseconds.
    */
   static uint32_t get_default_reading_period_ms(void) {
-    return DEFAULT_AANDERAA_CONDUCTIVITY_READING_PERIOD_MS;
+    return DEFAULT_AANDERAA_SALINITY_READING_PERIOD_MS;
   }
 
 } AanderaaConductivity_t;

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -66,6 +66,9 @@ void AanderaaConductivitySensor::configureSensor(void) {
   // enable sleep
   sendCommand(CMD_ENABLE_SLEEP_YES);
 
+  // set sleep timeout to 10s
+  sendCommand(CMD_SET_COMM_TIMEOUT_10S);
+
   checkAssignProductionConfigs();
 
   get_config_uint(BM_CFG_PARTITION_SYSTEM, SENSOR_SERIAL_NUMBER, strlen(SENSOR_SERIAL_NUMBER),

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -37,6 +37,7 @@ extern "C" {
 #define CMD_GET_CELL_COEF "Get CellCoef\r\n"
 #define CMD_GET_CONDUCTIVITY "Get Conductivity\r\n"
 #define CMD_GET_SERIAL_NUMBER "Get Serial Number\r\n"
+#define CMD_SET_COMM_TIMEOUT_10S "Set Comm TimeOut(10 s)\r\n"
 
 class AanderaaConductivitySensor {
 public:


### PR DESCRIPTION
## What changed?
Change the timeout for the salinity sensor to go into low power mode from 60 seconds, to 10 seconds.
Also changes the bridge configuration name for salinity reading period from `conductivityReadingPeriodMs` to `salinityReadingPeriodMs`.


## How does it make Bristlemouth better?
When the Aanderaa 5990 is not in low power mode, it consumes an excess of ~100mW, meaning this reduces the amount of time the device will be in a high powered state!
Below is a graph showing the Bristlemouth network power draw of a system with a single Salinity sensor attached with this change implemented:
<img width="720" height="435" alt="image" src="https://github.com/user-attachments/assets/84b89346-b935-461d-b2a7-977fa001a4f5" />

The following is a graph showing the Bristlemouth network power draw of a system with a single salinty sensor attached prior to this change:

<img width="601" height="374" alt="image" src="https://github.com/user-attachments/assets/56b16a0a-dbba-4eda-9c41-d016641f7cb7" />

Note the X-Axis time. The large spikes in power draw are when the salinity sensor is collecting its readings.


## Where should reviewers focus?
Questions or further validations necessary?
Not a large amount of change, but quite important!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
