### PR TITLE
Increase Buffer Size For Bridge Config Topology And Chunk Over UART

### DIFF
--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -431,6 +431,7 @@ static void defaultTask(void *parameters) {
 
   reportBuilderInit();
   sensorControllerInit(&bridge_power_controller);
+  bridgeLogInit();
   ncpInit(&usart3, &dfu_partition, &bridge_power_controller);
   topology_sampler_init(&bridge_power_controller);
   debug_ncp_init();

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -99,10 +99,9 @@ static void check_lock_publish_or_enqueue(const BridgeLogPubInfo *info) {
   if (!locked || is_locking_task) {
     bm_serial_pub(getNodeId(), info->topic, info->topic_length, info->data, info->data_length,
                   info->type, info->version);
-    return;
+  } else {
+    bridge_log_enqueue(info);
   }
-
-  bridge_log_enqueue(info);
 
   return;
 }

--- a/src/apps/bridge/bridgeLog.cpp
+++ b/src/apps/bridge/bridgeLog.cpp
@@ -1,11 +1,151 @@
 #include "bridgeLog.h"
 #include "FreeRTOS.h"
 #include "app_pub_sub.h"
+#include "bm_os.h"
 #include "bm_serial.h"
 #include "device_info.h"
+#include "q.h"
 #include "stm32_rtc.h"
+#include "task.h"
 #include <stdio.h>
 #include <string.h>
+
+#define SHARE_MESSAGE_BUF_SIZE 2048
+
+// Message sizes rarely should come close to the shared buffer size, this should adequate
+#define QUEUE_BUFFER_SIZE (2 * SHARE_MESSAGE_BUF_SIZE + 2 * sizeof(QItem))
+
+typedef struct {
+  uint8_t type;
+  uint8_t version;
+  uint16_t topic_length;
+  uint16_t data_length;
+  const char *topic;
+  const uint8_t *data;
+} BridgeLogPubInfo;
+
+typedef struct {
+  bool lock;              // If locked, enqueues items to send upon unlocking
+  BmTaskHandle lock_task; // Task performing the locking operation
+  BmSemaphore mut;
+  Q message_queue;
+  uint8_t message_queue_buf[QUEUE_BUFFER_SIZE];
+  uint8_t shared_message_buf[SHARE_MESSAGE_BUF_SIZE];
+} BridgeLogCtx;
+
+static BridgeLogCtx ctx = {};
+
+static BmErr bridge_log_enqueue(const BridgeLogPubInfo *info) {
+  uint32_t topic_offset = sizeof(BridgeLogPubInfo);
+  uint32_t data_offset = topic_offset + info->topic_length;
+  uint32_t total_size = data_offset + info->data_length;
+
+  if (total_size > SHARE_MESSAGE_BUF_SIZE) {
+    return BmENOMEM;
+  }
+
+  uint8_t *buf = ctx.shared_message_buf;
+
+  // Copy over the static parts of the struct
+  memcpy(buf, info, sizeof(BridgeLogPubInfo));
+
+  // Copy over the topic and data
+  memcpy(&buf[topic_offset], info->topic, info->topic_length);
+  memcpy(&buf[data_offset], info->data, info->data_length);
+
+  BmErr err = q_enqueue(&ctx.message_queue, buf, total_size);
+
+  return err;
+}
+
+static BmErr bridge_log_dequeue(BridgeLogPubInfo *info) {
+  uint32_t topic_offset = sizeof(BridgeLogPubInfo);
+  uint8_t *buf = ctx.shared_message_buf;
+  uint32_t buf_size = sizeof(ctx.shared_message_buf);
+
+  BmErr err = q_dequeue(&ctx.message_queue, buf, buf_size);
+  if (err != BmOK) {
+    // Clear queue in case of unexpected error
+    if (err != BmENODATA) {
+      q_clear(&ctx.message_queue);
+    }
+    return err;
+  }
+
+  // Copy static portions of the struct
+  memcpy(info, buf, sizeof(BridgeLogPubInfo));
+
+  // Assign pointers to the topic and data members
+  uint32_t data_offset = topic_offset + info->topic_length;
+  info->topic = reinterpret_cast<const char *>(&buf[topic_offset]);
+  info->data = &buf[data_offset];
+
+  return BmOK;
+}
+
+static void log_dequeue(void) {
+  BridgeLogPubInfo info;
+  // Dequeue all bridge log elements while
+  while (bridge_log_dequeue(&info) == BmOK) {
+    bm_serial_pub(getNodeId(), info.topic, info.topic_length, info.data, info.data_length,
+                  info.type, info.version);
+  }
+}
+
+static void check_lock_publish_or_enqueue(const BridgeLogPubInfo *info) {
+  bool locked = ctx.lock;
+  bool is_locking_task = xTaskGetCurrentTaskHandle() == ctx.lock_task;
+
+  if (!locked || is_locking_task) {
+    bm_serial_pub(getNodeId(), info->topic, info->topic_length, info->data, info->data_length,
+                  info->type, info->version);
+    return;
+  }
+
+  bridge_log_enqueue(info);
+
+  return;
+}
+
+void bridgeLogInit(void) {
+  ctx.mut = bm_mutex_create();
+
+  q_create_static(&ctx.message_queue, ctx.message_queue_buf, QUEUE_BUFFER_SIZE);
+}
+
+/*!
+ @brief Lock Bridge Logging
+
+ @details Locks other tasks from publishing log messages. This function will
+          only unlock the interface if the original calling task invokes this
+          function with false as the lock argument. Upon unlocking, log
+          messages queued during the locked period will be dequeued immedietely.
+          
+ @param lock Whether bridge logging should be locked or unlocked.
+
+ @return true if bridge log was locked or unlocked, false if it could not be
+         locked or unlocked
+ */
+bool bridgeLogLock(bool lock) {
+  BmTaskHandle current_task = xTaskGetCurrentTaskHandle();
+
+  bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
+  bool can_lock = !ctx.lock_task || current_task == ctx.lock_task;
+
+  if (can_lock) {
+    // If unlocking dequeue all buffered messages
+    if (ctx.lock && !lock) {
+      log_dequeue();
+      ctx.lock_task = NULL;
+    } else {
+      ctx.lock_task = current_task;
+    }
+    ctx.lock = lock;
+  }
+  bm_semaphore_give(ctx.mut);
+
+  return can_lock;
+}
 
 void bridgeLogPrint(bridgeLogType_e type, BmLogLevel level, bool print_header,
                     const char *format, ...) {
@@ -47,24 +187,31 @@ void vBridgeLogPrint(bridgeLogType_e type, BmLogLevel level, bool print_header,
       log_msg->timestamp_utc_s = rtcGetMicroSeconds(&datetime) * 1e-6;
     }
     printf("%s", log_msg->message);
+
+    BridgeLogPubInfo info = {};
+    info.data = reinterpret_cast<const uint8_t *>(log_msg);
+    info.data_length = msg_len;
     switch (type) {
     case BRIDGE_SYS:
-      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC,
-                    sizeof(APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC) - 1,
-                    reinterpret_cast<const uint8_t *>(log_msg), msg_len,
-                    APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE, APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION);
+      info.topic = APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC;
+      info.topic_length = sizeof(APP_PUB_SUB_BM_BRIDGE_PRINTF_TOPIC) - 1;
+      info.type = APP_PUB_SUB_BM_BRIDGE_PRINTF_TYPE;
+      info.version = APP_PUB_SUB_BM_BRIDGE_PRINTF_VERSION;
       break;
     case BRIDGE_CFG:
-      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC,
-                    sizeof(APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC) - 1,
-                    reinterpret_cast<const uint8_t *>(log_msg), msg_len,
-                    APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TYPE,
-                    APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_VERSION);
+      info.topic = APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC;
+      info.topic_length = sizeof(APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TOPIC) - 1;
+      info.type = APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_TYPE;
+      info.version = APP_PUB_SUB_BM_BRIDGE_CFG_PRINTF_VERSION;
       break;
     default:
       printf("ERROR: Unknown log type in bridgeLogPrintf\n");
       break;
     }
