### PR TITLE
Add In Read Validate Write Logic To aanderaa_conductivity_sensor.cpp

### DIFF
--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -621,6 +621,20 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command, T *value,
   return err;
 }
 
+/*!
+ @brief Compares UINT Values And Populates Set Buffer To Send Values
+
+ @details If the values for read and expected do not match, the buffer used to
+          set the parameter is populated.
+
+ @param parameter parameter to set if values do not match
+ @param buf buffer to populate to send the set command
+ @param read read value from 5990
+ @param expected expected value
+
+ @return true if the read value matches the expected value
+         false if the read value does not match the expected value
+ */
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
     const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityUint read,
@@ -635,13 +649,27 @@ bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
   return false;
 }
 
+/*!
+ @brief Compares Float Values And Populates Set Buffer To Send Values
+
+ @details If the values for read and expected do not match, the buffer used to
+          set the parameter is populated.
+
+ @param parameter parameter to set if values do not match
+ @param buf buffer to populate to send the set command
+ @param read read value from 5990
+ @param expected expected value
+
+ @return true if the read value matches the expected value
+         false if the read value does not match the expected value
+ */
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
     const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityFloat read,
     const AanderaaConductivitySensor::AanderaaConductivityFloat expected) {
 
-  constexpr float EPSILON = 0.0001f;
-  if (fabs(read - expected) < EPSILON) {
+  constexpr float epsilon = 0.0001f;
+  if (fabs(read - expected) < epsilon) {
     return true;
   }
 
@@ -650,6 +678,20 @@ bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
   return false;
 }
 
+/*!
+ @brief Compares String Values And Populates Set Buffer To Send Values
+
+ @details If the values for read and expected do not match, the buffer used to
+          set the parameter is populated.
+
+ @param parameter parameter to set if values do not match
+ @param buf buffer to populate to send the set command
+ @param read read value from 5990
+ @param expected expected value
+
+ @return true if the read value matches the expected value
+         false if the read value does not match the expected value
+ */
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
     const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityString read,
@@ -664,6 +706,16 @@ bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
   return false;
 }
 
+/*!
+ @brief Overloaded Wrapper To Accept String Literals For Expected Value
+
+ @param parameter parameter to get/set
+ @param expected_val expected value from get command
+ @param retries number of times to retry getting/setting the parameter
+
+ @return BmOk on success,
+         BmEINVAL if expected value is longer than AanderaaConductivityString
+ */
 BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter,
                                                          const char *expected_val,
                                                          uint8_t retries) {
@@ -678,6 +730,25 @@ BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter,
   return readValidateWriteValue<AanderaaConductivityString>(parameter, str_buf, retries);
 }
 
+/*!
+ @brief Reads/Validate/Write a Parameter On The 5990
+
+ @details This function will get a specified parameter from the 5990, compare that
+          parameter to an expected value and then proceed to write that parameter
+          if the read parameter is not expected. This will then mark the 5990's 
+          config parameters as dirty and will save the configuration to the
+          5990 at the end of configureSensor. Retries are implemented to
+          ensure that the get/set commands are able to be invoked properly.
+
+ @param parameter parameter to get/set
+ @param expected_val expected value from get command
+ @param retries number of times to retry getting/setting the parameter
+
+ @return BmOK on successful write or if the expected value matches the read value
+ @return BmEINVAL if command is NULL
+ @return BmETIMEDOUT if no response received within timeout
+ @return BmEBADMSG if sensor responds with error acknowledgment ('*')
+ */
 template <typename T>
 BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter, T expected_val,
                                                          uint8_t retries) {

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -622,7 +622,7 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command, T *value,
 }
 
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
-    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityUint read,
     const AanderaaConductivitySensor::AanderaaConductivityUint expected) {
 
@@ -630,27 +630,28 @@ bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
     return true;
   }
 
