### PR TITLE
Initialize Bridge Log Earlier

### DIFF
--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -343,6 +343,8 @@ static void defaultTask(void *parameters) {
   // Inhibit low power mode during boot process
   lpmPeripheralActive(LPM_BOOT);
 
+  bridgeLogInit();
+
   startSerial();
   startSerialConsole(&usbCLI);
   // Serial device will be enabled automatically when console connects
@@ -431,7 +433,6 @@ static void defaultTask(void *parameters) {
 
   reportBuilderInit();
   sensorControllerInit(&bridge_power_controller);
-  bridgeLogInit();
   ncpInit(&usart3, &dfu_partition, &bridge_power_controller);
   topology_sampler_init(&bridge_power_controller);
   debug_ncp_init();


### PR DESCRIPTION
There are bridge log portions of the code that can be reached before `bridgeLogInit` was called causing the bridge to crash

## What changed?
Initialize bridge log very early before anything else can call `bridgeLog` functions.


## How does it make Bristlemouth better?
The HIL tests remove configuration values and `sensorControllerInit` will `bridgeLogPrint` to Spotter if those values are missing. This was causing the bridge to crash. This fixes that by initializing the bridge log module very early on.
The `bridgeLogInit` function creates a mutex and queue, the mutex could not be taken because it was NULL.
Here is the crash backtrace:
<img width="2560" height="361" alt="image" src="https://github.com/user-attachments/assets/2e83afc1-33a1-4778-8c73-f4d64df6d87a" />

## Where should reviewers focus?
Should I also add protections in the bridgeLog module to only allow the mutex to be taken only if it has been created?
I feel fairly confident with this change, but extra defensive code would help just in-case `bridgeLogInit` were to change initialization location in the future.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