+
+    bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
+    check_lock_publish_or_enqueue(&info);
+    bm_semaphore_give(ctx.mut);
   } while (0);
   if (log_msg) {
     vPortFree(log_msg);
@@ -73,26 +220,31 @@ void vBridgeLogPrint(bridgeLogType_e type, BmLogLevel level, bool print_header,
 
 void bridgeSensorLogPrintf(bridgeSensorLogType_e type, const char *str, size_t len) {
   if (len > 0) {
+    BridgeLogPubInfo info = {};
+    info.data = reinterpret_cast<const uint8_t *>(str);
+    info.data_length = len;
     switch (type) {
     case BM_COMMON_IND:
       printf("[%s] %.*s", "BM_COMMON_IND", (int)len, str);
-      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC,
-                    sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC) - 1,
-                    reinterpret_cast<const uint8_t *>(str), len,
-                    APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE,
-                    APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION);
+      info.topic = APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC;
+      info.topic_length = sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TOPIC) - 1;
+      info.type = APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_TYPE;
+      info.version = APP_PUB_SUB_BM_BRIDGE_SENSOR_IND_VERSION;
       break;
     case BM_COMMON_AGG:
       printf("[%s] %.*s", "BM_COMMON_AGG", (int)len, str);
-      bm_serial_pub(getNodeId(), APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC,
-                    sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC) - 1,
-                    reinterpret_cast<const uint8_t *>(str), len,
-                    APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE,
-                    APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION);
+      info.topic = APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC;
+      info.topic_length = sizeof(APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TOPIC) - 1;
+      info.type = APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_TYPE;
+      info.version = APP_PUB_SUB_BM_BRIDGE_SENSOR_AGG_VERSION;
       break;
     default:
       printf("ERROR: Unknown log type in bridgerSensorLogPrintf\n");
       break;
     }
