### PR TITLE
Convert PLUART to queue for sensor lines (#16)

### DIFF
--- a/src/apps/bristleback_apps/serial_payload_example/user_code/user_code.cpp
+++ b/src/apps/bristleback_apps/serial_payload_example/user_code/user_code.cpp
@@ -46,8 +46,8 @@ void setup(void) {
   // Enable passing raw bytes to user app.
   PLUART::setUseByteStreamBuffer(true);
   // Enable parsing lines and passing to user app.
-  /// Warning: PLUART only stores a single line at a time. If your attached payload sends lines
-  /// faster than the app reads them, they will be overwritten and data will be lost.
+  /// PLUART buffers up to 8 lines. If the queue fills, incoming lines are dropped
+  /// and the dropped line counter is incremented. Use getDroppedLineCount() to check for overflow.
   PLUART::setUseLineBuffer(true);
   // Set a line termination character per protocol of the sensor.
   PLUART::setTerminationCharacter((char)line_term_config);
@@ -102,6 +102,14 @@ void loop(void) {
       printf("\n");
       readingBytesTimer = -1;
     }
+
+    // Check for dropped lines and report if any
+    uint32_t dropped = PLUART::getDroppedLineCount();
+    if (dropped > 0) {
+      printf("WARNING: %lu lines dropped due to queue overflow!\n", dropped);
+      PLUART::resetDroppedLineCount();
+    }
+
     uint16_t read_len = PLUART::readLine(payload_buffer, sizeof(payload_buffer));
 
     // Get the RTC if available
@@ -113,9 +121,9 @@ void loop(void) {
     // Based on configuration, print the payload data to a file, to the spotter_log_console console, and to the printf console.
     if (bm_log_enable) {
       spotter_log(0, "payload_data.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, line: %.*s\n",
-                 uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
-      spotter_log_console(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
-                read_len, payload_buffer);
+                  uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
+      spotter_log_console(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(),
+                          rtcTimeBuffer, read_len, payload_buffer);
     }
     printf("[payload-line] | tick: %llu, rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
            read_len, payload_buffer);

--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -179,14 +179,9 @@ static void processLine(void *serialHandle, uint8_t *line, size_t len) {
   memcpy(queued_line.buffer, line, len);
   queued_line.len = len;
 
-  // Try to enqueue the line without blocking (we're in an ISR context)
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  if (xQueueSendFromISR(_line_queue, &queued_line, &xHigherPriorityTaskWoken) != pdTRUE) {
-    // Queue is full - increment dropped line counter
-    // Use assignment to avoid C++20 deprecated volatile increment
+  if (xQueueSend(_line_queue, &queued_line, 0) != pdTRUE) {
     _dropped_lines = _dropped_lines + 1;
   }
-  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 char getTerminationCharacter() { return terminationCharacter; }

--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -6,6 +6,7 @@
 
 // FreeRTOS Includes
 #include "FreeRTOS.h"
+#include "queue.h"
 #include "semphr.h"
 
 namespace PLUART {
@@ -14,13 +15,19 @@ namespace PLUART {
 // Stream buffer for user bytes
 static StreamBufferHandle_t user_byte_stream_buffer = NULL;
 
-static struct {
-  // This mutex protects the buffer, len, and ready flag
-  SemaphoreHandle_t mutex;
+// Queue configuration for line buffering
+#define LINE_QUEUE_DEPTH 8 // Number of lines that can be queued
+
+// Structure to hold a single line in the queue
+typedef struct {
   uint8_t buffer[LPUART1_LINE_BUFF_LEN];
-  uint16_t len = 0;
-  bool ready = false;
-} _user_line;
+  uint16_t len;
+} QueuedLine_t;
+
+// Queue for storing multiple lines
+static QueueHandle_t _line_queue = NULL;
+// Counter for tracking dropped lines (overflow detection)
+static volatile uint32_t _dropped_lines = 0;
 
 // Line termination character
 static char terminationCharacter = 0;
@@ -168,14 +175,18 @@ static void processLine(void *serialHandle, uint8_t *line, size_t len) {
   configASSERT(line != NULL);
   (void)serialHandle;
 
-  configASSERT(xSemaphoreTake(_user_line.mutex, portMAX_DELAY) == pdTRUE);
-  // if the last line has not been read, lets reset the buffer
-  memset(_user_line.buffer, 0, LPUART1_LINE_BUFF_LEN);
-  // lets copy over the line to the user mutex protected buffer
-  memcpy(_user_line.buffer, line, len);
-  _user_line.len = len;
-  _user_line.ready = true;
-  xSemaphoreGive(_user_line.mutex);
+  QueuedLine_t queued_line;
+  memcpy(queued_line.buffer, line, len);
+  queued_line.len = len;
+
+  // Try to enqueue the line without blocking (we're in an ISR context)
+  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+  if (xQueueSendFromISR(_line_queue, &queued_line, &xHigherPriorityTaskWoken) != pdTRUE) {
+    // Queue is full - increment dropped line counter
+    // Use assignment to avoid C++20 deprecated volatile increment
+    _dropped_lines = _dropped_lines + 1;
+  }
+  portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
 char getTerminationCharacter() { return terminationCharacter; }
@@ -192,13 +203,7 @@ void setUseByteStreamBuffer(bool enable) { _useByteStreamBuffer = enable; }
 
 bool byteAvailable(void) { return (!xStreamBufferIsEmpty(user_byte_stream_buffer)); }
 
-bool lineAvailable(void) {
-  bool rval = false;
-  configASSERT(xSemaphoreTake(_user_line.mutex, portMAX_DELAY) == pdTRUE);
-  rval = _user_line.ready;
-  xSemaphoreGive(_user_line.mutex);
-  return rval;
-}
+bool lineAvailable(void) { return (uxQueueMessagesWaiting(_line_queue) > 0); }
 
 void reset(void) {
   disable(); // Disable the UART
@@ -207,12 +212,10 @@ void reset(void) {
 }
 
 void flush(void) {
-  configASSERT(xSemaphoreTake(_user_line.mutex, portMAX_DELAY) == pdTRUE);
-  // Clear the line buffer state
-  memset(_user_line.buffer, 0, LPUART1_LINE_BUFF_LEN);
-  _user_line.len = 0;
-  _user_line.ready = false;
-  xSemaphoreGive(_user_line.mutex);
+  // Clear the line queue
+  xQueueReset(_line_queue);
+  // Reset the dropped lines counter
+  _dropped_lines = 0;
   // Clear the user byte stream buffer
   xStreamBufferReset(user_byte_stream_buffer);
 }
@@ -224,23 +227,26 @@ uint8_t readByte(void) {
 }
 
 uint16_t readLine(char *buffer, size_t len) {
-  int16_t rval = 0;
-  size_t copy_len;
+  QueuedLine_t queued_line;
 
-  configASSERT(xSemaphoreTake(_user_line.mutex, portMAX_DELAY) == pdTRUE);
-  if (len > _user_line.len) {
-    copy_len = _user_line.len;
-  } else {
-    copy_len = len;
+  // Try to dequeue a line (non-blocking)
+  if (xQueueReceive(_line_queue, &queued_line, 0) == pdTRUE) {
+    size_t copy_len;
+    if (len > queued_line.len) {
+      copy_len = queued_line.len;
+    } else {
+      copy_len = len;
+    }
+    memcpy(buffer, queued_line.buffer, copy_len);
+    return copy_len;
   }
 
-  memcpy(buffer, _user_line.buffer, copy_len);
-  memset(_user_line.buffer, 0, LPUART1_LINE_BUFF_LEN);
-  _user_line.ready = false;
-  rval = copy_len;
-  xSemaphoreGive(_user_line.mutex);
-  return rval;
+  return 0; // No line available
 }
+
+uint32_t getDroppedLineCount(void) { return _dropped_lines; }
+
+void resetDroppedLineCount(void) { _dropped_lines = 0; }
 
 // TODO - change to bool and return false if transactions are enabled, but no transaciton is in progress?
 void write(uint8_t *buffer, size_t len) {
@@ -347,9 +353,9 @@ BaseType_t init(uint8_t task_priority) {
   user_byte_stream_buffer = xStreamBufferCreate(USER_BYTE_BUFFER_LEN, 1);
   configASSERT(user_byte_stream_buffer != NULL);
 
-  // Create the mutex used by the payload_uart namespace for users to safely access lines from the payload
-  _user_line.mutex = xSemaphoreCreateMutex();
-  configASSERT(_user_line.mutex != NULL);
+  // Create the line queue for storing multiple lines
+  _line_queue = xQueueCreate(LINE_QUEUE_DEPTH, sizeof(QueuedLine_t));
+  configASSERT(_line_queue != NULL);
 
   // Create the postTxFunction callback trigger semaphore
   _postTxSemaphore = xSemaphoreCreateBinary();

--- a/src/lib/common/payload_uart.h
+++ b/src/lib/common/payload_uart.h
@@ -39,6 +39,12 @@ bool lineAvailable(void);
 // Read a line from the UART - return length read
 uint16_t readLine(char *buffer, size_t len);
 
+// Get the number of lines that have been dropped due to queue overflow
+uint32_t getDroppedLineCount(void);
+
+// Reset the dropped line counter
+void resetDroppedLineCount(void);
+
 // Write to the UART
 void write(uint8_t *buffer, size_t len);
 

--- a/test/header_overrides/portmacro.h
+++ b/test/header_overrides/portmacro.h
@@ -76,12 +76,15 @@
     #define portDONT_DISCARD      __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 
-    #define portSET_INTERRUPT_MASK_FROM_ISR()
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define portSET_INTERRUPT_MASK_FROM_ISR() 0
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x ) ((void)(x))
     #define portDISABLE_INTERRUPTS()
     #define portENABLE_INTERRUPTS()
     #define portENTER_CRITICAL()
     #define portEXIT_CRITICAL()
+    #define portYIELD()
+    #define portYIELD_WITHIN_API()
+    #define portYIELD_FROM_ISR(x) ((void)(x))
 
     #ifdef __cplusplus
         }

--- a/test/src/common/CMakeLists.txt
+++ b/test/src/common/CMakeLists.txt
@@ -269,12 +269,22 @@ target_sources(payload_uart_queue_tests
 )
 
 # Disable specific warnings for FreeRTOS source files
-set_source_files_properties(
-    ${SRC_DIR}/third_party/FreeRTOS/Source/queue.c
-    ${SRC_DIR}/third_party/FreeRTOS/Source/list.c
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-tautological-constant-out-of-range-compare"
-)
+# Use compiler-specific flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(
+        ${SRC_DIR}/third_party/FreeRTOS/Source/queue.c
+        ${SRC_DIR}/third_party/FreeRTOS/Source/list.c
+        PROPERTIES
+        COMPILE_FLAGS "-Wno-tautological-constant-out-of-range-compare"
+    )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set_source_files_properties(
+        ${SRC_DIR}/third_party/FreeRTOS/Source/queue.c
+        ${SRC_DIR}/third_party/FreeRTOS/Source/list.c
+        PROPERTIES
+        COMPILE_FLAGS "-Wno-type-limits"
+    )
+endif()
 
 target_link_libraries(payload_uart_queue_tests gtest gmock gtest_main)
 

--- a/test/src/common/CMakeLists.txt
+++ b/test/src/common/CMakeLists.txt
@@ -243,3 +243,44 @@ add_test(
     COMMAND
     lineParsers
 )
+
+#
+# PLUART Queue tests
+#
+add_executable(payload_uart_queue_tests)
+target_include_directories(payload_uart_queue_tests
+    PRIVATE
+    ${SRC_DIR}/lib/common
+    ${TEST_DIR}/header_overrides
+    ${SRC_DIR}/third_party/FreeRTOS/Source/include
+)
+
+target_sources(payload_uart_queue_tests
+    PRIVATE
+    # Real FreeRTOS queue and list implementation
+    ${SRC_DIR}/third_party/FreeRTOS/Source/queue.c
+    ${SRC_DIR}/third_party/FreeRTOS/Source/list.c
+
+    # FreeRTOS stubs for task/timer functions we don't use
+    ${TEST_DIR}/stubs/FreeRTOSStubs.c
+
+    # Unit test wrapper for test
+    payload_uart_queue_ut.cpp
+)
+
+# Disable specific warnings for FreeRTOS source files
+set_source_files_properties(
+    ${SRC_DIR}/third_party/FreeRTOS/Source/queue.c
+    ${SRC_DIR}/third_party/FreeRTOS/Source/list.c
+    PROPERTIES
+    COMPILE_FLAGS "-Wno-tautological-constant-out-of-range-compare"
+)
+
+target_link_libraries(payload_uart_queue_tests gtest gmock gtest_main)
+
+add_test(
+    NAME
+    payload_uart_queue_tests
+    COMMAND
+    payload_uart_queue_tests
+)

--- a/test/src/common/payload_uart_queue_ut.cpp
+++ b/test/src/common/payload_uart_queue_ut.cpp
@@ -1,0 +1,296 @@
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <cstring>
+
+// Mock the LPUART1_LINE_BUFF_LEN constant
+#define LPUART1_LINE_BUFF_LEN 2048
+#define LINE_QUEUE_DEPTH 8
+
+// Structure to hold a single line in the queue (matches payload_uart.cpp)
+typedef struct {
+  uint8_t buffer[LPUART1_LINE_BUFF_LEN];
+  uint16_t len;
+} QueuedLine_t;
+
+// Test fixture for PLUART Queue functionality
+class PLUARTQueueTest : public ::testing::Test {
+protected:
+  QueueHandle_t test_queue;
+  uint32_t dropped_lines;
+
+  PLUARTQueueTest() : test_queue(NULL), dropped_lines(0) {}
+
+  void SetUp() override {
+    // Create a queue similar to the one in payload_uart.cpp
+    test_queue = xQueueCreate(LINE_QUEUE_DEPTH, sizeof(QueuedLine_t));
+    ASSERT_NE(test_queue, nullptr) << "Failed to create test queue";
+    dropped_lines = 0;
+  }
+
+  void TearDown() override {
+    if (test_queue) {
+      vQueueDelete(test_queue);
+      test_queue = NULL;
+    }
+  }
+
+  // Helper function to simulate processLine() behavior
+  bool enqueueLine(const char *line_data, size_t len) {
+    QueuedLine_t queued_line;
+    memcpy(queued_line.buffer, line_data, len);
+    queued_line.len = len;
+
+    if (xQueueSend(test_queue, &queued_line, 0) != pdTRUE) {
+      // Queue is full - increment dropped line counter
+      dropped_lines = dropped_lines + 1;
+      return false;
+    }
+    return true;
+  }
+
+  // Helper function to simulate readLine() behavior
+  uint16_t dequeueLine(char *buffer, size_t len) {
+    QueuedLine_t queued_line;
+
+    if (xQueueReceive(test_queue, &queued_line, 0) == pdTRUE) {
+      size_t copy_len;
+      if (len > queued_line.len) {
+        copy_len = queued_line.len;
+      } else {
+        copy_len = len;
+      }
+      memcpy(buffer, queued_line.buffer, copy_len);
+      return copy_len;
+    }
+
+    return 0; // No line available
+  }
+
+  // Helper function to simulate lineAvailable() behavior
+  bool lineAvailable() { return (uxQueueMessagesWaiting(test_queue) > 0); }
+};
+
+// Test 1: Basic enqueue and dequeue
+TEST_F(PLUARTQueueTest, BasicEnqueueDequeue) {
+  const char *test_line = "TEST_LINE_1\n";
+  char read_buffer[100];
+
+  // Enqueue a line
+  EXPECT_TRUE(enqueueLine(test_line, strlen(test_line)));
+
+  // Check line is available
+  EXPECT_TRUE(lineAvailable());
+
+  // Dequeue and verify
+  uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+  EXPECT_EQ(read_len, strlen(test_line));
+  EXPECT_EQ(memcmp(read_buffer, test_line, read_len), 0);
+
+  // Queue should now be empty
+  EXPECT_FALSE(lineAvailable());
+}
+
+// Test 2: Multiple lines FIFO ordering
+TEST_F(PLUARTQueueTest, FIFOOrdering) {
+  const char *lines[] = {"LINE_1\n", "LINE_2\n", "LINE_3\n", "LINE_4\n"};
+  char read_buffer[100];
+
+  // Enqueue multiple lines
+  for (int i = 0; i < 4; i++) {
+    EXPECT_TRUE(enqueueLine(lines[i], strlen(lines[i])));
+  }
+
+  // Verify FIFO ordering
+  for (int i = 0; i < 4; i++) {
+    EXPECT_TRUE(lineAvailable());
+    uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+    EXPECT_EQ(read_len, strlen(lines[i]));
+    EXPECT_EQ(memcmp(read_buffer, lines[i], read_len), 0);
+  }
+
+  EXPECT_FALSE(lineAvailable());
+}
+
+// Test 3: Queue overflow behavior
+TEST_F(PLUARTQueueTest, QueueOverflow) {
+  char line_buffer[50];
+
+  // Fill the queue to capacity
+  for (int i = 0; i < LINE_QUEUE_DEPTH; i++) {
+    snprintf(line_buffer, sizeof(line_buffer), "LINE_%d\n", i);
+    EXPECT_TRUE(enqueueLine(line_buffer, strlen(line_buffer)));
+    EXPECT_EQ(dropped_lines, 0) << "No lines should be dropped yet";
+  }
+
+  // Try to add one more line (should fail and increment dropped counter)
+  const char *overflow_line = "OVERFLOW_LINE\n";
+  EXPECT_FALSE(enqueueLine(overflow_line, strlen(overflow_line)));
+  EXPECT_EQ(dropped_lines, 1) << "One line should be dropped";
+
+  // Try to add another (should increment again)
+  EXPECT_FALSE(enqueueLine(overflow_line, strlen(overflow_line)));
+  EXPECT_EQ(dropped_lines, 2) << "Two lines should be dropped";
+
+  // Verify queue still has original lines
+  char read_buffer[100];
+  for (int i = 0; i < LINE_QUEUE_DEPTH; i++) {
+    snprintf(line_buffer, sizeof(line_buffer), "LINE_%d\n", i);
+    uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+    EXPECT_EQ(read_len, strlen(line_buffer));
+    EXPECT_EQ(memcmp(read_buffer, line_buffer, read_len), 0);
+  }
+
+  EXPECT_FALSE(lineAvailable());
+}
+
+// Test 4: Queue recovery after overflow
+TEST_F(PLUARTQueueTest, QueueRecoveryAfterOverflow) {
+  char line_buffer[50];
+
+  // Fill the queue
+  for (int i = 0; i < LINE_QUEUE_DEPTH; i++) {
+    snprintf(line_buffer, sizeof(line_buffer), "LINE_%d\n", i);
+    EXPECT_TRUE(enqueueLine(line_buffer, strlen(line_buffer)));
+  }
+
+  // Overflow
+  EXPECT_FALSE(enqueueLine("OVERFLOW\n", 9));
+  EXPECT_EQ(dropped_lines, 1);
+
+  // Read one line to make space
+  char read_buffer[100];
+  uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+  EXPECT_GT(read_len, 0);
+
+  // Now should be able to enqueue again
+  const char *new_line = "NEW_LINE\n";
+  EXPECT_TRUE(enqueueLine(new_line, strlen(new_line)));
+}
+
+// Test 5: Empty queue read returns 0
+TEST_F(PLUARTQueueTest, EmptyQueueRead) {
+  char read_buffer[100];
+
+  EXPECT_FALSE(lineAvailable());
+  uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+  EXPECT_EQ(read_len, 0) << "Reading from empty queue should return 0";
+}
+
+// Test 6: Large line handling
+TEST_F(PLUARTQueueTest, LargeLine) {
+  char large_line[LPUART1_LINE_BUFF_LEN];
+  char read_buffer[LPUART1_LINE_BUFF_LEN];
+
+  // Create a large line (but within buffer limits)
+  size_t large_len = LPUART1_LINE_BUFF_LEN - 100;
+  memset(large_line, 'A', large_len - 1);
+  large_line[large_len - 1] = '\n';
+
+  EXPECT_TRUE(enqueueLine(large_line, large_len));
+  EXPECT_TRUE(lineAvailable());
+
+  uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+  EXPECT_EQ(read_len, large_len);
+  EXPECT_EQ(memcmp(read_buffer, large_line, read_len), 0);
+}
+
+// Test 7: Buffer size limiting on read
+TEST_F(PLUARTQueueTest, ReadBufferSizeLimiting) {
+  const char *test_line = "THIS_IS_A_LONG_LINE\n";
+  char small_buffer[10];
+
+  EXPECT_TRUE(enqueueLine(test_line, strlen(test_line)));
+
+  // Read with smaller buffer - should be truncated
+  uint16_t read_len = dequeueLine(small_buffer, sizeof(small_buffer));
+  EXPECT_EQ(read_len, sizeof(small_buffer));
+  EXPECT_EQ(memcmp(small_buffer, test_line, sizeof(small_buffer)), 0);
+}
+
+// Test 8: Mixed size lines
+TEST_F(PLUARTQueueTest, MixedSizeLines) {
+  const char *lines[] = {"SHORT\n", "A_MUCH_LONGER_LINE_WITH_MORE_CONTENT\n", "MED\n",
+                         "TINY\n"};
+  char read_buffer[100];
+
+  for (int i = 0; i < 4; i++) {
+    EXPECT_TRUE(enqueueLine(lines[i], strlen(lines[i])));
+  }
+
+  for (int i = 0; i < 4; i++) {
+    uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+    EXPECT_EQ(read_len, strlen(lines[i]));
+    EXPECT_EQ(memcmp(read_buffer, lines[i], read_len), 0);
+  }
+}
+
+// Test 9: Queue messages waiting count
+TEST_F(PLUARTQueueTest, QueueMessagesWaiting) {
+  EXPECT_EQ(uxQueueMessagesWaiting(test_queue), 0);
+
+  // Add lines and check count
+  for (int i = 1; i <= 5; i++) {
+    char line[20];
+    snprintf(line, sizeof(line), "LINE_%d\n", i);
+    EXPECT_TRUE(enqueueLine(line, strlen(line)));
+    EXPECT_EQ(uxQueueMessagesWaiting(test_queue), i);
+  }
+
+  // Remove lines and check count
+  char read_buffer[100];
+  for (int i = 5; i > 0; i--) {
+    dequeueLine(read_buffer, sizeof(read_buffer));
+    EXPECT_EQ(uxQueueMessagesWaiting(test_queue), i - 1);
+  }
+}
+
+// Test 10: Queue reset behavior
+TEST_F(PLUARTQueueTest, QueueReset) {
+  // Fill queue with data
+  for (int i = 0; i < 5; i++) {
+    char line[20];
+    snprintf(line, sizeof(line), "LINE_%d\n", i);
+    EXPECT_TRUE(enqueueLine(line, strlen(line)));
+  }
+
+  EXPECT_TRUE(lineAvailable());
+  EXPECT_EQ(uxQueueMessagesWaiting(test_queue), 5);
+
+  // Reset queue (simulates flush() behavior)
+  xQueueReset(test_queue);
+
+  EXPECT_FALSE(lineAvailable());
+  EXPECT_EQ(uxQueueMessagesWaiting(test_queue), 0);
+
+  // Verify queue is usable after reset
+  const char *new_line = "AFTER_RESET\n";
+  EXPECT_TRUE(enqueueLine(new_line, strlen(new_line)));
+  EXPECT_TRUE(lineAvailable());
+}
+
+// Test 11: Stress test - rapid enqueue/dequeue
+TEST_F(PLUARTQueueTest, RapidEnqueueDequeue) {
+  char line_buffer[50];
+  char read_buffer[100];
+
+  for (int cycle = 0; cycle < 20; cycle++) {
+    // Enqueue some lines
+    int lines_to_add = (cycle % (LINE_QUEUE_DEPTH - 1)) + 1;
+    for (int i = 0; i < lines_to_add; i++) {
+      snprintf(line_buffer, sizeof(line_buffer), "CYCLE_%d_LINE_%d\n", cycle, i);
+      EXPECT_TRUE(enqueueLine(line_buffer, strlen(line_buffer)));
+    }
+
+    // Dequeue all lines
+    for (int i = 0; i < lines_to_add; i++) {
+      snprintf(line_buffer, sizeof(line_buffer), "CYCLE_%d_LINE_%d\n", cycle, i);
+      uint16_t read_len = dequeueLine(read_buffer, sizeof(read_buffer));
+      EXPECT_EQ(read_len, strlen(line_buffer));
+      EXPECT_EQ(memcmp(read_buffer, line_buffer, read_len), 0);
+    }
+
+    EXPECT_FALSE(lineAvailable());
+  }
+}

--- a/test/stubs/FreeRTOSStubs.c
+++ b/test/stubs/FreeRTOSStubs.c
@@ -1,16 +1,66 @@
 
 #include "FreeRTOS.h"
+#include "task.h"
+#include <stdlib.h>
 
 static TickType_t _current_ticks = 0;
 
-void vTaskDelay( const TickType_t xTicksToDelay ){
+void vTaskDelay(const TickType_t xTicksToDelay) {
   _current_ticks = _current_ticks + xTicksToDelay;
 }
 
-TickType_t xTaskGetTickCount() {
-  return _current_ticks;
-}
+TickType_t xTaskGetTickCount() { return _current_ticks; }
 
 void xTaskSetTickCount(uint32_t xCurrentTickCount) {
-  _current_ticks = (TickType_t) xCurrentTickCount;
+  _current_ticks = (TickType_t)xCurrentTickCount;
 }
+
+// Stubs for FreeRTOS task functions used by queue.c
+void vTaskSuspendAll(void) {}
+BaseType_t xTaskResumeAll(void) { return pdTRUE; }
+void vTaskMissedYield(void) {}
+void vTaskPlaceOnEventList(List_t *pxEventList, TickType_t xTicksToWait) {
+  (void)pxEventList;
+  (void)xTicksToWait;
+}
+void vTaskPlaceOnEventListRestricted(List_t *pxEventList, TickType_t xTicksToWait,
+                                     const BaseType_t xWaitIndefinitely) {
+  (void)pxEventList;
+  (void)xTicksToWait;
+  (void)xWaitIndefinitely;
+}
+BaseType_t xTaskRemoveFromEventList(const List_t *pxEventList) {
+  (void)pxEventList;
+  return pdFALSE;
+}
+void vTaskInternalSetTimeOutState(TimeOut_t *pxTimeOut) { (void)pxTimeOut; }
+BaseType_t xTaskCheckForTimeOut(TimeOut_t *pxTimeOut, TickType_t *pxTicksToWait) {
+  (void)pxTimeOut;
+  (void)pxTicksToWait;
+  return pdFALSE;
+}
+void vTaskPriorityDisinheritAfterTimeout(TaskHandle_t const pxMutexHolder,
+                                         UBaseType_t uxHighestPriorityWaitingTask) {
+  (void)pxMutexHolder;
+  (void)uxHighestPriorityWaitingTask;
+}
+TaskHandle_t pvTaskIncrementMutexHeldCount(void) { return NULL; }
+UBaseType_t uxTaskGetNumberOfTasks(void) { return 0; }
+TaskHandle_t xTaskGetCurrentTaskHandle(void) { return NULL; }
+BaseType_t xTaskGetSchedulerState(void) { return taskSCHEDULER_RUNNING; }
+BaseType_t xTaskPriorityDisinherit(TaskHandle_t const pxMutexHolder) {
+  (void)pxMutexHolder;
+  return pdFALSE;
+}
+BaseType_t xTaskPriorityInherit(TaskHandle_t const pxMutexHolder) {
+  (void)pxMutexHolder;
+  return pdFALSE;
+}
+
+// Memory allocation stubs
+// Undefine the macros from FreeRTOSConfig.h to avoid infinite recursion
+#undef pvPortMalloc
+#undef vPortFree
+
+void *pvPortMalloc(size_t xWantedSize) { return malloc(xWantedSize); }
+void vPortFree(void *pv) { free(pv); }


### PR DESCRIPTION
## What changed?

Implements queue-based line buffering for PLUART to prevent data loss when multiple lines arrive before being read.

## How does it make Bristlemouth better?

Issue #16 raised by the devs seems to indicate a need and makes sense to me! As mentioned in the issue, many sensors issue multiple lines and this change seems to only make the project more robust to timing jitter without changing the user API.

## Where should reviewers focus?

src/lib/common/payload_uart.cpp contains the important bits. I have added a set of basic unit tests as well.

## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
