### PR TITLE
Fixes Missing RBR Readings

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -1,11 +1,11 @@
 #include "rbr_sensor.h"
 #include "FreeRTOS.h"
 #include "OrderedSeparatorLineParser.h"
-#include "spotter.h"
 #include "configuration.h"
 #include "payload_uart.h"
 #include "rbr_sensor_util.h"
 #include "serial.h"
+#include "spotter.h"
 #include "stm32_rtc.h"
 #include "task_priorities.h"
 #include "uptime.h"
@@ -18,10 +18,10 @@ static constexpr char PRESSURE[] = "pressure";
 static constexpr char TEMPERATURE[] = "temperature";
 
 /*!
-* @brief Initialize the RBR sensor driver.
-* @param type The sensor type.
-* @param min_probe_period_ms How often to check the sensor type in milliseconds.
-*/
+ * @brief Initialize the RBR sensor driver.
+ * @param type The sensor type.
+ * @param min_probe_period_ms How often to check the sensor type in milliseconds.
+ */
 void RbrSensor::init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms) {
   _type = type;
   _stored_type = type;
@@ -52,12 +52,30 @@ void RbrSensor::init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_
 }
 
 /*!
-* @brief Probe the sensor type if enough time has passed.
-*/
+ * @brief Probe the sensor type if enough time has passed.
+ */
 void RbrSensor::maybeProbeType(uint64_t last_power_on_time) {
   uint64_t now = uptimeGetMs();
+
+  // Cannot transmit to the RBR while a reading is ongoing or else the
+  // RBR will "blank" the streaming data, see:
+  // https://docs.rbr-global.com/l3-command-reference/N/External/timeouts-output-blanking-and-power-saving
+  // Create a window in which the probe can occur:
+  //+--------------+---------------+---------------+
+  //|     0ms      |    200-300ms  |       500ms   |
+  //+--------------+---------------+---------------+
+  //| RBR reading  |  Probe TX     |   RBR reading |
+  //+--------------+---------------+---------------+
+  static constexpr uint32_t window_start_time =
+      RBR_READING_PERIOD_MS / 2 - PROBE_WINDOW_WIDTH_MS / 2;
+  static constexpr uint32_t window_end_time =
+      RBR_READING_PERIOD_MS / 2 + PROBE_WINDOW_WIDTH_MS / 2;
+  bool lower_window = now > _last_data_time + window_start_time;
+  bool upper_window = now < _last_data_time + window_end_time;
+  bool can_transmit = lower_window && upper_window;
+
   if (now - _lastProbeTime >= _minProbePeriodMs &&
-      now - last_power_on_time >= _minProbePeriodMs) {
+      now - last_power_on_time >= _minProbePeriodMs && can_transmit) {
     PLUART::write((uint8_t *)typeCommand, strlen(typeCommand));
     _lastProbeTime = uptimeGetMs();
     _awaitingProbeResponse = true;
@@ -78,9 +96,12 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       handleOutputformat(_payload_buffer, read_len);
     } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
       success = handleDataString(_payload_buffer, read_len, d);
+      if (success) {
+        _last_data_time = uptimeGetMs();
+      }
     } else {
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid line from sensor: %.*s\n", read_len,
-                 _payload_buffer);
+                  _payload_buffer);
       spotter_log_console(0, "Invalid line from sensor: %.*s", read_len, _payload_buffer);
       printf("Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
     }
@@ -119,7 +140,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
           BM_CFG_PARTITION_SYSTEM, CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP,
-                 "Detected temp & pressure sensor, saving config\n");
+                  "Detected temp & pressure sensor, saving config\n");
       spotter_log_console(0, "Detected temp & pressure sensor, saving config");
       printf("Detected temp & pressure sensor, saving config.\n");
       save_config(BM_CFG_PARTITION_SYSTEM, true); // reboot
@@ -160,10 +181,10 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
   rtcPrint(rtcTimeBuffer, NULL);
   if (_sensorBmLogEnable) {
     spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
-               uptimeGetMs(), rtcTimeBuffer, read_len, s);
+                uptimeGetMs(), rtcTimeBuffer, read_len, s);
   }
-  spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
-            read_len, s);
+  spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
+                      rtcTimeBuffer, read_len, s);
   printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
          (int)read_len, s);
 

--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.h
@@ -10,7 +10,7 @@ public:
         _stored_type(BmRbrDataMsg::SensorType_t::UNKNOWN), _sensorDropDebounceCount(0),
         _sensorBmLogEnable(false), _minProbePeriodMs(0), _lastProbeTime(0),
         _awaitingProbeResponse(false), _parserTwoArguments(",", 256, parserValueTypeOne, 2),