+
+    bm_semaphore_take(ctx.mut, BM_MAX_DELAY_UINT32);
+    check_lock_publish_or_enqueue(&info);
+    bm_semaphore_give(ctx.mut);
   }
 }

--- a/src/apps/bridge/bridgeLog.h
+++ b/src/apps/bridge/bridgeLog.h
@@ -17,6 +17,8 @@ typedef enum {
   BRIDGE_CFG,
 } bridgeLogType_e;
 
+void bridgeLogInit(void);
+bool bridgeLogLock(bool lock);
 void bridgeLogPrint(bridgeLogType_e type, BmLogLevel level, bool print_header,
                     const char *format, ...);
 void vBridgeLogPrint(bridgeLogType_e type, BmLogLevel level, bool print_header,

--- a/src/apps/bridge/network_config_logger.cpp
+++ b/src/apps/bridge/network_config_logger.cpp
@@ -50,6 +50,7 @@ void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buf
   }
 
   state.pos = 0;
+  bridgeLogLock(true);
   bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge network config: ");
   cbor_value_to_pretty_stream(print_stream_handler, &state, &it, CborPrettyDefaultFlags);
   // Flush rest of buffer here
@@ -59,4 +60,5 @@ void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buf
                    state.buf);
   }
   bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "\n");
+  bridgeLogLock(false);
 }

--- a/src/apps/bridge/network_config_logger.cpp
+++ b/src/apps/bridge/network_config_logger.cpp
@@ -1,33 +1,39 @@
 #include "network_config_logger.h"
 #include "FreeRTOS.h"
+#include "bm_os.h"
 #include "bridgeLog.h"
 #include "cbor.h"
 #include "ncp_uart.h"
 
-static char *log_buffer = NULL;
-static size_t log_buffer_size = 0;
-static size_t log_buffer_offset = 0;
+#define CHUNK_SIZE (NCP_BUFF_LEN / 2)
 
-static CborError size_handler(void *out, const char *fmt, ...) {
-  (void)out;
-
-  va_list args;
-  va_start(args, fmt);
-  int n = vsnprintf(nullptr, 0, fmt, args);
-  log_buffer_size += n;
-  va_end(args);
-
-  return n < 0 ? CborErrorIO : CborNoError;
-}
+typedef struct {
+  char buf[CHUNK_SIZE];
+  size_t pos;
+} ChunkState;
 
 static CborError print_stream_handler(void *out, const char *fmt, ...) {
-  configASSERT(log_buffer != NULL);
-  (void)out;
+  ChunkState *state = static_cast<ChunkState *>(out);
 
+  // Write tmp into our chunk buffer, flushing as needed
   va_list args;
   va_start(args, fmt);
-  log_buffer_offset +=
-      vsnprintf(&log_buffer[log_buffer_offset], log_buffer_size - log_buffer_offset, fmt, args);
+  int n = vsnprintf(NULL, 0, fmt, args);
+  va_end(args);
+
+  size_t space_left = CHUNK_SIZE - state->pos;
+
+  // If cannot fit into chunked buffer, send now
+  if (space_left < static_cast<size_t>(n)) {
+    size_t to_write = state->pos;
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "%.*s", to_write,
+                   state->buf);
+    state->pos = 0;
+    space_left = CHUNK_SIZE;
+  }
+
+  va_start(args, fmt);
+  state->pos += vsnprintf(&state->buf[state->pos], space_left, fmt, args);
   va_end(args);
 
   return CborNoError;