-  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%" PRIu32 ")\r\n", CMD_SET,
+  snprintf(*buf, sizeof(AanderaaConductivityString), "%s %s(%" PRIu32 ")\r\n", CMD_SET,
            parameter, expected);
   return false;
 }
 
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
-    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityFloat read,
     const AanderaaConductivitySensor::AanderaaConductivityFloat expected) {
 
-  if (read == expected) {
+  constexpr float EPSILON = 0.0001f;
+  if (fabs(read - expected) < EPSILON) {
     return true;
   }
 
-  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%f)\r\n", CMD_SET, parameter,
+  snprintf(*buf, sizeof(AanderaaConductivityString), "%s %s(%f)\r\n", CMD_SET, parameter,
            expected);
   return false;
 }
 
 bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
-    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString *buf,
     const AanderaaConductivitySensor::AanderaaConductivityString read,
     const AanderaaConductivitySensor::AanderaaConductivityString expected) {
 
@@ -658,7 +659,7 @@ bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
     return true;
   }
 
-  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%s)\r\n", CMD_SET, parameter,
+  snprintf(*buf, sizeof(AanderaaConductivityString), "%s %s(%s)\r\n", CMD_SET, parameter,
            expected);
   return false;
 }
@@ -681,25 +682,23 @@ template <typename T>
 BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter, T expected_val,
                                                          uint8_t retries) {
   T read_val;
-  AanderaaConductivityString _readValidateCompareBuf = {};
+  AanderaaConductivityString command_buf = {};
   BmErr ret = BmOK;
 
   do {
-    snprintf(_readValidateCompareBuf, sizeof(_readValidateCompareBuf), "%s %s\r\n", CMD_GET,
-             parameter);
+    snprintf(command_buf, sizeof(command_buf), "%s %s\r\n", CMD_GET, parameter);
 
-    ret = sendCommand(_readValidateCompareBuf, &read_val);
+    ret = sendCommand(command_buf, &read_val);
     if (ret != BmOK) {
       continue;
     }
 
-    if (compareValuesPopulateBuffer(parameter, _readValidateCompareBuf, read_val,
-                                    expected_val)) {
+    if (compareValuesPopulateBuffer(parameter, &command_buf, read_val, expected_val)) {
       ret = BmOK;
       break;
     }
 
-    ret = sendCommand(_readValidateCompareBuf);
+    ret = sendCommand(command_buf);
 
     if (ret == BmOK) {
       _sensorConfigDirty = true;

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -64,10 +64,10 @@ void AanderaaConductivitySensor::configureSensor(void) {
   sendCommand(CMD_SET_PASSKEY_1000);
 
   // enable sleep
-  sendCommand(CMD_ENABLE_SLEEP_YES);
+  readValidateWriteValue(CMD_ENABLE_SLEEP, CMD_YES);
 
   // set sleep timeout to 10s
-  sendCommand(CMD_SET_COMM_TIMEOUT_10S);
+  readValidateWriteValue(CMD_COMM_TIMEOUT, "10 s");
 
   checkAssignProductionConfigs();
 
@@ -78,43 +78,42 @@ void AanderaaConductivitySensor::configureSensor(void) {
   sendCommand(CMD_SET_PASSKEY_1);
 
   // set interval, define default interval
-  AanderaaConductivityString interval_cmd;
-  snprintf(interval_cmd, sizeof(interval_cmd), CMD_SET_INTERVAL, _readingPeriodS);
-  sendCommand(interval_cmd);
+  readValidateWriteValue(CMD_INTERVAL, (AanderaaConductivityUint)_readingPeriodS);
 
   // enable Temperature
-  sendCommand(CMD_ENABLE_TEMPERATURE_YES);
+  readValidateWriteValue(CMD_ENABLE_TEMPERATURE, CMD_YES);
 
   // disable rawdata
-  sendCommand(CMD_ENABLE_RAWDATA_NO);
+  readValidateWriteValue(CMD_ENABLE_RAWDATA, CMD_NO);
 
   // disable RawCond1
-  sendCommand(CMD_ENABLE_RAWCOND1_NO);
+  readValidateWriteValue(CMD_ENABLE_RAWCOND1, CMD_NO);
 
   // enable conductivity
-  sendCommand(CMD_ENABLE_CONDUCTIVITY_YES);
+  readValidateWriteValue(CMD_ENABLE_CONDUCTIVITY, CMD_YES);
 
   //  disable Polled Mode
-  sendCommand(CMD_ENABLE_POLLEDMODE_NO);
+  readValidateWriteValue(CMD_ENABLE_POLLEDMODE, CMD_NO);
 
   // disable text
-  sendCommand(CMD_ENABLE_TEXT_NO);
+  readValidateWriteValue(CMD_ENABLE_TEXT, CMD_NO);
 
   // enable decimalformat
-  sendCommand(CMD_ENABLE_DECIMALFORMAT_YES);
+  readValidateWriteValue(CMD_ENABLE_DECIMALFORMAT, CMD_YES);
 
   // enable derived parameters
-  sendCommand(CMD_ENABLE_DERIVEDPARAMETERS_YES);
+  readValidateWriteValue(CMD_ENABLE_DERIVEDPARAMETERS, CMD_YES);
 
   // set pressure command
   spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
               "Calculated pressure for depth %.2f m is %f kPa\n", _sensorDepthM, _pressureKpa);
-  AanderaaConductivityString pressure_cmd;
-  snprintf(pressure_cmd, sizeof(pressure_cmd), CMD_SET_PRESSURE, _pressureKpa);
-  sendCommand(pressure_cmd);
+  readValidateWriteValue(CMD_PRESSURE, (AanderaaConductivityFloat)_pressureKpa);
 
   // save
-  sendCommand(CMD_SAVE, _saveTimeMs);
+  if (_sensorConfigDirty) {
+    sendCommand(CMD_SAVE, _saveTimeMs);
+    _sensorConfigDirty = false;
+  }
 
   // send get_all command
   PLUART::write((uint8_t *)CMD_GET_ALL, strlen(CMD_GET_ALL));
@@ -620,4 +619,92 @@ BmErr AanderaaConductivitySensor::sendCommand(const char *command, T *value,
   debug_printf("%s err: %d\n", __func__, err);
 
   return err;
+}
+
+bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const AanderaaConductivitySensor::AanderaaConductivityUint read,
+    const AanderaaConductivitySensor::AanderaaConductivityUint expected) {
+
+  if (read == expected) {
+    return true;
+  }
+
+  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%" PRIu32 ")\r\n", CMD_SET,
+           parameter, expected);
+  return false;
+}
+
+bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const AanderaaConductivitySensor::AanderaaConductivityFloat read,
+    const AanderaaConductivitySensor::AanderaaConductivityFloat expected) {
+
+  if (read == expected) {
+    return true;
+  }
+
+  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%f)\r\n", CMD_SET, parameter,
+           expected);
+  return false;
+}
+
+bool AanderaaConductivitySensor::compareValuesPopulateBuffer(
+    const char *parameter, AanderaaConductivitySensor::AanderaaConductivityString buf,
+    const AanderaaConductivitySensor::AanderaaConductivityString read,
+    const AanderaaConductivitySensor::AanderaaConductivityString expected) {
+
+  if (!strncmp(read, expected, sizeof(AanderaaConductivityString))) {
+    return true;
+  }
+
+  snprintf(buf, sizeof(AanderaaConductivityString), "%s %s(%s)\r\n", CMD_SET, parameter,
+           expected);
+  return false;
+}
+
+BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter,
+                                                         const char *expected_val,
+                                                         uint8_t retries) {
+  AanderaaConductivityString str_buf = {};
+
+  if (strlen(expected_val) > sizeof(str_buf)) {
+    return BmEINVAL;
+  }
+
+  strncpy(str_buf, expected_val, sizeof(str_buf));
+
+  return readValidateWriteValue<AanderaaConductivityString>(parameter, str_buf, retries);
+}
+
+template <typename T>
+BmErr AanderaaConductivitySensor::readValidateWriteValue(const char *parameter, T expected_val,
+                                                         uint8_t retries) {
+  T read_val;
+  AanderaaConductivityString _readValidateCompareBuf = {};
+  BmErr ret = BmOK;
+
+  do {
+    snprintf(_readValidateCompareBuf, sizeof(_readValidateCompareBuf), "%s %s\r\n", CMD_GET,
+             parameter);
+
+    ret = sendCommand(_readValidateCompareBuf, &read_val);
+    if (ret != BmOK) {
+      continue;
+    }
+
+    if (compareValuesPopulateBuffer(parameter, _readValidateCompareBuf, read_val,
+                                    expected_val)) {
+      ret = BmOK;
+      break;
+    }
+
+    ret = sendCommand(_readValidateCompareBuf);
+
+    if (ret == BmOK) {
+      _sensorConfigDirty = true;
+    }
+  } while (ret != BmOK && retries--);
+
+  return ret;
 }

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -14,30 +14,36 @@ extern "C" {
 #define CMD_START "Start\r\n"
 #define CMD_SET_PASSKEY_1 "Set Passkey(1)\r\n"
 #define CMD_SET_PASSKEY_1000 "Set Passkey(1000)\r\n"
-#define CMD_ENABLE_CONDUCTIVITY_YES "Set Enable Conductivity(Yes)\r\n"
-#define CMD_ENABLE_SLEEP_YES "Set Enable Sleep(Yes)\r\n"
-#define CMD_ENABLE_POLLEDMODE_NO "Set Enable Polled Mode(No)\r\n"
-#define CMD_ENABLE_TEXT_YES "Set Enable Text(Yes)\r\n"
-#define CMD_ENABLE_TEXT_NO "Set Enable Text(No)\r\n"
-#define CMD_ENABLE_DECIMALFORMAT_YES "Set Enable Decimalformat(Yes)\r\n"
-#define CMD_ENABLE_TEMPERATURE_YES "Set Enable Temperature(Yes)\r\n"
-#define CMD_ENABLE_RAWDATA_NO "Set Enable Rawdata(No)\r\n"
-#define CMD_ENABLE_DERIVEDPARAMETERS_YES "Set Enable Derived Parameters(Yes)\r\n"
-#define CMD_ENABLE_DERIVEDPARAMETERS_NO "Set Enable Derived Parameters(No)\r\n"
-#define CMD_ENABLE_RAWCOND1_NO "Set Enable RawCond1(No)\r\n"
-#define CMD_SET_INTERVAL "Set Interval(%" PRIu32 ")\r\n"
+
+#define CMD_ENABLE_CONDUCTIVITY "Enable Conductivity"
+#define CMD_ENABLE_SLEEP "Enable Sleep"
+#define CMD_ENABLE_POLLEDMODE "Enable Polled Mode"
+#define CMD_ENABLE_TEXT "Enable Text"
+#define CMD_ENABLE_DECIMALFORMAT "Enable Decimalformat"
+#define CMD_ENABLE_TEMPERATURE "Enable Temperature"
+#define CMD_ENABLE_RAWDATA "Enable Rawdata"
+#define CMD_ENABLE_DERIVEDPARAMETERS "Enable Derived Parameters"
+#define CMD_ENABLE_RAWCOND1 "Enable RawCond1"
+#define CMD_INTERVAL "Interval"
+#define CMD_COMM_TIMEOUT "Comm TimeOut"
+#define CMD_PRESSURE "Pressure"
+
+#define CMD_YES "Yes"
+#define CMD_NO "No"
+
+#define CMD_GET "Get"
+#define CMD_SET "Set"
+
 #define CMD_SAVE "Save\r\n"
 #define CMD_RESET "Reset\r\n"
 #define ACK "#"
 #define CMD_WAKE "\r\n"
 #define CMD_GET_ALL "Get_All\r\n"
 #define CMD_GET_ALL_PARAMS "Get_All Parameters\r\n"
-#define CMD_SET_PRESSURE "Set Pressure(%f)\r\n"
 #define CMD_SET_CELL_COEF "Set CellCoef(%f)\r\n"
 #define CMD_GET_CELL_COEF "Get CellCoef\r\n"
 #define CMD_GET_CONDUCTIVITY "Get Conductivity\r\n"
 #define CMD_GET_SERIAL_NUMBER "Get Serial Number\r\n"
-#define CMD_SET_COMM_TIMEOUT_10S "Set Comm TimeOut(10 s)\r\n"
 
 class AanderaaConductivitySensor {
 public:
@@ -51,7 +57,6 @@ public:
   void startStreaming(void);
   void calibrateCellCoef(void);
   bool checkAssignEpochValues(void);
-
 
   static constexpr char AANDERAA_CONDUCTIVITY_RAW_LOG[] = "aanderaa_salinity_raw.log";
   static constexpr char AANDERAA_CONDUCTIVITY_LOG[] = "aanderaa_salinity.log";
@@ -97,6 +102,7 @@ private:
   float _cellCoef = 0.000000f;
   float _referenceConductivity = NAN;
   float _measuredConductivity = NAN;
+  bool _sensorConfigDirty = false;
 
   // The save procedure may take up to 20 seconds according to Table 5-2 in the
   // TD321 Operation Manual
@@ -110,9 +116,25 @@ private:
   void checkTypeAndAssign(const char *output, uint16_t length, AanderaaConductivityUint *value);
   void checkTypeAndAssign(const char *output, uint16_t length,
                           AanderaaConductivityFloat *value);
-  void checkTypeAndAssign(const char *output, uint16_t length, AanderaaConductivityString *value);
+  void checkTypeAndAssign(const char *output, uint16_t length,
+                          AanderaaConductivityString *value);
 
   BmErr sendCommand(const char *command, uint32_t timeout_ms = 1000);
   template <typename T>
   BmErr sendCommand(const char *command, T *value = nullptr, uint32_t timeout_ms = 1000);
+
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+                                   const AanderaaConductivityUint read,
+                                   const AanderaaConductivityUint validate);
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+                                   const AanderaaConductivityFloat read,
+                                   const AanderaaConductivityFloat validate);
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+                                   const AanderaaConductivityString read,
+                                   const AanderaaConductivityString validate);
+
+  BmErr readValidateWriteValue(const char *parameter, const char *expected_val,
+                               uint8_t retries = 3);
+  template <typename T>
+  BmErr readValidateWriteValue(const char *parameter, T expected_val, uint8_t retries = 3);
 };

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -123,13 +123,13 @@ private:
   template <typename T>
   BmErr sendCommand(const char *command, T *value = nullptr, uint32_t timeout_ms = 1000);
 