-        _parserThreeArguments(",", 256, parserValueTypeTwo, 3){};
+        _parserThreeArguments(",", 256, parserValueTypeTwo, 3) {};
   void init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms);
   void maybeProbeType(uint64_t last_power_on_time);
   bool getData(BmRbrDataMsg::Data &d);
@@ -32,6 +32,9 @@ private:
   static constexpr char typeCommand[] = "outputformat channelslist\n";
   static constexpr uint8_t SENSOR_DROP_DEBOUNCE_MAX_COUNT = 3;
   static constexpr uint32_t PROBE_TYPE_TIMEOUT_MS = 1000;
+  static constexpr uint32_t PROBE_WINDOW_WIDTH_MS = 100;
+  static constexpr uint32_t RBR_READING_PERIOD_MS = 500;
+
   static constexpr uint8_t NUM_PARSERS = 4;
   static constexpr char sensor_bm_log_enable[] = "sensorBmLogEnable";
 
@@ -42,6 +45,7 @@ private:
   uint32_t _sensorBmLogEnable = 0;
   uint32_t _minProbePeriodMs = 0;
   uint64_t _lastProbeTime = 0;
+  uint64_t _last_data_time = 0;
   bool _awaitingProbeResponse = false;
   OrderedSeparatorLineParser _parserTwoArguments;
   OrderedSeparatorLineParser _parserThreeArguments;

--- a/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -1,11 +1,11 @@
 #include "rbr_sensor.h"
 #include "FreeRTOS.h"
 #include "OrderedSeparatorLineParser.h"
-#include "spotter.h"
 #include "configuration.h"
 #include "payload_uart.h"
 #include "rbr_sensor_util.h"
 #include "serial.h"
+#include "spotter.h"
 #include "stm32_rtc.h"
 #include "task_priorities.h"
 #include "uptime.h"
@@ -18,10 +18,10 @@ static constexpr char PRESSURE[] = "pressure";
 static constexpr char TEMPERATURE[] = "temperature";
 
 /*!
-* @brief Initialize the RBR sensor driver.
-* @param type The sensor type.
-* @param min_probe_period_ms How often to check the sensor type in milliseconds.
-*/
+ * @brief Initialize the RBR sensor driver.
+ * @param type The sensor type.
+ * @param min_probe_period_ms How often to check the sensor type in milliseconds.
+ */
 void RbrSensor::init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms) {
   _type = type;
   _stored_type = type;
@@ -52,12 +52,30 @@ void RbrSensor::init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_
 }
 
 /*!
-* @brief Probe the sensor type if enough time has passed.
-*/
+ * @brief Probe the sensor type if enough time has passed.
+ */
 void RbrSensor::maybeProbeType(uint64_t last_power_on_time) {
   uint64_t now = uptimeGetMs();
+
+  // Cannot transmit to the RBR while a reading is ongoing or else the
+  // RBR will "blank" the streaming data, see:
+  // https://docs.rbr-global.com/l3-command-reference/N/External/timeouts-output-blanking-and-power-saving
+  // Create a window in which the probe can occur:
+  //+--------------+---------------+---------------+
+  //|     0ms      |    200-300ms  |       500ms   |
+  //+--------------+---------------+---------------+
+  //| RBR reading  |  Probe TX     |   RBR reading |
+  //+--------------+---------------+---------------+
+  static constexpr uint32_t window_start_time =
+      RBR_READING_PERIOD_MS / 2 - PROBE_WINDOW_WIDTH_MS / 2;
+  static constexpr uint32_t window_end_time =
+      RBR_READING_PERIOD_MS / 2 + PROBE_WINDOW_WIDTH_MS / 2;
+  bool lower_window = now > _last_data_time + window_start_time;
+  bool upper_window = now < _last_data_time + window_end_time;
+  bool can_transmit = lower_window && upper_window;
+
   if (now - _lastProbeTime >= _minProbePeriodMs &&
-      now - last_power_on_time >= _minProbePeriodMs) {
+      now - last_power_on_time >= _minProbePeriodMs && can_transmit) {
     PLUART::write((uint8_t *)typeCommand, strlen(typeCommand));
     _lastProbeTime = uptimeGetMs();
     _awaitingProbeResponse = true;
@@ -78,9 +96,12 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       handleOutputformat(_payload_buffer, read_len);
     } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
       success = handleDataString(_payload_buffer, read_len, d);
+      if (success) {
+        _last_data_time = uptimeGetMs();
+      }
     } else {
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid line from sensor: %.*s\n", read_len,
-                 _payload_buffer);
+                  _payload_buffer);
       spotter_log_console(0, "Invalid line from sensor: %.*s", read_len, _payload_buffer);
       printf("Invalid line from sensor: %.*s\n", read_len, _payload_buffer);
     }