@@ -35,8 +41,7 @@ static CborError print_stream_handler(void *out, const char *fmt, ...) {
 
 void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buffer_size) {
   configASSERT(cbor_buffer != NULL);
-  log_buffer_size = 0;
-  log_buffer_offset = 0;
+  static ChunkState state = {};
   CborParser parser;
   CborValue it;
   CborError err = cbor_parser_init(cbor_buffer, cbor_buffer_size, 0, &parser, &it);
@@ -44,37 +49,14 @@ void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buf
     return;
   }
 
-  // Obtain log buffer size
-  err = cbor_value_to_pretty_stream(size_handler, NULL, &it, CborPrettyDefaultFlags);
-  if (err != CborNoError) {
-    return;
-  }
-
-  // Must re-initialize parser's iterator
-  err = cbor_parser_init(cbor_buffer, cbor_buffer_size, 0, &parser, &it);
-  if (err != CborNoError) {
-    return;
-  }
-
-  // Fail gracefully here, the system can still operate without sending this message
-  log_buffer = static_cast<char *>(pvPortMalloc(log_buffer_size));
-  if (!log_buffer) {
-    return;
-  }
-
-  cbor_value_to_pretty_stream(print_stream_handler, NULL, &it, CborPrettyDefaultFlags);
+  state.pos = 0;
   bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge network config: ");
-
-  // Chunk the config map to be sent over NCP UART
-  constexpr uint32_t print_max_size = NCP_BUFF_LEN / 2;
-  for (uint32_t i = 0; i < log_buffer_size; i += print_max_size) {
-    uint32_t log_send_size =
-        log_buffer_size > print_max_size ? print_max_size : log_buffer_size;
-    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "%.*s", log_send_size,
-                   &log_buffer[i]);
+  cbor_value_to_pretty_stream(print_stream_handler, &state, &it, CborPrettyDefaultFlags);
+  // Flush rest of buffer here
+  if (state.pos) {
+    size_t to_write = state.pos;
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "%.*s", to_write,
+                   state.buf);
   }
   bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "\n");
-
-  vPortFree(log_buffer);
-  log_buffer = NULL;
 }

--- a/src/apps/bridge/network_config_logger.cpp
+++ b/src/apps/bridge/network_config_logger.cpp
@@ -2,10 +2,23 @@
 #include "FreeRTOS.h"
 #include "bridgeLog.h"
 #include "cbor.h"
+#include "ncp_uart.h"
 
 static char *log_buffer = NULL;
 static size_t log_buffer_size = 0;
