### PR TITLE
Allow External Repositories To Be Clone With Full Git History

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -305,7 +305,6 @@ class AutoBuilder:
                 repo = git.Repo.clone_from(
                     config["repo"],
                     dir,
-                    depth=1,
                 )
 
                 # If specified SHA in config, checkout that SHA


### PR DESCRIPTION
## What changed?

Remove the shallow clone when cloning external git repository in `auto_build.py`.

## How does it make Bristlemouth better?

Allows release applications such as Borealis to be built by examining the full Git history.


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
