### PR TITLE
Forward USV Messages To Spotter

### DIFF
--- a/src/apps/bm_devkit/mavlink_bridge/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/mavlink_bridge/user_code/user_code.cpp
@@ -1,7 +1,6 @@
 #include "user_code.h"
 #include "bm_config.h"
 #include "bm_mavlink.h"
-#include "bsp.h"
 #include "payload_uart.h"
 #include "spotter.h"
 #include "task_priorities.h"
@@ -44,7 +43,7 @@ static void process_rx_bytes(uint8_t byte) {
       bm_mavlink_transmit(&msg);
       break;
     }
-    case MAVLINK_MSG_ID_VFR_HUD:
+    case MAVLINK_MSG_ID_VFR_HUD: {
       mavlink_vfr_hud_t vfr_hud;
       mavlink_msg_vfr_hud_decode(&msg, &vfr_hud);
       bm_debug("Mavlink VFR HUD:\n"
@@ -59,6 +58,8 @@ static void process_rx_bytes(uint8_t byte) {
                msg.sysid, msg.compid, vfr_hud.airspeed, vfr_hud.groundspeed, vfr_hud.alt,
                vfr_hud.climb, vfr_hud.heading, vfr_hud.throttle);
       bm_mavlink_transmit(&msg);
+      break;
+    }
     }
   }
 }