@@ -119,7 +140,7 @@ void RbrSensor::handleOutputformat(const char *s, size_t read_len) {
           BM_CFG_PARTITION_SYSTEM, CFG_RBR_TYPE, strlen(CFG_RBR_TYPE),
           static_cast<uint32_t>(BmRbrDataMsg::SensorType::PRESSURE_AND_TEMPERATURE));
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP,
-                 "Detected temp & pressure sensor, saving config\n");
+                  "Detected temp & pressure sensor, saving config\n");
       spotter_log_console(0, "Detected temp & pressure sensor, saving config");
       printf("Detected temp & pressure sensor, saving config.\n");
       save_config(BM_CFG_PARTITION_SYSTEM, true); // reboot
@@ -160,10 +181,10 @@ bool RbrSensor::handleDataString(const char *s, size_t read_len, BmRbrDataMsg::D
   rtcPrint(rtcTimeBuffer, NULL);
   if (_sensorBmLogEnable) {
     spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "tick: %" PRIu64 ", rtc: %s, line: %.*s\n",
-               uptimeGetMs(), rtcTimeBuffer, read_len, s);
+                uptimeGetMs(), rtcTimeBuffer, read_len, s);
   }
-  spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
-            read_len, s);
+  spotter_log_console(0, "rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s", uptimeGetMs(),
+                      rtcTimeBuffer, read_len, s);
   printf("rbr | tick: %" PRIu64 ", rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
          (int)read_len, s);
 

--- a/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.h
+++ b/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.h
@@ -10,7 +10,7 @@ public:
         _stored_type(BmRbrDataMsg::SensorType_t::UNKNOWN), _sensorDropDebounceCount(0),
         _sensorBmLogEnable(false), _minProbePeriodMs(0), _lastProbeTime(0),
         _awaitingProbeResponse(false), _parserTwoArguments(",", 256, parserValueTypeOne, 2),
-        _parserThreeArguments(",", 256, parserValueTypeTwo, 3){};
+        _parserThreeArguments(",", 256, parserValueTypeTwo, 3) {};
   void init(BmRbrDataMsg::SensorType_t type, uint32_t min_probe_period_ms);
   void maybeProbeType(uint64_t last_power_on_time);
   bool getData(BmRbrDataMsg::Data &d);
@@ -32,6 +32,9 @@ private:
   static constexpr char typeCommand[] = "outputformat channelslist\n";
   static constexpr uint8_t SENSOR_DROP_DEBOUNCE_MAX_COUNT = 3;
   static constexpr uint32_t PROBE_TYPE_TIMEOUT_MS = 1000;
+  static constexpr uint32_t PROBE_WINDOW_WIDTH_MS = 100;
+  static constexpr uint32_t RBR_READING_PERIOD_MS = 500;
+
   static constexpr uint8_t NUM_PARSERS = 4;
   static constexpr char sensor_bm_log_enable[] = "sensorBmLogEnable";
 
@@ -42,6 +45,7 @@ private:
   uint32_t _sensorBmLogEnable = 0;
   uint32_t _minProbePeriodMs = 0;
   uint64_t _lastProbeTime = 0;
+  uint64_t _last_data_time = 0;
   bool _awaitingProbeResponse = false;
   OrderedSeparatorLineParser _parserTwoArguments;
   OrderedSeparatorLineParser _parserThreeArguments;


### PR DESCRIPTION
## What changed?
Ensures that probing the RBR cannot happen at the same time that an expected reading is incoming.
This is due to the fact that the RBR cannot transmit and receive over UART at the same time!
This is called "Data Blanking" in RBR's terminology.


## How does it make Bristlemouth better?
About 1/1,000 RBR streaming data readings were getting dropped.
This improves the data integrity by preventing the [blanking](https://docs.rbr-global.com/l3-command-reference/N/External/timeouts-output-blanking-and-power-saving#id-(N)Timeouts,outputblankingandpowersaving-Outputblanking) timing condition from occurring.


## Where should reviewers focus?
Small PR. Ask any questions you might have!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
