### PR TITLE
Change Salinity Standard Deviation Max

### DIFF
--- a/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.h
+++ b/src/apps/bridge/sensor_drivers/aanderaaConductivitySensor.h
@@ -167,7 +167,7 @@ public:
    * Accounts for timing slop between sensor sampling and bridge aggregation periods.
    */
   static constexpr uint32_t N_SAMPLES_PAD = 150;
-  static constexpr double SALINITY_STD_DEV_MAX = 0.1018;
+  static constexpr double SALINITY_STD_DEV_MAX = 0.506;
 
   /**
    * @brief Default aggregation structure with NaN values


### PR DESCRIPTION
## What changed?
Change Salinity Standard Deviation Max To 0.506


## How does it make Bristlemouth better?
This is to support reducing the bitpacked message size for standard deviation from 9 to 8 bits on the Spotter platform


## Where should reviewers focus?
Validation that the updated value matches the documented maximum.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
