### PR TITLE
Fix stringop-truncation Compiler Error On Linux For Salinity Application

### DIFF
--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -505,8 +505,13 @@ void AanderaaConductivitySensor::checkTypeAndAssign(
 void AanderaaConductivitySensor::checkTypeAndAssign(
     const char *output, uint16_t length,
     AanderaaConductivitySensor::AanderaaConductivityString *value) {
+  const size_t copy_len = sizeof(AanderaaConductivityString) - 1;
+
+  if (length > copy_len) {
+    return;
+  }
+
   if (value) {
-    size_t copy_len = bm_min(length, sizeof(AanderaaConductivityString) - 1);
     strncpy(*value, output, copy_len);
     (*value)[copy_len] = '\0';
   }


### PR DESCRIPTION
## What changed?
Changes how size is checked in `checkTypeAndAssign` to avoid linux compiler errors:

```
STDERR:
 In member function 'void AanderaaConductivitySensor::checkTypeAndAssign(const char*, uint16_t, char (*)[64])',
    inlined from 'void AanderaaConductivitySensor::checkTypeAndAssign(const char*, uint16_t, char (*)[64])' at /home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:505:6,
    inlined from 'BmErr AanderaaConductivitySensor::sendCommand(const char*, T*, uint32_t) [with T = char [64]]' at /home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:598:27,
    inlined from 'BmErr AanderaaConductivitySensor::readValidateWriteValue(const char*, T, uint8_t) [with T = char [64]]' at /home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:762:22:
/home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:510:12: error: 'char* strncpy(char*, const char*, size_t)' specified bound depends on the length of the source argument [-Werror=stringop-truncation]
  510 |     strncpy(*value, output, copy_len);
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
In member function 'BmErr AanderaaConductivitySensor::sendCommand(const char*, T*, uint32_t) [with T = char [64]]',
    inlined from 'BmErr AanderaaConductivitySensor::readValidateWriteValue(const char*, T, uint8_t) [with T = char [64]]' at /home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:762:22:
/home/runner/work/bm_protocol/bm_protocol/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp:598:44: note: length computed here
  598 |         checkTypeAndAssign(last_tab, strlen(last_tab), value);
      |                                      ~~~~~~^~~~~~~~~~
cc1plus: all warnings being treated as errors
```


## How does it make Bristlemouth better?
Allows the salinity app to be built properly!


## Where should reviewers focus?
Validation the logic looks good!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