--- a/src/apps/bridge/CMakeLists.txt
+++ b/src/apps/bridge/CMakeLists.txt
@@ -17,6 +17,7 @@ set(APP_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/sensors/sensors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sensorController.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bridgeLog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mavlink_integration.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cbor_sensor_report_encoder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/reportBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/reportBuilderList.cpp

--- a/src/apps/bridge/mavlink_integration.c
+++ b/src/apps/bridge/mavlink_integration.c
@@ -9,8 +9,8 @@
 #define BM_BRIDGE_MAVLINK_SYS_ID 1
 #define BM_BRIDGE_MAVLINK_COMP_ID MAV_COMP_ID_USER51
 
-// From flight controller, messages of interest are sent at the same time at a minimum rate of 1Hz
-#define BM_USV_TIMEOUT_TIME_MS (500)
+// From flight controller, messages of interest are sent at a minimum rate of 1Hz
+#define BM_USV_TIMEOUT_TIME_MS (1500)
 
 typedef struct {
   bm_serial_usv_metrics_t metrics;
@@ -29,6 +29,7 @@ static void metrics_send_to_ncp(void) {
 
 static void metrics_timer_cb(void *timer) {
   (void)timer;
+  bm_debug("MAVLink metrics timed out...\n");
   metrics_send_to_ncp();
 }
 
@@ -98,6 +99,7 @@ static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *ms
 
   // Message ready to send
   if (full_message) {
+    bm_debug("MAVLink metrics sending...\n");
     metrics_send_to_ncp();
     bm_timer_stop(ctx.metrics_timer, 0);
   } else if (partial_message) {

--- a/src/apps/bridge/mavlink_integration.c
+++ b/src/apps/bridge/mavlink_integration.c
@@ -9,31 +9,32 @@
 #define BM_BRIDGE_MAVLINK_SYS_ID 1
 #define BM_BRIDGE_MAVLINK_COMP_ID MAV_COMP_ID_USER51
 
-// From flight controller, messages of interest are sent at the same time at a rate of 1Hz
+// From flight controller, messages of interest are sent at the same time at a minimum rate of 1Hz
 #define BM_USV_TIMEOUT_TIME_MS (500)
+
+typedef struct {
+  bm_serial_usv_metrics_t metrics;
+  BmTimer metrics_timer;
+  BmSemaphore mut;
+} MavlinkIntegrationCtx;
+
+static MavlinkIntegrationCtx ctx = {0};
+
+static void metrics_send_to_ncp(void) {
+  bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
+  bm_serial_send_usv_metrics(ctx.metrics);
+  ctx.metrics = (bm_serial_usv_metrics_t){0};
+  bm_semaphore_give(ctx.mut);
+}
+
+static void metrics_timer_cb(void *timer) {
+  (void)timer;
+  metrics_send_to_ncp();
+}
 
 static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *msg,
                                          mavlink_status_t *status) {
   (void)status;
-  static bool imu_part = false;
-  static bool vfr_hud_part = false;
-  static bm_serial_usv_metrics_t metrics = {0};
-  static uint64_t last_message_ms = 0;
-
-  uint64_t current_ms = uptimeGetMs();
-  bool partial_message = imu_part != vfr_hud_part;
-  bool timed_out = current_ms - last_message_ms > BM_USV_TIMEOUT_TIME_MS;
-
-  // Clear message if not completed after timeout
-  if (partial_message && timed_out) {
-    bm_debug("USV message incomplete and timed out after %" PRIu16 "ms, clearing...\n",
-             BM_USV_TIMEOUT_TIME_MS);
-    imu_part = false;
-    vfr_hud_part = false;
-    metrics = (bm_serial_usv_metrics_t){0};
-  }
-
-  last_message_ms = current_ms;
 
   switch (msg->msgid) {
   case MAVLINK_MSG_ID_RAW_IMU: {
@@ -58,16 +59,16 @@ static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *ms
              node_id, msg->sysid, msg->compid, imu.time_usec, imu.xacc, imu.yacc, imu.zacc,
              imu.xgyro, imu.ygyro, imu.zgyro, imu.xmag, imu.ymag, imu.zmag, imu.id,
              imu.temperature);
-    metrics.xacc = imu.xacc;
-    metrics.yacc = imu.yacc;
-    metrics.zacc = imu.zacc;
-    metrics.xgyro = imu.xgyro;
-    metrics.ygyro = imu.ygyro;
-    metrics.zgyro = imu.zgyro;
-    metrics.xmag = imu.xmag;
-    metrics.ymag = imu.ymag;
-    metrics.zmag = imu.zmag;
-    imu_part = true;
+    ctx.metrics.imu.xacc = imu.xacc;
+    ctx.metrics.imu.yacc = imu.yacc;
+    ctx.metrics.imu.zacc = imu.zacc;
+    ctx.metrics.imu.xgyro = imu.xgyro;
+    ctx.metrics.imu.ygyro = imu.ygyro;
+    ctx.metrics.imu.zgyro = imu.zgyro;
+    ctx.metrics.imu.xmag = imu.xmag;
+    ctx.metrics.imu.ymag = imu.ymag;
+    ctx.metrics.imu.zmag = imu.zmag;
+    ctx.metrics.has_imu = true;
     break;
   }
   case MAVLINK_MSG_ID_VFR_HUD: {
@@ -85,19 +86,22 @@ static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *ms
              "\tthrottle: %" PRIu16 "\n",
              node_id, msg->sysid, msg->compid, vfr_hud.airspeed, vfr_hud.groundspeed,
              vfr_hud.alt, vfr_hud.climb, vfr_hud.heading, vfr_hud.throttle);
-    metrics.throttle = vfr_hud.throttle;
-    metrics.groundspeed = vfr_hud.groundspeed;
-    vfr_hud_part = true;
+    ctx.metrics.vfr.throttle = vfr_hud.throttle;
+    ctx.metrics.vfr.groundspeed = vfr_hud.groundspeed;
+    ctx.metrics.has_vfr = true;
     break;
   }
   }
 
+  bool partial_message = ctx.metrics.has_imu != ctx.metrics.has_vfr;
+  bool full_message = ctx.metrics.has_vfr && ctx.metrics.has_imu;
+
   // Message ready to send
-  if (vfr_hud_part && imu_part) {
-    vfr_hud_part = false;
-    imu_part = false;
-    bm_serial_send_usv_metrics(metrics);
-    metrics = (bm_serial_usv_metrics_t){0};
+  if (full_message) {
+    metrics_send_to_ncp();
+    bm_timer_stop(ctx.metrics_timer, 0);
+  } else if (partial_message) {
+    bm_timer_start(ctx.metrics_timer, 0);
   }
 }
 
@@ -108,20 +112,32 @@ bool bridge_mavlink_init(void) {
       {package_and_send_usv_metrics, MAVLINK_MSG_ID_VFR_HUD},
   };
 
-  bool ret = true;
+  if (initialized) {
+    return true;
+  }
 
-  if (!initialized) {
-    BmMavLinkInfo info = {
-        BM_BRIDGE_MAVLINK_SYS_ID,
-        BM_BRIDGE_MAVLINK_COMP_ID,
-        MAV_TYPE_GENERIC,
-    };
+  BmMavLinkInfo info = {
+      BM_BRIDGE_MAVLINK_SYS_ID,
+      BM_BRIDGE_MAVLINK_COMP_ID,
+      MAV_TYPE_GENERIC,
+  };
 
-    ret = bm_mavlink_init(info, MAV_STATE_ACTIVE, rx_lut, array_size(rx_lut)) == BmOK;
+  BmErr err = bm_mavlink_init(info, MAV_STATE_ACTIVE, rx_lut, array_size(rx_lut));
+  if (err != BmOK) {
+    return false;
+  }
 
-    if (ret) {
-      initialized = true;
-    }
+  ctx.metrics_timer =
+      bm_timer_create("mavlink_timer", BM_USV_TIMEOUT_TIME_MS, false, NULL, metrics_timer_cb);
+  if (!ctx.metrics_timer) {
+    return false;
+  }
+
+  bool ret = false;
+  ctx.mut = bm_mutex_create();
+  if (ctx.mut) {
+    initialized = true;
+    ret = true;
   }
 
   return ret;

--- a/src/apps/bridge/mavlink_integration.c
+++ b/src/apps/bridge/mavlink_integration.c
@@ -1,0 +1,128 @@
+#include "mavlink_integration.h"
+#include "bm_config.h"
+#include "bm_mavlink.h"
+#include "bm_os.h"
+#include "bm_serial.h"
+#include "uptime.h"
+#include "util.h"
+
+#define BM_BRIDGE_MAVLINK_SYS_ID 1
+#define BM_BRIDGE_MAVLINK_COMP_ID MAV_COMP_ID_USER51
+
+// From flight controller, messages of interest are sent at the same time at a rate of 1Hz
+#define BM_USV_TIMEOUT_TIME_MS (500)
+
+static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *msg,
+                                         mavlink_status_t *status) {
+  (void)status;
+  static bool imu_part = false;
+  static bool vfr_hud_part = false;
+  static bm_serial_usv_metrics_t metrics = {0};
+  static uint64_t last_message_ms = 0;
+
+  uint64_t current_ms = uptimeGetMs();
+  bool partial_message = imu_part != vfr_hud_part;
+  bool timed_out = current_ms - last_message_ms > BM_USV_TIMEOUT_TIME_MS;
+
+  // Clear message if not completed after timeout
+  if (partial_message && timed_out) {
+    bm_debug("USV message incomplete and timed out after %" PRIu16 "ms, clearing...\n",
+             BM_USV_TIMEOUT_TIME_MS);
+    imu_part = false;
+    vfr_hud_part = false;
+    metrics = (bm_serial_usv_metrics_t){0};
+  }
+
+  last_message_ms = current_ms;
+
+  switch (msg->msgid) {
+  case MAVLINK_MSG_ID_RAW_IMU: {
+    mavlink_raw_imu_t imu;
+    mavlink_msg_raw_imu_decode(msg, &imu);
+    bm_debug("Mavlink RAW IMU:\n"
+             "\tnode_id: %" PRIx64 "\n"
+             "\tsystem_id: %" PRIu8 "\n"
+             "\tcomponent_id: %" PRIu8 "\n"
+             "\ttime_usec: %" PRIu64 "\n"
+             "\txacc: %" PRIi16 "\n"
+             "\tyacc: %" PRIi16 "\n"
+             "\tzacc: %" PRIi16 "\n"
+             "\txgyro: %" PRIi16 "\n"
+             "\tygyro: %" PRIi16 "\n"
+             "\tzgyro: %" PRIi16 "\n"
+             "\txmag: %" PRIi16 "\n"
+             "\tymag: %" PRIi16 "\n"
+             "\tzmag: %" PRIi16 "\n"
+             "\tid: %" PRIu8 "\n"
+             "\ttemperature: %" PRIi16 "\n",
+             node_id, msg->sysid, msg->compid, imu.time_usec, imu.xacc, imu.yacc, imu.zacc,
+             imu.xgyro, imu.ygyro, imu.zgyro, imu.xmag, imu.ymag, imu.zmag, imu.id,
+             imu.temperature);
+    metrics.xacc = imu.xacc;
+    metrics.yacc = imu.yacc;
+    metrics.zacc = imu.zacc;
+    metrics.xgyro = imu.xgyro;
+    metrics.ygyro = imu.ygyro;
+    metrics.zgyro = imu.zgyro;
+    metrics.xmag = imu.xmag;
+    metrics.ymag = imu.ymag;
+    metrics.zmag = imu.zmag;
+    imu_part = true;
+    break;
+  }
+  case MAVLINK_MSG_ID_VFR_HUD: {
+    mavlink_vfr_hud_t vfr_hud;
+    mavlink_msg_vfr_hud_decode(msg, &vfr_hud);
+    bm_debug("Mavlink VFR HUD:\n"
+             "\tnode_id: %" PRIx64 "\n"
+             "\tsystem_id: %" PRIu8 "\n"
+             "\tcomponent_id: %" PRIu8 "\n"
+             "\tairspeed: %.3f\n"
+             "\tgroundspeed: %.3f\n"
+             "\talt: %.3f\n"
+             "\tclimb: %.3f\n"
+             "\theading: %" PRIi16 "\n"
+             "\tthrottle: %" PRIu16 "\n",
+             node_id, msg->sysid, msg->compid, vfr_hud.airspeed, vfr_hud.groundspeed,
+             vfr_hud.alt, vfr_hud.climb, vfr_hud.heading, vfr_hud.throttle);
+    metrics.throttle = vfr_hud.throttle;
+    metrics.groundspeed = vfr_hud.groundspeed;
+    vfr_hud_part = true;
+    break;
+  }
+  }
+
+  // Message ready to send
+  if (vfr_hud_part && imu_part) {
+    vfr_hud_part = false;
+    imu_part = false;
+    bm_serial_send_usv_metrics(metrics);
+    metrics = (bm_serial_usv_metrics_t){0};
+  }
+}
+
+bool bridge_mavlink_init(void) {
+  static bool initialized = false;
+  static BmMavLinkRxEntry rx_lut[] = {
+      {package_and_send_usv_metrics, MAVLINK_MSG_ID_RAW_IMU},
+      {package_and_send_usv_metrics, MAVLINK_MSG_ID_VFR_HUD},
+  };
+
+  bool ret = true;
+
+  if (!initialized) {
+    BmMavLinkInfo info = {
+        BM_BRIDGE_MAVLINK_SYS_ID,
+        BM_BRIDGE_MAVLINK_COMP_ID,
+        MAV_TYPE_GENERIC,
+    };
+
+    ret = bm_mavlink_init(info, MAV_STATE_ACTIVE, rx_lut, array_size(rx_lut)) == BmOK;
+
+    if (ret) {
+      initialized = true;
+    }
+  }
+
+  return ret;
+}

--- a/src/apps/bridge/mavlink_integration.c
+++ b/src/apps/bridge/mavlink_integration.c
@@ -21,22 +21,23 @@ typedef struct {
 static MavlinkIntegrationCtx ctx = {0};
 
 static void metrics_send_to_ncp(void) {
-  bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
   bm_serial_send_usv_metrics(ctx.metrics);
   ctx.metrics = (bm_serial_usv_metrics_t){0};
-  bm_semaphore_give(ctx.mut);
 }
 
 static void metrics_timer_cb(void *timer) {
   (void)timer;
+  bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
   bm_debug("MAVLink metrics timed out...\n");
   metrics_send_to_ncp();
+  bm_semaphore_give(ctx.mut);
 }
 
 static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *msg,
                                          mavlink_status_t *status) {
   (void)status;
 
+  bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
   switch (msg->msgid) {
   case MAVLINK_MSG_ID_RAW_IMU: {
     mavlink_raw_imu_t imu;
@@ -105,6 +106,7 @@ static void package_and_send_usv_metrics(uint64_t node_id, mavlink_message_t *ms
   } else if (partial_message) {
     bm_timer_start(ctx.metrics_timer, 0);
   }
+  bm_semaphore_give(ctx.mut);
 }
 
 bool bridge_mavlink_init(void) {

--- a/src/apps/bridge/mavlink_integration.h
+++ b/src/apps/bridge/mavlink_integration.h
@@ -1,0 +1,16 @@
+#ifndef __BRIDGE_MAVLINK_INTEGRATION_H__
+#define __BRIDGE_MAVLINK_INTEGRATION_H__
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool bridge_mavlink_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__BRIDGE_MAVLINK_INTEGRATION_H__

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -423,7 +423,6 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
       } else if (strncmp(reply.app_name, "mavlink_bridge",
                          MIN(reply.app_name_strlen, strlen("mavlink_bridge"))) == 0) {
         bridge_mavlink_init();
-        printf("Here starting MAVLink!\n");
       }
     } else {
       printf("NACK\n");

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include "bridgeLog.h"
 #include "bridgePowerController.h"
 #include "device_info.h"
+#include "mavlink_integration.h"
 #include "pmeDissolvedOxygenSensor.h"
 #include "pmeWipeSensor.h"
 #include "rbrCodaSensor.h"
@@ -420,6 +421,9 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
           }
         }
       }
+    } else if (strncmp(reply.app_name, "mavlink_bridge",
+                       MIN(reply.app_name_strlen, strlen("mavlink_bridge"))) == 0) {
+      bridge_mavlink_init();
     } else {
       printf("NACK\n");
     }