-static constexpr size_t log_buffer_max_size = 2048;
+static size_t log_buffer_offset = 0;
+
+static CborError size_handler(void *out, const char *fmt, ...) {
+  (void)out;
+
+  va_list args;
+  va_start(args, fmt);
+  int n = vsnprintf(nullptr, 0, fmt, args);
+  log_buffer_size += n;
+  va_end(args);
+
+  return n < 0 ? CborErrorIO : CborNoError;
+}
 
 static CborError print_stream_handler(void *out, const char *fmt, ...) {
   configASSERT(log_buffer != NULL);
@@ -13,32 +26,55 @@ static CborError print_stream_handler(void *out, const char *fmt, ...) {
 
   va_list args;
   va_start(args, fmt);
-  int n = vsnprintf(nullptr, 0, fmt, args);
-  if (n > 0 && log_buffer_size < log_buffer_max_size) {
-    vsnprintf(&log_buffer[log_buffer_size], log_buffer_max_size - log_buffer_size, fmt, args);
-    log_buffer_size += n;
-  }
+  log_buffer_offset +=
+      vsnprintf(&log_buffer[log_buffer_offset], log_buffer_size - log_buffer_offset, fmt, args);
   va_end(args);
 
-  return n < 0 ? CborErrorIO : CborNoError;
+  return CborNoError;
 }
 
 void log_cbor_network_configurations(const uint8_t *cbor_buffer, size_t cbor_buffer_size) {
   configASSERT(cbor_buffer != NULL);
-  configASSERT(log_buffer == NULL);
-  log_buffer = static_cast<char *>(pvPortMalloc(log_buffer_max_size));
-  configASSERT(log_buffer);
   log_buffer_size = 0;
+  log_buffer_offset = 0;
   CborParser parser;
   CborValue it;
   CborError err = cbor_parser_init(cbor_buffer, cbor_buffer_size, 0, &parser, &it);
-  if (err == CborNoError) {
-    cbor_value_to_pretty_stream(print_stream_handler, NULL, &it, CborPrettyDefaultFlags);
-    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
-                   "Bridge network config: %.*s\n", log_buffer_size, log_buffer);
+  if (err != CborNoError) {
+    return;
   }
-  if (log_buffer) {
-    vPortFree(log_buffer);
-    log_buffer = NULL;
+
+  // Obtain log buffer size
+  err = cbor_value_to_pretty_stream(size_handler, NULL, &it, CborPrettyDefaultFlags);
+  if (err != CborNoError) {
+    return;
   }
+
+  // Must re-initialize parser's iterator
+  err = cbor_parser_init(cbor_buffer, cbor_buffer_size, 0, &parser, &it);
+  if (err != CborNoError) {
+    return;
+  }
+
+  // Fail gracefully here, the system can still operate without sending this message
+  log_buffer = static_cast<char *>(pvPortMalloc(log_buffer_size));
+  if (!log_buffer) {
+    return;
+  }
+
+  cbor_value_to_pretty_stream(print_stream_handler, NULL, &it, CborPrettyDefaultFlags);
+  bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER, "Bridge network config: ");
+
+  // Chunk the config map to be sent over NCP UART
+  constexpr uint32_t print_max_size = NCP_BUFF_LEN / 2;
+  for (uint32_t i = 0; i < log_buffer_size; i += print_max_size) {
+    uint32_t log_send_size =
+        log_buffer_size > print_max_size ? print_max_size : log_buffer_size;
+    bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "%.*s", log_send_size,
+                   &log_buffer[i]);
+  }
+  bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "\n");
+
+  vPortFree(log_buffer);
+  log_buffer = NULL;
 }