-  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString *buf,
                                    const AanderaaConductivityUint read,
                                    const AanderaaConductivityUint validate);
-  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString *buf,
                                    const AanderaaConductivityFloat read,
                                    const AanderaaConductivityFloat validate);
-  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString buf,
+  bool compareValuesPopulateBuffer(const char *parameter, AanderaaConductivityString *buf,
                                    const AanderaaConductivityString read,
                                    const AanderaaConductivityString validate);
 


### PR DESCRIPTION
## What changed?
Aanderaa 5990 configuration values are only updated if they do not match what is expected using the new API `readValidateWriteValue`.

## How does it make Bristlemouth better?
The sensor that the salinity app communicates to, the Aanderaa 5990, currently is configured and saved to the sensor on every boot of the mote application. When saving this configuration to the 5990, the internal flash of the sensor is written to in order to store these values permanently. This is an action that does not have to be performed every time that the sensor boots, but only when actual values change (such as the first time the device is configured, when new values are added in a firmware update for the mote or when the Bristlemouth configuration values `sensorDepthM` or `readingPeriodS` are changed).
This update reduces the amount of times the flash is written to and saves precious erase/write cycles.
Also, the save action takes ~8 seconds to complete, so when a save is not required, it allows the sensor to begin collecting data sooner.

## Where should reviewers focus?
The following console outputs represent when a parameter is not configured properly on the 5990:

`Enable Rawdata`
```
command: Get Enable Rawdata
command response: Enable Rawdata        5990    75      No
command response: #
sendCommand err: 0
command: Set Enable Rawdata(Yes)
command response: #
sendCommand err: 0
```

Sensor's sample interval (`Interval`)
```
command: Get Interval
command response: Interval      5990    75      60.000
command response: #
sendCommand err: 0
command: Set Interval(10)
command response: #
sendCommand err: 0
```

System pressure (`Pressure`)
```
command: Get Pressure
command response: Pressure      5990    75      0.000000E+00
command response: #
sendCommand err: 0
command: Set Pressure(155.000000)
command response: #
sendCommand err: 0
````

The configuration is then saved if a value has to change on the 5990 (through the `save` command). This is based on the `_sensorConfigDirty` variable.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