--- a/src/apps/bridge/sensorController.cpp
+++ b/src/apps/bridge/sensorController.cpp
@@ -420,10 +420,11 @@ static bool node_info_reply_cb(bool ack, uint32_t msg_id, size_t service_strlen,
             bm_free(borealis_sub);
           }
         }
+      } else if (strncmp(reply.app_name, "mavlink_bridge",
+                         MIN(reply.app_name_strlen, strlen("mavlink_bridge"))) == 0) {
+        bridge_mavlink_init();
+        printf("Here starting MAVLink!\n");
       }
-    } else if (strncmp(reply.app_name, "mavlink_bridge",
-                       MIN(reply.app_name_strlen, strlen("mavlink_bridge"))) == 0) {
-      bridge_mavlink_init();
     } else {
       printf("NACK\n");
     }


### PR DESCRIPTION
## What changed?
Forwards messages of interest from Bristlemouth MAVLink integration to the network co-processor (in this case Sofar Ocean's Spotter).

Makes sure both parts of the message exist before packaging it to be sent to Spotter, will timeout if only part of the 2 messages are sent.

## How does it make Bristlemouth better?

Bridges USV integration into Bristlemouth! 😉 

## Where should reviewers focus?

Because the Ardupilot flight controller publishes all Mavlink messages at a default rate of 1Hz, the two messages of interest would arrive at the same time. But these publishing rates can vary depending on how the flight controller is configured for each of these messages, which has me concerned. So my question is:

Should the `bm_serial` message be broken up into two separate messages, one for each of the MAVLink messages
- It would be nice to keep this as a single message to prevent adding more messages to `bm_serial`
- Maybe the struct for the `bm_serial` message can look like:
  ```c
  typedef struct {
    bool has_imu;
    bool has_power_control;
    struct {
      // USV realtime accelerometer readings
      int16_t xacc;
      int16_t yacc;
      int16_t zacc;
      // USV realtime gyroscope readings
      int16_t xgyro;
      int16_t ygyro;
      int16_t zgyro;
      // USV realtime magnetometer readings
      int16_t xmag;
      int16_t ymag;
      int16_t zmag;
    } imu;
    struct {
      // USV speed
      float groundspeed;
      // USV engine throttle
      uint16_t throttle;
    } power_control;
  } __attribute__((packed)) bm_serial_usv_metrics_t;
  ```
  And the timeout can be used to determine when to send the message, i.e. if the second part does not arrive.
  Would love feedback on thoughts around this!

  (edit: I have went through and implemented the above)
## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