--- a/src/apps/bringup_bridge/app_main.cpp
+++ b/src/apps/bringup_bridge/app_main.cpp
@@ -235,7 +235,6 @@ static void defaultTask(void *parameters) {
   // Inhibit low power mode during boot process
   lpmPeripheralActive(LPM_BOOT);
 
-  bridgeLogInit();
   startSerial();
 
   startCLI();

--- a/src/apps/bringup_bridge/app_main.cpp
+++ b/src/apps/bringup_bridge/app_main.cpp
@@ -235,6 +235,7 @@ static void defaultTask(void *parameters) {
   // Inhibit low power mode during boot process
   lpmPeripheralActive(LPM_BOOT);
 
+  bridgeLogInit();
   startSerial();
 
   startCLI();

--- a/src/lib/bm_ncp/ncp_uart.cpp
+++ b/src/lib/bm_ncp/ncp_uart.cpp
@@ -35,7 +35,6 @@ static constexpr uint8_t NCP_PROCESSOR_RX_QUEUE_DEPTH = 16;
 static constexpr uint8_t NCP_PROCESSOR_TX_QUEUE_DEPTH = 16;
 static constexpr uint8_t NCP_BAUD_RATE_NEGOTIATE_TIMEOUT_MS = 10;
 static constexpr uint8_t NCP_RX_BUFF_COUNT = 2;
-static constexpr uint16_t NCP_BUFF_LEN = 2048;
 static volatile uint32_t ncpRXBuffIdx = 0;
 static volatile uint8_t ncpRXCurrBuff = 0;
 static volatile uint8_t ncpRXBuff[NCP_RX_BUFF_COUNT][NCP_BUFF_LEN];

--- a/src/lib/bm_ncp/ncp_uart.h
+++ b/src/lib/bm_ncp/ncp_uart.h
@@ -11,6 +11,8 @@
 #include "nvmPartition.h"
 #include "serial.h"
 
+static constexpr uint16_t NCP_BUFF_LEN = 2048;
+
 // unused for now, but will be needed for bridge power sampling/interrupt driven uart comms
 typedef struct {
   IOPinHandle_t *intPin;
@@ -21,4 +23,3 @@ typedef struct {
 void ncpInit(SerialHandle_t *ncpUartHandle, NvmPartition *dfu_partition,
              BridgePowerController *power_controller);
 bool ncp_negotiate_baud_rate(uint32_t baud);
-// bool bridgeStart(const BridgeConfig_t *config); // TODO - do we need something like this - probably?


### PR DESCRIPTION
## What changed?

Pretty prints cbor configuration map to NULL buffer on bridge to get the size needed for the NCP log buffer, then proceeds to pretty print to the allocated buffer.
The log statement is broken up into chunks so that it may be sent over the UART interface properly.


## How does it make Bristlemouth better?

Allows for larger buffer size on Bridge when sending configuration maps to the NCP over UART to support an increased number of nodes on the Bristlemouth network.

## Where should reviewers focus?

I have looked for alternative solutions that will not potentially use a large amount of RAM but was not able to find anything great in tinycbor's library. Let me know if you can think of some better solutions!

## Testing
Here is the config map output from a Sofar Spotter:
<img width="2556" height="443" alt="image" src="https://github.com/user-attachments/assets/80a3df7c-f38e-40fe-b1c7-4f75f39d622a" />

```
2025-03-09T18:02:22.113Z [BRIDGE_CFG] [INFO] Bridge network config: [[18051847170415161419, "bridge", 2794679863, 3944824111, {"sampleIntervalMs": 1800000, "sampleDurationMs": 840000, "subsampleIntervalMs": 60000, "subsampleDurationMs": 30000, "subsample
Enabled": 0, "bridgePowerControllerEnabled": 1, "alignmentInterval5Min": 1, "samplesPerReport": 2, "transmitAggregations": 1, "currentReadingPeriodMs": 60000, "softReadingPeriodMs": 500, "rbrCodaReadingPeriodMs": 500, "disableUnusedPortsTimeMs": 0, "tick
sSamplingEnabled": 0, "turbidityReadingPeriodMs": 1000, "salinityReadingPeriodMs": 30000}], [11316520146590703508, "bm_rbr", 3114525382, 1280529602, {"9d0c5b1da7171f94": 0, "3ab84acda350c349": 0, "45694087da99b923": 0, "dfu_confirm": 1, "rbrCodaType": 2,
 "disableUnusedPortsTimeMs": 0}], [15307738215748708816, "serial_bridge", 838057655, 1030244400, {"disableUnusedPortsTimeMs": 0}], [17338441281132032165, "borealis", 3114525382, 245190499, {"disableUnusedPortsTimeMs": 0, "enable_sbc": 0, "sbc_command": "
/usr/local/bin/borealis_hydrotwin.sh", "report_interval": 810.f, "hydrotwin_ldr": 12, "sample_rate": 48000, "enable_daq_recording": 1}], [7371431991783118678, "aanderaa", 3114525382, 1941523237, {"sensorsPollIntervalMs": 5000, "sensorsCheckIntervalS": 60
, "currentAggPeriodMin": 0.f, "nSkipReadings": 0, "readingIntervalMs": 60000, "payloadWdToS": 70, "plUartBaudRate": 9600, "dfu_confirm": 1, "sensorBmLogEnable": 1, "disableUnusedPortsTimeMs": 0}], [4187221732029418504, "serial_bridge", 1876941642, 103024
4400, {"disableUnusedPortsTimeMs": 0}], [3028553066222167635, "bm_rbr", 3114525382, 2842535829, {"dfu_confirm": 1, "rbrCodaType": 2, "sensorsPollIntervalMs": 10000, "sensorBmLogEnable": 1, "disableUnusedPortsTimeMs": 0}], [17099771185193130725, "serial_b
ridge", 3634098711, 1030244400, {"disableUnusedPortsTimeMs": 0}], [16084703961411914896, "aanderaa", 3114525382, 4096890594, {"sensorsPollIntervalMs": 10000, "sensorsCheckIntervalS": 60, "currentAggPeriodMin": 0.f, "nSkipReadings": 0, "readingIntervalMs"
: 60000, "payloadWdToS": 70, "plUartBaudRate": 9600, "dfu_confirm": 1, "sensorBmLogEnable": 1, "disableUnusedPortsTimeMs": 0}], [16089316954901563807, "serial_bridge", 1876941642, 772967734, {"disableUnusedPortsTimeMs": 15000}]
```


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
