### PR TITLE
Update spotter log aggregate reportings for the salinity application

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
@@ -257,9 +257,12 @@ BmErr AanderaaConductivitySensor::send_spotter_log_aggregate(
 
   BmErr err = AbstractSensor::send_spotter_log_aggregate(
       "aanderaa_salinity", agg.reading_count,
+      "%.4f,"   // conductivity_mean_ms_cm
       "%.3f,"   // temperature_mean_deg_c
       "%.3f,"   // salinity_mean_psu
-      "%.4f\n", // salinity_std_dev
+      "%.4f,"   // salinity_std_dev
+      "%.3f,"   // water_density_mean_kg_m3
+      "%.3f\n", // sound_speed_mean_m_s
       agg.temperature_mean_deg_c, agg.salinity_mean_psu, agg.salinity_std_dev);
 
   if (err != BmOK) {

--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
@@ -263,7 +263,8 @@ BmErr AanderaaConductivitySensor::send_spotter_log_aggregate(
       "%.4f,"   // salinity_std_dev
       "%.3f,"   // water_density_mean_kg_m3
       "%.3f\n", // sound_speed_mean_m_s
-      agg.temperature_mean_deg_c, agg.salinity_mean_psu, agg.salinity_std_dev);
+      agg.conductivity_mean_ms_cm, agg.temperature_mean_deg_c, agg.salinity_mean_psu,
+      agg.salinity_std_dev, agg.water_density_mean_kg_m3, agg.sound_speed_mean_m_s);
 
   if (err != BmOK) {
     bm_debug("ERROR: Failed to send PME DO aggregate log to spotter, err: %d\n", err);

--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.cpp
@@ -257,16 +257,10 @@ BmErr AanderaaConductivitySensor::send_spotter_log_aggregate(
 
   BmErr err = AbstractSensor::send_spotter_log_aggregate(
       "aanderaa_salinity", agg.reading_count,
-      "%.4f,"   // conductivity_mean_ms_cm
       "%.3f,"   // temperature_mean_deg_c
       "%.3f,"   // salinity_mean_psu
-      "%.4f,"   // salinity_std_dev
-      "%.3f,"   // water_density_mean_kg_m3
-      "%.3f,"   // sound_speed_mean_m_s
-      "%.3f\n", // depth_mean_m
-      agg.conductivity_mean_ms_cm, agg.temperature_mean_deg_c, agg.salinity_mean_psu,
-      agg.salinity_std_dev, agg.water_density_mean_kg_m3, agg.sound_speed_mean_m_s,
-      agg.depth_mean_m);
+      "%.4f\n", // salinity_std_dev
+      agg.temperature_mean_deg_c, agg.salinity_mean_psu, agg.salinity_std_dev);
 
   if (err != BmOK) {
     bm_debug("ERROR: Failed to send PME DO aggregate log to spotter, err: %d\n", err);


### PR DESCRIPTION
## What changed?
This changes the way the bridge application reports aggregated log data to the Spotter platform's `XXXX_SENS_AGG.csv` file.
Reduces the columns from:

```
      "%.4f,"   // conductivity_mean_ms_cm
      "%.3f,"   // temperature_mean_deg_c
      "%.3f,"   // salinity_mean_psu
      "%.4f,"   // salinity_std_dev
      "%.3f,"   // water_density_mean_kg_m3
      "%.3f,"   // sound_speed_mean_m_s
      "%.3f\n", // depth_mean_m
```

To:

```
      "%.4f,"    // conductivity_mean_ms_cm
      "%.3f,"    // temperature_mean_deg_c
      "%.3f,"    // salinity_mean_psu
      "%.4f,"    // salinity_std_dev
      "%.3f,"    // water_density_mean_kg_m3
      "%.3f\n", // sound_speed_mean_m_s
```

## How does it make Bristlemouth better?
Removes the `depth_mean_m` from being stored on the Spotter's `XXXX_SENS_AGG.csv` file as it will not change over time unless the user instructs it as so, but this will be reflected in the `XXXX_SENS_IND.csv` file, making the `XXXX_SENS_IND.csv` file the only source of truth. 


## Where should reviewers focus?
Rubber stamp.
Any thoughts against making this change?


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
