### PR TITLE
Minor bug fixes to address in Salinity app

### DIFF
--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -78,7 +78,7 @@ void AanderaaConductivitySensor::configureSensor(void) {
   sendCommand(CMD_SET_PASSKEY_1);
 
   // set interval, define default interval
-  readValidateWriteValue(CMD_INTERVAL, (AanderaaConductivityUint)_readingPeriodS);
+  readValidateWriteValue(CMD_INTERVAL, (AanderaaConductivityFloat)_readingPeriodS);
 
   // enable Temperature
   readValidateWriteValue(CMD_ENABLE_TEMPERATURE, CMD_YES);

--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.h
@@ -64,7 +64,7 @@ public:
 private:
   typedef uint32_t AanderaaConductivityUint;
   typedef float AanderaaConductivityFloat;
-  typedef char AanderaaConductivityString[32];
+  typedef char AanderaaConductivityString[64];
 
   typedef struct {
     AanderaaConductivityUint serial_number;


### PR DESCRIPTION
## What changed?
- Changed size of typedef buffer AanderaaConductivityString
- CMD_INTERVAL is reported as a float value on the 5990 not uint

## How does it make Bristlemouth better?
Fixes bugs that address the Salinity app


## Where should reviewers focus?
When reading the interval from the 5990 it is reported in exponential format:

```
command: Get Interval
command response: Interval      5990    75      1.000000E+02
command response: #
sendCommand err: 0
```

When examining this value as an int, it looks like the reading is 1 second rather than 100.
Casting the value to a float addresses this.

The string length for AanderaaConductivityString was too small for one specific parameter:

```
#define CMD_ENABLE_DERIVEDPARAMETERS "Enable Derived Parameters"
```

This breached the 32 char limit. Increasing this to 64 will address any immediate issues.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
