### PR TITLE
Fix Salinity App Spam To Log File

### DIFF
--- a/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
+++ b/src/apps/rs232_expander_apps/aanderaa_salinity/user_code/aanderaa_conductivity_sensor.cpp
@@ -236,12 +236,12 @@ void AanderaaConductivitySensor::calibrateCellCoef(void) {
   get_config_float(BM_CFG_PARTITION_SYSTEM, EXTERNAL_REFERENCE_CONDUCTIVITY,
                    strlen(EXTERNAL_REFERENCE_CONDUCTIVITY), &_referenceConductivity);
 
-  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
-              "Calibrating salinity sensor...\n");
-
   if (isnan(_referenceConductivity)) {
     return;
   }
+
+  spotter_log(0, AANDERAA_CONDUCTIVITY_RAW_LOG, USE_TIMESTAMP,
+              "Calibrating salinity sensor...\n");
 
   // if _referenceConductivity is within expected range --- Minimum = 0.000 S/m (0.000 mS/cm) and Maximum = 7.500 S/m (75.000 mS/cm)
   if (_referenceConductivity < 0.000f || _referenceConductivity > 75.000f) {


### PR DESCRIPTION
## What changed?
Moved Spotter SD card log statement to a location where it will not be spamming the Spotter file system.


## How does it make Bristlemouth better?
Users would have unnecessary log statements filling up their SD card while the Salinity sensor is powered on.


## Where should reviewers focus?
This was writing logs to a log file at an interval of 10ms but not the console, so it was easy to slip by.
Testing with this fix has had expected results!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
