### PR TITLE
Feat/uart sbc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
     # Setup testing
     include(CTest)
 
-    # Get v1.10.0 of googletest from github and compile
+    # Get googletest from github and compile
     CPMAddPackage(
       NAME googletest
       GITHUB_REPOSITORY google/googletest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -155,6 +155,14 @@
             }
         },
         {
+            "name": "native-serial-bridge",
+            "inherits": "default",
+            "cacheVariables": {
+                "APP": "native_serial_bridge",
+                "BSP": "bm_mote_v1.0"
+            }
+        },
+        {
             "name": "nortek",
             "inherits": "hello-world",
             "cacheVariables": {
@@ -361,6 +369,11 @@
         {
             "configurePreset": "mote-bristlefin",
             "name": "mote-bristlefin",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "native-serial-bridge",
+            "name": "native-serial-bridge",
             "jobs": 8
         },
         {

--- a/UART_SBC_PLAN.md
+++ b/UART_SBC_PLAN.md
@@ -1,0 +1,212 @@
+# UART SBC Transport — Design Plan
+
+## Goal
+
+Enable transparent Bristlemouth communication over PLUART between a dev kit
+mote and a Linux SBC (Raspberry Pi). PLUART becomes a third Bristlemouth
+network port alongside the two ADIN2111 PHY ports. BCMP neighbor discovery,
+heartbeats, pub-sub, and multicast forwarding work automatically.
+
+---
+
+## Why a new app, not modifying `serial_bridge`
+
+The existing `serial_bridge` (in `bm_devkit/`) uses `bm_serial` — a
+higher-level application protocol that handles pub/sub commands, DFU, config,
+etc. over COBS-framed messages. What we need is fundamentally different:
+**raw L2 Ethernet frame transport**. The new app lives in `src/apps/` (not
+`bm_devkit/`) since it's a highly customized app with its own `app_main.cpp`,
+not a community-facing dev kit example.
+
+---
+
+## Wire Format (matching bm_sbc)
+
+Must be identical to `bm_sbc/src/transports/uart_l2/`:
+
+```
+[COBS-encoded payload] [0x00 delimiter]
+```
+
+Payload (before COBS encoding):
+```
+[len_hi] [len_lo] [L2 frame ...] [CRC-32C, 4 bytes, big-endian]
+```
+
+- Length: 2-byte big-endian, equals the L2 frame size.
+- CRC-32C (Castagnoli, polynomial 0x82F63B78 reflected): computed over
+  length + L2 frame bytes.
+- 8N1, no flow control, 115200 baud default.
+
+COBS: Use the existing `src/third_party/cobs-c` library (different API from
+bm_sbc's minimal COBS — returns `cobs_encode_result` / `cobs_decode_result`
+structs with status codes).
+
+CRC-32C: Port the bm_sbc nibble-table implementation (~24 lines of C) since
+the firmware has CRC-32 IEEE in bm_core but not Castagnoli.
+
+---
+
+## Architecture
+
+### Current init chain
+
+```
+bcl_init()   [src/lib/bm_integration/bristlemouth_client.cpp]
+  → adin2111_init()
+  → bristlemouth_init(power_cb)   [bm_core/middleware/bristlemouth.c]
+      → adin2111_network_device()  → 2-port NetworkDevice
+      → bm_l2_init(adin_device)
+      → bm_ip_init()
+      → bcmp_init(adin_device)
+      → topology_init(2)
+      → bm_service_init(), bm_pubsub_init(), bm_middleware_init()
+```
+
+### Problem
+
+`bristlemouth_init()` hardcodes `adin2111_network_device()` and passes it
+to `bm_l2_init` / `bcmp_init`. We need a 3-port composite device instead.
+There's no way to inject a third port after the fact since `bcmp_init()` and
+`bm_ip_init()` lack deinit functions.
+
+### Solution: custom app_main.cpp that bypasses bcl_init / bristlemouth_init
+
+The new app has its own `app_main.cpp` (based on `mote_bristlefin/app_main.cpp`
+pattern, not the shared `bmdk_common` one). In `defaultTask()`, instead of
+calling `bcl_init()`, it:
+
+1. Initializes ADIN as usual (`adin2111_init()`, `adin2111_network_device()`)
+2. Initializes PLUART as a UART network device
+3. Creates a composite NetworkDevice (3 ports total)
+4. Calls `bm_l2_init(composite)`, `bm_ip_init()`, `bcmp_init(composite)`,
+   `topology_init(3)`, `bm_service_init()`, `bm_pubsub_init()`,
+   `bm_middleware_init()` directly
+
+This avoids modifying bm_core and keeps everything in the app layer.
+
+### Composite NetworkDevice
+
+```
+CompositeDevice { adin_device, uart_device }
+
+Port mapping:
+  Global port 1 → ADIN port 1
+  Global port 2 → ADIN port 2
+  Global port 3 → UART port 1
+
+num_ports() → 3
+
+send(self, data, len, port):
+  port 0 (flood) → adin.send(0) + uart.send(1)
+  port 1-2       → adin.send(port)
+  port 3         → uart.send(1)
+
+callbacks->receive(port_num, data, len):
+  ADIN calls with port_num 1 or 2 → forwarded as-is to composite callback
+  UART calls with port_num 1      → remapped to port_num 3
+
+callbacks->link_change(port_idx, is_up):
+  ADIN calls with port_idx 0 or 1 → forwarded as-is
+  UART calls with port_idx 0      → remapped to port_idx 2
+```
+
+### UART Network Device
+
+Implements `NetworkDeviceTrait` for a single-port UART device:
+
+| Trait function       | Implementation |
+|----------------------|----------------|
+| `send(port=1)`      | frame_encode (len+CRC+COBS), PLUART::write |
+| `enable`             | PLUART::init/enable, start RX task, signal link up |
+| `disable`            | PLUART::disable |
+| `num_ports`          | 1 |
+| `enable_port`        | no-op (always enabled) |
+| `disable_port`       | no-op |
+| `retry_negotiation`  | NULL |
+| `port_stats`         | NULL |
+| `handle_interrupt`   | no-op (UART has its own ISR) |
+
+**RX path:** A FreeRTOS task continuously reads bytes from PLUART
+byte-stream buffer, accumulates until `0x00` delimiter, calls
+`frame_decode()`, then invokes `callbacks->receive(1, l2_frame, len)`.
+
+**Link state:** Report link-up immediately on enable. BCMP heartbeats
+handle liveness detection.
+
+---
+
+## File Layout
+
+```
+src/apps/native_serial_bridge/
+  CMakeLists.txt
+  app_main.cpp              # Custom init: composite device → bm_l2_init etc.
+  FreeRTOSConfig.h          # Copied from mote_bristlefin or bmdk_common
+  memfault_platform_config.h
+  task_priorities.h
+  sensors/
+    sensors.cpp             # Minimal / empty sensor init
+  crc32c.h                  # CRC-32C (ported from bm_sbc, with TODO note)
+  crc32c.c
+  frame_codec.h             # frame_encode / frame_decode (ported, with TODO)
+  frame_codec.c
+  uart_network_device.h     # UART NetworkDeviceTrait implementation
+  uart_network_device.cpp
+  composite_device.h        # Wraps ADIN + UART into one NetworkDevice
+  composite_device.cpp
+```
+
+The app is selected with `-DAPP=native_serial_bridge` (no `CMAKE_APP_TYPE`
+needed — the `else()` branch in `src/CMakeLists.txt` resolves
+`src/apps/native_serial_bridge/` directly).
+
+---
+
+## Implementation Steps
+
+### Step 1: Port frame codec from bm_sbc
+
+Copy `crc32c.c/h` and `frame_codec.c/h` from bm_sbc. Adapt frame_codec to
+use the firmware's `cobs-c` third_party API (`cobs_encode_result` structs).
+Add TODO comments noting the duplication with bm_sbc.
+
+### Step 2: UART Network Device
+
+Create `uart_network_device.cpp/h`:
+- `NetworkDeviceTrait` vtable with send/enable/disable/num_ports
+- TX: frame_encode → PLUART::write
+- RX: FreeRTOS task polling PLUART byte stream, accumulating into buffer,
+  decoding on 0x00 delimiter, calling callbacks->receive
+- Link-up signaled immediately on enable
+
+### Step 3: Composite Network Device
+
+Create `composite_device.cpp/h`:
+- Stores references to both ADIN and UART NetworkDevices
+- Port remapping logic in send()
+- Wrapper callbacks that remap port numbers from sub-devices before
+  forwarding to the composite's own callbacks (which L2 sets)
+
+### Step 4: App scaffolding
+
+- Create `app_main.cpp` based on `mote_bristlefin/app_main.cpp` structure
+- Replace `bcl_init()` with custom init sequence using composite device
+- Create CMakeLists.txt listing all source files
+- Copy supporting files (FreeRTOSConfig.h, task_priorities.h, etc.)
+
+### Step 5: Build verification
+
+- Build with `-DAPP=native_serial_bridge`
+- Fix any compilation issues
+
+---
+
+## Risks / Notes
+
+- **PLUART buffer sizes:** TX stream buffer is 128 bytes, but
+  `PLUART::write()` streams through. Should handle ~1522-byte COBS frames.
+- **Frame loss is acceptable** — no flow control, CRC catches corruption,
+  BCMP heartbeats handle liveness. UDP-like by design.
+- **Topology display will break** — CLI expects 2-port daisy chain. Deferred.
+- **bm_serial not used:** PLUART is exclusively for L2 frame transport.

--- a/src/apps/native_serial_bridge/CMakeLists.txt
+++ b/src/apps/native_serial_bridge/CMakeLists.txt
@@ -1,0 +1,34 @@
+set(APP_DIR ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
+
+set(APP_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/app_main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/crc32c.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/frame_codec.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/uart_network_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/composite_device.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensors/sensors.cpp
+    ${SRC_DIR}/lib/common/payload_uart.cpp
+    # bristlefin.cpp is not auto-included for this APP_NAME/APP_TYPE combination;
+    # add it explicitly so Bristlefin::setGpioDefault() / setLed() are available.
+    ${SRC_DIR}/lib/bristlefin/bristlefin.cpp
+)
+
+set(APP_INCLUDES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/sensors
+)
+
+set(APP_LIBS
+)
+
+set(APP_DEFINES
+    APP_NAME="${APP_NAME}"
+)
+
+# Send APP_DEFINES to parent scope (otherwise we can't append to the
+# list above)
+set(APP_DEFINES "${APP_DEFINES}" PARENT_SCOPE)
+set(APP_LIBS "${APP_LIBS}" PARENT_SCOPE)
+set(APP_FILES "${APP_FILES}" PARENT_SCOPE)
+set(APP_INCLUDES "${APP_INCLUDES}" PARENT_SCOPE)
+

--- a/src/apps/native_serial_bridge/FreeRTOSConfig.h
+++ b/src/apps/native_serial_bridge/FreeRTOSConfig.h
@@ -1,0 +1,237 @@
+/* USER CODE BEGIN Header */
+/*
+ * FreeRTOS Kernel V10.2.1
+ * Portion Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Portion Copyright (C) 2019 StMicroelectronics, Inc.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+/* USER CODE END Header */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * These parameters and more are described within the 'configuration' section of the
+ * FreeRTOS API documentation available on the FreeRTOS.org web site.
+ *
+ * See http://www.freertos.org/a00110.html
+ *----------------------------------------------------------*/
+
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__)
+#include "lpm.h"
+#endif
+
+/* Ensure definitions are only used by the compiler, and not by the assembler. */
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__)
+#include <stdint.h>
+extern uint32_t SystemCoreClock;
+#endif
+#define configENABLE_FPU 1
+#define configENABLE_MPU 0
+#define configENABLE_TRUSTZONE 0
+
+#define configUSE_PREEMPTION 1
+#define configSUPPORT_STATIC_ALLOCATION 1
+#define configSUPPORT_DYNAMIC_ALLOCATION 1
+#define configUSE_IDLE_HOOK 1
+#define configUSE_TICK_HOOK 0
+#define configCPU_CLOCK_HZ (SystemCoreClock)
+#define configTICK_RATE_HZ ((TickType_t)1000)
+#define configMAX_PRIORITIES (32)
+#define configMINIMAL_STACK_SIZE ((uint16_t)128)
+#define configTOTAL_HEAP_SIZE ((size_t)1024 * 256)
+#define configMAX_TASK_NAME_LEN (16)
+#define configUSE_TRACE_FACILITY 1
+#define configUSE_16_BIT_TICKS 0
+#define configUSE_MUTEXES 1
+#define configQUEUE_REGISTRY_SIZE 8
+#define configUSE_RECURSIVE_MUTEXES 1
+#define configUSE_COUNTING_SEMAPHORES 1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configUSE_TICKLESS_IDLE 2
+#define configUSE_QUEUE_SETS 1
+
+/* Defaults to size_t for backward compatibility, but can be changed
+   if lengths will always be less than the number of bytes in a size_t. */
+#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
+
+// Adding an extra task notification entry for sensor hub pub/sub and other stuff
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES 3
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 0
+#define configMAX_CO_ROUTINE_PRIORITIES (2)
+
+/* Software timer definitions. */
+#define configUSE_TIMERS 1
+#define configTIMER_TASK_PRIORITY (2)
+#define configTIMER_QUEUE_LENGTH 32
+#define configTIMER_TASK_STACK_DEPTH 256
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet 1
+#define INCLUDE_uxTaskPriorityGet 1
+#define INCLUDE_vTaskDelete 1
+#define INCLUDE_vTaskCleanUpResources 0
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_vTaskDelayUntil 1
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_xTimerPendFunctionCall 1
+#define INCLUDE_xQueueGetMutexHolder 1
+#define INCLUDE_uxTaskGetStackHighWaterMark 1
+#define INCLUDE_eTaskGetState 1
+
+/*
+ * The CMSIS-RTOS V2 FreeRTOS wrapper is dependent on the heap implementation used
+ * by the application thus the correct define need to be enabled below
+ */
+#define USE_FreeRTOS_HEAP_4
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+/* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
+#define configPRIO_BITS __NVIC_PRIO_BITS
+#else
+#define configPRIO_BITS 4
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 15
+
+/* The highest interrupt priority that can be used by any interrupt service
+routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
+INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
+PRIORITY THAN THIS! (higher priorities are lower numeric values. */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY                                                        \
+  (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY                                                   \
+  (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+
+#include "memfault/panics/assert.h"
+#include "memfault/ports/freertos_trace.h"
+
+#define configASSERT(x) MEMFAULT_ASSERT(x)
+
+/* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
+standard names. */
+#define vPortSVCHandler SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+
+/* IMPORTANT: This define is commented when used with STM32Cube firmware, when the timebase source is SysTick,
+              to prevent overwriting SysTick_Handler defined within STM32Cube HAL */
+
+#define xPortSysTickHandler SysTick_Handler
+
+/* USER CODE BEGIN Defines */
+
+/* CLI output buffer size*/
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE 1024
+
+/* USER CODE END Defines */
+
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__)
+void PreSleepProcessing(uint32_t *ulExpectedIdleTime);
+void PostSleepProcessing(uint32_t *ulExpectedIdleTime);
+#endif /* defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__) */
+
+/* The configPRE_SLEEP_PROCESSING() and configPOST_SLEEP_PROCESSING() macros
+allow the application writer to add additional code before and after the MCU is
+placed into the low power state respectively. */
+#if configUSE_TICKLESS_IDLE == 1
+#define configPRE_SLEEP_PROCESSING PreSleepProcessing
+#define configPOST_SLEEP_PROCESSING PostSleepProcessing
+#endif /* configUSE_TICKLESS_IDLE == 1 */
+
+// #ifdef BUILD_DEBUG
+// Use "slow" but more reliable stack overflow check
+// Uncomment above line to only do this for debug builds
+// Can also use 1 instead of 2 for faster, but less reliable overflow checks
+#define configCHECK_FOR_STACK_OVERFLOW 2
+// #endif
+
+// Useful for debugging, takes up an additional 4 bytes per task
+#define configRECORD_STACK_HIGH_ADDRESS 1
+
+// Code is responsible for checking for malloc failures
+#define configUSE_MALLOC_FAILED_HOOK 0
+
+#define pdTICKS_TO_MS(xTicks)                                                                  \
+  ((uint32_t)(((uint64_t)(xTicks) * (uint32_t)1000U) / (uint32_t)configTICK_RATE_HZ))
+
+#define pdMS_TO_TICKS(xTimeInMs)                                                               \
+  ((uint32_t)(((uint64_t)(xTimeInMs) * (uint32_t)configTICK_RATE_HZ) / (uint32_t)1000U))
+
+// Integrate lptimTick.c and low power manager
+// For more information, see:
+// https://gist.github.com/jefftenney/02b313fe649a14b4c75237f925872d72
+//
+#if (configUSE_TICKLESS_IDLE == 2)
+
+//      Preprocessor code in lptimTick.c requires that configTICK_RATE_HZ be a preprocessor-friendly numeric
+// literal.  As a result, the application *ignores* the CubeMX configuration of the FreeRTOS tick rate.
+//
+#undef configTICK_RATE_HZ
+#define configTICK_RATE_HZ 1000UL // <-- Set FreeRTOS tick rate here, not in CubeMX.
+
+//      Don't bother installing xPortSysTickHandler() into the vector table or including it in the firmware
+// image at all.  FreeRTOS doesn't use the SysTick timer nor xPortSysTickHandler() when lptimTick.c is
+// providing the OS tick.
+//
+#undef xPortSysTickHandler
+
+// Use low power manager to determine if device can enter low power stop modes
+#define configPRE_SLEEP_PROCESSING(x) lpmPreSleepProcessing()
+#define configPOST_SLEEP_PROCESSING(x) lpmPostSleepProcessing()
+
+#endif // configUSE_TICKLESS_IDLE == 2
+
+// Custom trace code
+// #include "trace.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERTOS_CONFIG_H */

--- a/src/apps/native_serial_bridge/app_main.cpp
+++ b/src/apps/native_serial_bridge/app_main.cpp
@@ -1,0 +1,385 @@
+// Includes from CubeMX Generated files
+#include "main.h"
+
+// Peripheral
+#include "gpio.h"
+#include "icache.h"
+#include "iwdg.h"
+#include "usart.h"
+#include "usb_otg.h"
+
+// Includes for FreeRTOS
+#include "FreeRTOS.h"
+#include "task.h"
+#include "task_priorities.h"
+
+#include "bcmp_cli.h"
+#include "bm_adin2111.h"
+#include "bm_config.h"
+extern "C" {
+#include "bm_ip.h"
+}
+#include "bristlefin.h"
+#include "bristlemouth_client.h"
+#include "bsp.h"
+#include "cli.h"
+#include "composite_device.h"
+#include "config_cbor_map_service.h"
+#include "configuration.h"
+#include "debug_bm_service.h"
+#include "debug_configuration.h"
+#include "debug_dfu.h"
+#include "debug_gpio.h"
+#include "debug_memfault.h"
+#include "debug_nvm_cli.h"
+#include "debug_rtc.h"
+#include "debug_spotter.h"
+#include "debug_sys.h"
+#include "debug_w25.h"
+#include "device_info.h"
+#include "external_flash_partitions.h"
+#include "gpdma.h"
+#include "gpioISR.h"
+#include "l2.h"
+#include "memfault_platform_core.h"
+#include "nvmPartition.h"
+#include "pcap.h"
+#include "port_monitor.h"
+#include "printf.h"
+#include "ram_partitions.h"
+#include "sensorSampler.h"
+#include "sensors.h"
+#include "serial.h"
+#include "serial_console.h"
+#include "stm32_rtc.h"
+#include "sys_info_service.h"
+#include "timer_callback_handler.h"
+#include "uart_network_device.h"
+#include "uptime.h"
+#include "usb.h"
+#include "w25.h"
+#include "watchdog.h"
+
+#define LED_ON_TIME_MS 20
+#define LED_PERIOD_MS 1000
+
+extern "C" {
+#include "bcmp.h"
+#include "bm_service.h"
+#include "bristlemouth.h"
+#include "device.h"
+#include "middleware.h"
+#include "pubsub.h"
+#include "topology.h"
+}
+
+#include <stdio.h>
+#include <string.h>
+
+static void defaultTask(void *parameters);
+
+// Serial console (when no usb present)
+SerialHandle_t usart3 = {
+    .device = USART3,
+    .name = "usart3",
+    .txPin = &BM_MOSI_TX3,
+    .rxPin = &BM_SCK_RX3,
+    .interruptPin = NULL,
+    .txStreamBuffer = NULL,
+    .rxStreamBuffer = NULL,
+    .txBufferSize = 1024,
+    .rxBufferSize = 512,
+    .rxBytesFromISR = serialGenericRxBytesFromISR,
+    .getTxBytesFromISR = serialGenericGetTxBytesFromISR,
+    .processByte = NULL,
+    .data = NULL,
+    .arg = NULL,
+    .enabled = false,
+    .flags = 0,
+    .preTxCb = NULL,
+    .postTxCb = NULL,
+};
+
+// Serial console USB device
+SerialHandle_t usbCLI = {
+    .device = (void *)0, // Using CDC 0
+    .name = "vcp-cli",
+    .txPin = NULL,
+    .rxPin = NULL,
+    .interruptPin = NULL,
+    .txStreamBuffer = NULL,
+    .rxStreamBuffer = NULL,
+    .txBufferSize = 1024,
+    .rxBufferSize = 512,
+    .rxBytesFromISR = NULL,
+    .getTxBytesFromISR = NULL,
+    .processByte = NULL,
+    .data = NULL,
+    .arg = NULL,
+    .enabled = false,
+    .flags = 0,
+    .preTxCb = NULL,
+    .postTxCb = NULL,
+};
+
+SerialHandle_t usbPcap = {
+    .device = (void *)1, // Using CDC 1
+    .name = "vcp-bm",
+    .txPin = NULL,
+    .rxPin = NULL,
+    .interruptPin = NULL,
+    .txStreamBuffer = NULL,
+    .rxStreamBuffer = NULL,
+    .txBufferSize = 2048,
+    .rxBufferSize = 64,
+    .rxBytesFromISR = NULL,
+    .getTxBytesFromISR = NULL,
+    .processByte = NULL,
+    .data = NULL,
+    .arg = NULL,
+    .enabled = false,
+    .flags = 0,
+    .preTxCb = NULL,
+    .postTxCb = NULL,
+};
+
+extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }
+
+// TODO - make a getter API for these
+NvmPartition *userConfigurationPartition = NULL;
+NvmPartition *systemConfigurationPartition = NULL;
+NvmPartition *hardwareConfigurationPartition = NULL;
+NvmPartition *dfu_partition_global = NULL;
+
+// ---------------------------------------------------------------------------
+// ADIN2111 interrupt → L2
+// ---------------------------------------------------------------------------
+
+static bool network_device_interrupt(const void *pinHandle, uint8_t value, void *args) {
+  (void)pinHandle;
+  (void)value;
+  (void)args;
+  return bm_l2_handle_device_interrupt() == BmOK;
+}
+
+// ---------------------------------------------------------------------------
+// ADIN2111 power / reset callback (used as the composite power callback)
+// ---------------------------------------------------------------------------
+
+#define RESET_DELAY (1)
+#define AFTER_RESET_DELAY (100)
+
+static void native_power_callback(bool on) {
+  IOWrite(&ADIN_PWR, on);
+  if (on) {
+    IOWrite(&ADIN_CS, 1);
+    IOWrite(&ADIN_RST, 0);
+    vTaskDelay(pdMS_TO_TICKS(RESET_DELAY));
+    IOWrite(&ADIN_RST, 1);
+    vTaskDelay(pdMS_TO_TICKS(AFTER_RESET_DELAY));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Debug GPIO pin table (Bristleback mote pins)
+// ---------------------------------------------------------------------------
+
+// TODO - move this to some debug file?
+static const DebugGpio_t debugGpioPins[] = {
+    {"adin_cs", &ADIN_CS, GPIO_OUT},        {"adin_int", &ADIN_INT, GPIO_IN},
+    {"adin_pwr", &ADIN_PWR, GPIO_OUT},      {"adin_rst", &ADIN_RST, GPIO_OUT},
+    {"flash_cs", &FLASH_CS, GPIO_OUT},      {"boot_led", &BOOT_LED, GPIO_IN},
+    {"vusb_detect", &VUSB_DETECT, GPIO_IN},
+};
+
+// ---------------------------------------------------------------------------
+// main() — minimal pre-scheduler setup
+// ---------------------------------------------------------------------------
+
+extern "C" int main(void) {
+  HAL_Init();
+
+  SystemClock_Config();
+
+  SystemPower_Config_ext();
+
+  // Enable hardfault on divide-by-zero
+  SCB->CCR |= 0x10;
+
+  BaseType_t rval = xTaskCreate(defaultTask, "Default",
+                                // TODO - verify stack size
+                                128 * 4, NULL,
+                                // Start with very high priority during boot
+                                // then downgrade once done initializing
+                                DEFAULT_BOOT_TASK_PRIORITY, NULL);
+  configASSERT(rval == pdTRUE);
+
+  // Start FreeRTOS scheduler
+  vTaskStartScheduler();
+
+  /* We should never get here as control is now taken by the scheduler */
+  while (1) {
+  }
+}
+
+// ---------------------------------------------------------------------------
+// defaultTask — all initialization happens here (post-scheduler)
+// ---------------------------------------------------------------------------
+
+static void defaultTask(void *parameters) {
+  (void)parameters;
+
+  mxInit();
+
+  usbMspInit();
+
+  rtcInit();
+
+  // Initialize low power manager
+  lpmInit();
+
+  // Inhibit low power mode during boot process
+  lpmPeripheralActive(LPM_BOOT);
+
+  startSerial();
+  startSerialConsole(&usbCLI);
+  // Serial device will be enabled automatically when console connects
+  // so no explicit serialEnable is required
+  pcapInit(&usbPcap);
+
+  startCLI();
+
+  gpioISRStartTask();
+
+  memfault_platform_boot();
+  memfault_platform_start();
+
+  bspInit();
+  usbInit(&VUSB_DETECT, usb_is_connected);
+
+  debugSysInit();
+  debugMemfaultInit(&usbCLI);
+
+  debugGpioInit(debugGpioPins, sizeof(debugGpioPins) / sizeof(DebugGpio_t));
+  debugSpotterInit();
+  debugRTCInit();
+
+  timer_callback_handler_init();
+  spiflash::W25 debugW25(&spi2, &FLASH_CS);
+  debugW25Init(&debugW25);
+  NvmPartition debug_user_partition(debugW25, user_configuration);
+  NvmPartition debug_hardware_partition(debugW25, hardware_configuration);
+  NvmPartition debug_system_partition(debugW25, system_configuration);
+  userConfigurationPartition = &debug_user_partition;
+  systemConfigurationPartition = &debug_system_partition;
+  hardwareConfigurationPartition = &debug_hardware_partition;
+  NvmPartition debug_cli_partition(debugW25, cli_configuration);
+  NvmPartition dfu_partition(debugW25, dfu_configuration);
+  dfu_partition_global = &dfu_partition;
+  debugNvmCliInit(&debug_cli_partition, &dfu_partition);
+  debugDfuInit(&dfu_partition);
+
+  // -----------------------------------------------------------------------
+  // Bristlemouth stack init — manual sequence bypassing bcl_init() /
+  // bristlemouth_init() so we can inject our 3-port composite device.
+  // -----------------------------------------------------------------------
+
+  // Register the ADIN2111 GPIO interrupt → L2 before enabling the device.
+  extern adin_pins_t adin_pins;
+  IORegisterCallback(adin_pins.interrupt, network_device_interrupt, NULL);
+
+  HAL_Init_Hook();
+  config_init();
+  port_monitor_init();
+
+  uint8_t major, minor, patch;
+  getFWVersion(&major, &minor, &patch);
+  DeviceCfg device_cfg = {
+      .node_id = getNodeId(),
+      .git_sha = getGitSHA(),
+      .device_name = getUIDStr(),
+      .version_string = getFWVersionStr(),
+      .vendor_id = 0,
+      .product_id = 0,
+      .hw_ver = 0,
+      .ver_major = major,
+      .ver_minor = minor,
+      .ver_patch = patch,
+      .sn = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'},
+  };
+  device_init(device_cfg);
+
+  // Build the composite 3-port network device:
+  //   Port 1 → ADIN port 1
+  //   Port 2 → ADIN port 2
+  //   Port 3 → UART (PLUART) port 1
+  NetworkDevice adin_dev = adin2111_network_device();
+  NetworkDevice uart_dev = uart_network_device(UART_RX_TASK_PRIORITY);
+  NetworkDevice composite_dev = composite_network_device(adin_dev, uart_dev);
+
+  // Wire the ADIN power/reset callback through the composite power callback.
+  composite_dev.callbacks->power = native_power_callback;
+
+  printf("Starting native_serial_bridge BM stack (3-port composite)\n");
+
+  BmErr err = BmOK;
+  bm_err_check(err, adin2111_init());
+  bm_err_check(err, bm_l2_init(composite_dev));
+  bm_err_check(err, bm_ip_init());
+  bm_err_check(err, bcmp_init(composite_dev));
+  bm_err_check(err, topology_init(composite_dev.trait->num_ports()));
+  bm_err_check(err, bm_service_init());
+  bm_err_check(err, bm_pubsub_init());
+  bm_err_check(err, bm_middleware_init());
+
+  if (err == BmOK) {
+    // Enable packet capture output over USB VCP.
+    composite_dev.callbacks->debug_packet_dump = pcapTxPacket;
+    bcmp_cli_init();
+  } else {
+    printf("ERROR: BM stack init failed (%d)\n", err);
+  }
+
+  debugConfigurationInit();
+
+  uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;
+  uint32_t sys_cfg_sensorsCheckIntervalS = DEFAULT_SENSORS_CHECK_S;
+
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
+                  strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);
+  get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsCheckIntervalS",
+                  strlen("sensorsCheckIntervalS"), &sys_cfg_sensorsCheckIntervalS);
+
+  sensorConfig_t sensorConfig = {.sensorCheckIntervalS = sys_cfg_sensorsCheckIntervalS,
+                                 .sensorsPollIntervalMs = sys_cfg_sensorsPollIntervalMs};
+  sensorSamplerInit(&sensorConfig);
+  sensorsInit();
+  debugBmServiceInit();
+  sys_info_service_init();
+  config_cbor_map_service_init();
+
+  // Re-enable low power mode
+  lpmPeripheralInactive(LPM_BOOT);
+
+  // Drop priority now that we're done booting
+  vTaskPrioritySet(xTaskGetCurrentTaskHandle(), DEFAULT_TASK_PRIORITY);
+
+  // 1 Hz heartbeat: LED1 green on for LED_ON_TIME_MS, off for the remainder.
+  bool ledState = false;
+  uint64_t ledLastScheduledOnTime = uptimeGetMs();
+
+  while (1) {
+    const uint64_t elapsedSinceOnTime = uptimeGetMs() - ledLastScheduledOnTime;
+
+    if (!ledState && elapsedSinceOnTime >= LED_PERIOD_MS) {
+      ledLastScheduledOnTime += LED_PERIOD_MS;
+      bristlefin.setLed(1, Bristlefin::LED_GREEN);
+      ledState = true;
+    } else if (ledState && elapsedSinceOnTime >= LED_ON_TIME_MS) {
+      bristlefin.setLed(1, Bristlefin::LED_OFF);
+      ledState = false;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(1));
+  }
+}

--- a/src/apps/native_serial_bridge/app_main.cpp
+++ b/src/apps/native_serial_bridge/app_main.cpp
@@ -98,6 +98,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -120,6 +121,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -141,6 +143,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }

--- a/src/apps/native_serial_bridge/composite_device.cpp
+++ b/src/apps/native_serial_bridge/composite_device.cpp
@@ -1,0 +1,190 @@
+#include "composite_device.h"
+
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// Internal context
+// ---------------------------------------------------------------------------
+
+struct CompositeDeviceCtx {
+  NetworkDevice adin; ///< ADIN2111 sub-device (ports 1-2).
+  NetworkDevice uart; ///< UART sub-device (port 3).
+  /// Callbacks filled in by bm_l2_init — the "upward" composite callbacks.
+  NetworkDeviceCallbacks composite_callbacks;
+};
+
+static CompositeDeviceCtx s_ctx;
+
+// ---------------------------------------------------------------------------
+// Wrapper callbacks — ADIN sub-device
+//   ADIN port_num 1,2  → composite port_num 1,2  (no remap)
+//   ADIN port_idx 0,1  → composite port_idx 0,1  (no remap)
+// ---------------------------------------------------------------------------
+
+static void adin_power(bool on) {
+  if (s_ctx.composite_callbacks.power) {
+    s_ctx.composite_callbacks.power(on);
+  }
+}
+
+static void adin_link_change(uint8_t port_idx, bool is_up) {
+  if (s_ctx.composite_callbacks.link_change) {
+    s_ctx.composite_callbacks.link_change(port_idx, is_up); // forward as-is
+  }
+}
+
+static void adin_receive(uint8_t port_num, uint8_t *data, size_t length) {
+  if (s_ctx.composite_callbacks.receive) {
+    s_ctx.composite_callbacks.receive(port_num, data, length); // forward as-is
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper callbacks — UART sub-device
+//   UART port_num 1  → composite port_num 3
+//   UART port_idx 0  → composite port_idx 2
+// ---------------------------------------------------------------------------
+
+static void uart_link_change(uint8_t port_idx, bool is_up) {
+  (void)port_idx;
+  if (s_ctx.composite_callbacks.link_change) {
+    s_ctx.composite_callbacks.link_change(2U, is_up); // remap idx 0 → 2
+  }
+}
+
+static void uart_receive(uint8_t port_num, uint8_t *data, size_t length) {
+  (void)port_num;
+  if (s_ctx.composite_callbacks.receive) {
+    s_ctx.composite_callbacks.receive(3U, data, length); // remap port 1 → 3
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NetworkDeviceTrait implementations
+// ---------------------------------------------------------------------------
+
+static BmErr composite_send(void *self, uint8_t *data, size_t length, uint8_t port) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  BmErr err = BmOK;
+
+  if (port == 0U) {
+    // Flood: send on all ports.
+    err = ctx->adin.trait->send(ctx->adin.self, data, length, 0U);
+    BmErr uart_err = ctx->uart.trait->send(ctx->uart.self, data, length, 1U);
+    if (err == BmOK) {
+      err = uart_err;
+    }
+  } else if (port <= 2U) {
+    err = ctx->adin.trait->send(ctx->adin.self, data, length, port);
+  } else if (port == 3U) {
+    err = ctx->uart.trait->send(ctx->uart.self, data, length, 1U);
+  } else {
+    err = BmEINVAL;
+  }
+  return err;
+}
+
+static BmErr composite_enable(void *self) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  BmErr err = ctx->adin.trait->enable(ctx->adin.self);
+  if (err == BmOK) {
+    err = ctx->uart.trait->enable(ctx->uart.self);
+  }
+  return err;
+}
+
+static BmErr composite_disable(void *self) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  BmErr err = ctx->adin.trait->disable(ctx->adin.self);
+  BmErr uart_err = ctx->uart.trait->disable(ctx->uart.self);
+  return (err != BmOK) ? err : uart_err;
+}
+
+static BmErr composite_enable_port(void *self, uint8_t port_num) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  if (port_num <= 2U) {
+    return ctx->adin.trait->enable_port(ctx->adin.self, port_num);
+  } else if (port_num == 3U) {
+    return ctx->uart.trait->enable_port(ctx->uart.self, 1U);
+  }
+  return BmEINVAL;
+}
+
+static BmErr composite_disable_port(void *self, uint8_t port_num) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  if (port_num <= 2U) {
+    return ctx->adin.trait->disable_port(ctx->adin.self, port_num);
+  } else if (port_num == 3U) {
+    return ctx->uart.trait->disable_port(ctx->uart.self, 1U);
+  }
+  return BmEINVAL;
+}
+
+static BmErr composite_retry_negotiation(void *self, uint8_t port_index, bool *renegotiated) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  // Only ADIN supports renegotiation; UART has no negotiation.
+  if (port_index <= 1U && ctx->adin.trait->retry_negotiation) {
+    return ctx->adin.trait->retry_negotiation(ctx->adin.self, port_index, renegotiated);
+  }
+  if (renegotiated) {
+    *renegotiated = false;
+  }
+  return BmOK;
+}
+
+static uint8_t composite_num_ports(void) { return 3U; }
+
+static BmErr composite_port_stats(void *self, uint8_t port_index, void *stats) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  if (port_index <= 1U && ctx->adin.trait->port_stats) {
+    return ctx->adin.trait->port_stats(ctx->adin.self, port_index, stats);
+  }
+  // UART has no hardware stats.
+  return BmEINVAL;
+}
+
+static BmErr composite_handle_interrupt(void *self) {
+  CompositeDeviceCtx *ctx = static_cast<CompositeDeviceCtx *>(self);
+  // ADIN2111 uses SPI interrupts; UART has its own ISR.
+  if (ctx->adin.trait->handle_interrupt) {
+    return ctx->adin.trait->handle_interrupt(ctx->adin.self);
+  }
+  return BmOK;
+}
+
+// ---------------------------------------------------------------------------
+// Public factory function
+// ---------------------------------------------------------------------------
+
+NetworkDevice composite_network_device(NetworkDevice adin, NetworkDevice uart) {
+  s_ctx.adin = adin;
+  s_ctx.uart = uart;
+  memset(&s_ctx.composite_callbacks, 0, sizeof(s_ctx.composite_callbacks));
+
+  // Install wrapper callbacks on the ADIN sub-device.
+  s_ctx.adin.callbacks->power = adin_power;
+  s_ctx.adin.callbacks->link_change = adin_link_change;
+  s_ctx.adin.callbacks->receive = adin_receive;
+
+  // Install wrapper callbacks on the UART sub-device (no power callback needed).
+  s_ctx.uart.callbacks->link_change = uart_link_change;
+  s_ctx.uart.callbacks->receive = uart_receive;
+
+  static NetworkDeviceTrait const trait = {
+      .send = composite_send,
+      .enable = composite_enable,
+      .disable = composite_disable,
+      .enable_port = composite_enable_port,
+      .disable_port = composite_disable_port,
+      .retry_negotiation = composite_retry_negotiation,
+      .num_ports = composite_num_ports,
+      .port_stats = composite_port_stats,
+      .handle_interrupt = composite_handle_interrupt,
+  };
+
+  return NetworkDevice{
+      .self = &s_ctx,
+      .trait = &trait,
+      .callbacks = &s_ctx.composite_callbacks,
+  };
+}

--- a/src/apps/native_serial_bridge/composite_device.h
+++ b/src/apps/native_serial_bridge/composite_device.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/// @file composite_device.h
+/// @brief Composite NetworkDevice that multiplexes ADIN2111 (ports 1-2) and
+///        UART (port 3) into a single 3-port Bristlemouth network device.
+///
+/// Port mapping:
+///   Global port 1 → ADIN port 1
+///   Global port 2 → ADIN port 2
+///   Global port 3 → UART port 1
+///
+/// Usage:
+///   NetworkDevice adin = adin2111_network_device();
+///   NetworkDevice uart = uart_network_device(task_priority);
+///   NetworkDevice dev  = composite_network_device(adin, uart);
+///   bm_l2_init(dev);   // bm_l2_init fills in dev.callbacks
+
+#include "network_device.h"
+
+/// Create a 3-port composite NetworkDevice from an ADIN and a UART device.
+///
+/// Installs wrapper callbacks on @p adin and @p uart that remap port numbers
+/// to the composite namespace before forwarding to the composite's own
+/// callbacks (which bm_l2_init later fills in).
+///
+/// @param adin  A NetworkDevice returned by adin2111_network_device().
+/// @param uart  A NetworkDevice returned by uart_network_device().
+/// @return A 3-port NetworkDevice suitable for passing to bm_l2_init.
+NetworkDevice composite_network_device(NetworkDevice adin, NetworkDevice uart);

--- a/src/apps/native_serial_bridge/crc32c.c
+++ b/src/apps/native_serial_bridge/crc32c.c
@@ -1,0 +1,25 @@
+// TODO: This file is duplicated from bm_sbc/src/transports/uart_l2/crc32c.c.
+// Consolidate into a shared library (e.g. bm_common) when both repos stabilize.
+
+#include "crc32c.h"
+
+/// Nibble-based CRC-32C lookup table (bit-reflected polynomial 0x82F63B78).
+/// Same 4-bit-at-a-time approach used by bm_core's crc32_ieee, but with the
+/// Castagnoli polynomial for better burst-error detection on serial links.
+static const uint32_t table[16] = {
+    0x00000000U, 0x105EC76FU, 0x20BD8EDEU, 0x30E349B1U, 0x417B1DBCU, 0x5125DAD3U,
+    0x61C69362U, 0x7198540DU, 0x82F63B78U, 0x92A8FC17U, 0xA24BB5A6U, 0xB21572C9U,
+    0xC38D26C4U, 0xD3D3E1ABU, 0xE330A81AU, 0xF36E6F75U,
+};
+
+uint32_t crc32c_update(uint32_t crc, const uint8_t *data, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    crc = (crc >> 4) ^ table[(crc ^ data[i]) & 0x0F];
+    crc = (crc >> 4) ^ table[(crc ^ ((uint32_t)data[i] >> 4)) & 0x0F];
+  }
+  return crc;
+}
+
+uint32_t crc32c(const uint8_t *data, size_t len) {
+  return crc32c_finalize(crc32c_update(0xFFFFFFFF, data, len));
+}

--- a/src/apps/native_serial_bridge/crc32c.h
+++ b/src/apps/native_serial_bridge/crc32c.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// TODO: This file is duplicated from bm_sbc/src/transports/uart_l2/crc32c.h.
+// Consolidate into a shared library (e.g. bm_common) when both repos stabilize.
+
+/// @file crc32c.h
+/// @brief CRC-32C (Castagnoli) for UART frame integrity.
+///
+/// Uses polynomial 0x1EDC6F41 (bit-reflected: 0x82F63B78).
+/// Provides better burst-error detection than CRC-32 IEEE for the
+/// types of bit errors common on embedded serial links.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Compute CRC-32C over @p len bytes starting at @p data.
+/// @return The CRC-32C value.
+uint32_t crc32c(const uint8_t *data, size_t len);
+
+/// Incrementally update a running CRC-32C with additional data.
+/// @param crc  Previous CRC value (pass 0xFFFFFFFF for the first call).
+/// @param data Pointer to new data.
+/// @param len  Length of new data.
+/// @return Updated CRC (call crc32c_finalize() after all data is fed).
+uint32_t crc32c_update(uint32_t crc, const uint8_t *data, size_t len);
+
+/// Finalize a running CRC-32C (XOR with 0xFFFFFFFF).
+static inline uint32_t crc32c_finalize(uint32_t crc) { return crc ^ 0xFFFFFFFF; }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/apps/native_serial_bridge/frame_codec.c
+++ b/src/apps/native_serial_bridge/frame_codec.c
@@ -60,7 +60,7 @@ size_t frame_decode(uint8_t *l2_frame, size_t l2_len, const uint8_t *wire, size_
   // COBS-decode into a temporary buffer.
   // Firmware cobs-c API returns a cobs_decode_result struct, unlike bm_sbc's
   // minimal COBS which returns a bare size_t.
-  uint8_t decoded[2 + FRAME_CODEC_MAX_L2_SIZE + 4];
+  uint8_t decoded[FRAME_CODEC_MAX_L2_SIZE + FRAME_CODEC_OVERHEAD];
   cobs_decode_result dec = cobs_decode(decoded, sizeof(decoded), wire, wire_len);
   if (dec.status != COBS_DECODE_OK) {
     return 0;
@@ -78,7 +78,7 @@ size_t frame_decode(uint8_t *l2_frame, size_t l2_len, const uint8_t *wire, size_
   if (frame_len == 0 || frame_len > FRAME_CODEC_MAX_L2_SIZE) {
     return 0;
   }
-  if (dec.out_len != 2 + (size_t)frame_len + 4) {
+  if (dec.out_len != (size_t)frame_len + FRAME_CODEC_OVERHEAD) {
     return 0;
   }
 

--- a/src/apps/native_serial_bridge/frame_codec.c
+++ b/src/apps/native_serial_bridge/frame_codec.c
@@ -1,0 +1,102 @@
+// TODO: This file is adapted from bm_sbc/src/transports/uart_l2/frame_codec.c.
+// Differences from bm_sbc: the firmware's third_party/cobs-c library returns
+// cobs_encode_result / cobs_decode_result structs (with .status and .out_len
+// fields) instead of a bare size_t. All cobs_encode / cobs_decode call sites
+// are updated accordingly.
+// Consolidate into a shared library (e.g. bm_common) when both repos stabilize.
+
+#include "frame_codec.h"
+#include "cobs.h"
+#include "crc32c.h"
+#include <string.h>
+
+size_t frame_encode(uint8_t *wire, size_t wire_len, const uint8_t *l2_frame, size_t l2_len) {
+  if (!wire || !l2_frame || l2_len == 0 || l2_len > FRAME_CODEC_MAX_L2_SIZE) {
+    return 0;
+  }
+
+  // Build the pre-COBS payload: [len_hi, len_lo, l2_frame..., crc32c (4 bytes)]
+  const size_t payload_len = 2 + l2_len + 4;
+  uint8_t payload[2 + FRAME_CODEC_MAX_L2_SIZE + 4];
+
+  // 2-byte big-endian length of L2 frame.
+  payload[0] = (uint8_t)(l2_len >> 8);
+  payload[1] = (uint8_t)(l2_len & 0xFF);
+
+  // L2 frame data.
+  memcpy(&payload[2], l2_frame, l2_len);
+
+  // CRC-32C over length + L2 frame bytes.
+  const size_t crc_input_len = 2 + l2_len;
+  uint32_t crc = crc32c(payload, crc_input_len);
+  payload[crc_input_len + 0] = (uint8_t)(crc >> 24);
+  payload[crc_input_len + 1] = (uint8_t)(crc >> 16);
+  payload[crc_input_len + 2] = (uint8_t)(crc >> 8);
+  payload[crc_input_len + 3] = (uint8_t)(crc & 0xFF);
+
+  // Need room for COBS-encoded data + 1 byte for the 0x00 delimiter.
+  if (wire_len < COBS_ENCODE_DST_BUF_LEN_MAX(payload_len) + 1) {
+    return 0;
+  }
+
+  // COBS-encode the payload.
+  // Firmware cobs-c API returns a cobs_encode_result struct, unlike bm_sbc's
+  // minimal COBS which returns a bare size_t.
+  cobs_encode_result enc = cobs_encode(wire, wire_len - 1, payload, payload_len);
+  if (enc.status != COBS_ENCODE_OK) {
+    return 0;
+  }
+
+  // Append 0x00 delimiter.
+  wire[enc.out_len] = 0x00;
+  return enc.out_len + 1;
+}
+
+size_t frame_decode(uint8_t *l2_frame, size_t l2_len, const uint8_t *wire, size_t wire_len) {
+  if (!l2_frame || !wire || wire_len == 0) {
+    return 0;
+  }
+
+  // COBS-decode into a temporary buffer.
+  // Firmware cobs-c API returns a cobs_decode_result struct, unlike bm_sbc's
+  // minimal COBS which returns a bare size_t.
+  uint8_t decoded[2 + FRAME_CODEC_MAX_L2_SIZE + 4];
+  cobs_decode_result dec = cobs_decode(decoded, sizeof(decoded), wire, wire_len);
+  if (dec.status != COBS_DECODE_OK) {
+    return 0;
+  }
+
+  if (dec.out_len < FRAME_CODEC_OVERHEAD) {
+    // Too short to contain the 2-byte length field and 4-byte CRC.
+    return 0;
+  }
+
+  // Extract the 2-byte big-endian length field.
+  uint16_t frame_len = ((uint16_t)decoded[0] << 8) | decoded[1];
+
+  // Validate the length.
+  if (frame_len == 0 || frame_len > FRAME_CODEC_MAX_L2_SIZE) {
+    return 0;
+  }
+  if (dec.out_len != 2 + (size_t)frame_len + 4) {
+    return 0;
+  }
+
+  // Verify CRC-32C over length + L2 frame bytes.
+  const size_t crc_input_len = 2 + frame_len;
+  uint32_t crc_computed = crc32c(decoded, crc_input_len);
+  uint32_t crc_received = ((uint32_t)decoded[crc_input_len + 0] << 24) |
+                          ((uint32_t)decoded[crc_input_len + 1] << 16) |
+                          ((uint32_t)decoded[crc_input_len + 2] << 8) |
+                          ((uint32_t)decoded[crc_input_len + 3]);
+  if (crc_computed != crc_received) {
+    return 0;
+  }
+
+  // Copy L2 frame to output buffer.
+  if (frame_len > l2_len) {
+    return 0;
+  }
+  memcpy(l2_frame, &decoded[2], frame_len);
+  return frame_len;
+}

--- a/src/apps/native_serial_bridge/frame_codec.h
+++ b/src/apps/native_serial_bridge/frame_codec.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// TODO: This file is adapted from bm_sbc/src/transports/uart_l2/frame_codec.h.
+// Differences from bm_sbc: uses the firmware's third_party cobs-c macros
+// (COBS_ENCODE_DST_BUF_LEN_MAX) instead of bm_sbc's COBS_ENCODE_MAX.
+// Consolidate into a shared library (e.g. bm_common) when both repos stabilize.
+
+/// @file frame_codec.h
+/// @brief UART L2 frame codec — encodes/decodes L2 Ethernet frames for
+///        transport over a serial link.
+///
+/// Wire format:
+///   [COBS-encoded payload] [0x00 delimiter]
+///
+/// Payload (before COBS encoding):
+///   [len_hi] [len_lo] [L2 frame bytes...] [crc32c (4 bytes, big-endian)]
+///
+/// - Length is a 2-byte big-endian value equal to the L2 frame size.
+/// - CRC-32C (Castagnoli) is computed over the length + L2 frame bytes.
+/// - COBS encoding ensures no 0x00 bytes appear in the encoded payload,
+///   so 0x00 can serve as an unambiguous frame delimiter.
+
+#include "cobs.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Overhead added to each L2 frame: 2 bytes length + 4 bytes CRC-32C.
+#define FRAME_CODEC_OVERHEAD 6
+
+/// Maximum L2 frame size supported (standard Ethernet MTU + header).
+#define FRAME_CODEC_MAX_L2_SIZE 1522
+
+/// Maximum wire size: COBS overhead over full payload + 1 byte 0x00 delimiter.
+/// Uses COBS_ENCODE_DST_BUF_LEN_MAX from the firmware's third_party/cobs-c/cobs.h.
+#define FRAME_CODEC_MAX_WIRE_SIZE                                                              \
+  (COBS_ENCODE_DST_BUF_LEN_MAX(FRAME_CODEC_MAX_L2_SIZE + FRAME_CODEC_OVERHEAD) + 1)
+
+/// Encode an L2 frame into wire format (COBS-encoded, 0x00-terminated).
+///
+/// @param wire      Output buffer for the encoded frame.
+/// @param wire_len  Size of the output buffer (must be >= FRAME_CODEC_MAX_WIRE_SIZE).
+/// @param l2_frame  The raw L2 Ethernet frame to encode.
+/// @param l2_len    Length of the L2 frame in bytes.
+/// @return Total bytes written to @p wire (including the 0x00 delimiter), or 0 on error.
+size_t frame_encode(uint8_t *wire, size_t wire_len, const uint8_t *l2_frame, size_t l2_len);
+
+/// Decode a wire frame back into the original L2 frame.
+///
+/// @param l2_frame  Output buffer for the decoded L2 frame.
+/// @param l2_len    Size of the output buffer.
+/// @param wire      COBS-encoded data WITHOUT the trailing 0x00 delimiter.
+/// @param wire_len  Length of the wire data.
+/// @return Length of the decoded L2 frame, or 0 on error (CRC mismatch,
+///         length mismatch, or COBS decode failure).
+size_t frame_decode(uint8_t *l2_frame, size_t l2_len, const uint8_t *wire, size_t wire_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/apps/native_serial_bridge/memfault_platform_config.h
+++ b/src/apps/native_serial_bridge/memfault_platform_config.h
@@ -1,0 +1,19 @@
+//
+// Important note! For some reason, changes to this file don't trigger a rebuild
+// of the memfault libraries! Until that's fixed, run make clean then make
+// after changing this file
+//
+
+#define MEMFAULT_PLATFORM_MAX_TRACKED_TASKS 32
+
+#define MEMFAULT_EXC_HANDLER_MEMORY_MANAGEMENT MemManage_Handler
+
+#define MEMFAULT_ASSERT_HALT_IF_DEBUGGING_ENABLED 1
+
+#define MEMFAULT_EVENT_STORAGE_READ_BATCHING_ENABLED 1
+#define MEMFAULT_EVENT_STORAGE_READ_BATCHING_MAX_BYTES 320
+
+// Send memfault metric updates every six hours
+#define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS (6 * 60 * 60)
+
+#define MEMFAULT_WATCHDOG_SW_TIMEOUT_SECS 30

--- a/src/apps/native_serial_bridge/sensors/sensors.cpp
+++ b/src/apps/native_serial_bridge/sensors/sensors.cpp
@@ -1,0 +1,38 @@
+#include "sensors.h"
+#include "abstract_htu_sensor.h"
+#include "abstract_pressure_sensor.h"
+#include "bsp.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+// Sensor driver includes
+#include "bme280driver.h"
+#include "bristlefin.h"
+#include "htu21d.h"
+#include "ina232.h"
+#include "ms5803.h"
+#include "tca9546a.h"
+
+void powerSamplerInit(INA::INA232 **sensors);
+
+static TCA::TCA9546A bristlefinTCA(&i2c1, TCA9546A_ADDR, &I2C_MUX_RESET);
+static Bme280 debugPHTU(&i2c1, Bme280::I2C_ADDR);
+
+static MS5803 debugPressure(&i2c1, MS5803_ADDR);
+static HTU21D debugHTU(&i2c1);
+static INA::INA232 debugIna1(&i2c1, I2C_INA_MAIN_ADDR);
+static INA::INA232 debugIna2(&i2c1, I2C_INA_PODL_ADDR);
+static INA::INA232 *debugIna[NUM_INA232_DEV] = {
+    &debugIna1,
+    &debugIna2,
+};
+
+Bristlefin bristlefin(debugPressure, debugHTU, debugPHTU, bristlefinTCA, debugIna2);
+
+void sensorsInit() {
+  bristlefin.setGpioDefault();
+  if (!bristlefin.sensorsInit()) {
+    printf("Failed to init bristlefin\n");
+  }
+  powerSamplerInit(debugIna);
+}

--- a/src/apps/native_serial_bridge/sensors/sensors.h
+++ b/src/apps/native_serial_bridge/sensors/sensors.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "bristlefin.h"
+
+// Required by sensor_sampler library headers even when sensors are unused.
+#define SENSORS_NUM_RETRIES 3
+#define DEFAULT_SENSORS_POLL_MS 0
+#define DEFAULT_SENSORS_CHECK_S 0
+
+/// Global Bristlefin instance — controls LEDs and GPIO expander.
+extern Bristlefin bristlefin;
+
+void sensorsInit(void);

--- a/src/apps/native_serial_bridge/task_priorities.h
+++ b/src/apps/native_serial_bridge/task_priorities.h
@@ -1,0 +1,32 @@
+//
+// Define all task priorities here for ease of access/comparison
+// Trying to keep them sorted by priority here
+//
+
+#define PCA9535_IRQ_TASK_PRIORITY 20
+
+#define DEFAULT_BOOT_TASK_PRIORITY 16
+
+#define ADIN_GPIO_TASK_PRIORITY 15
+#define BM_DFU_EVENT_TASK_PRIORITY 11
+#define BM_L2_TX_TASK_PRIORITY 7
+
+// UART RX frame-decoder task runs at the same priority as GPIO ISR tasks
+// to ensure responsive frame processing from the SBC.
+#define GPIO_ISR_TASK_PRIORITY 6
+#define UART_RX_TASK_PRIORITY 6
+
+#define STRESS_TASK_PRIORITY 5
+#define TIMER_HANDLER_TASK_PRIORITY 5
+
+#define MIDDLEWARE_NET_TASK_PRIORITY 4
+#define BRIDGE_POWER_TASK_PRIORITY 4
+
+#define SENSOR_SAMPLER_TASK_PRIORITY 3
+#define USB_TASK_PRIORITY 3
+
+#define SERIAL_TX_TASK_PRIORITY 2
+#define CONSOLE_RX_TASK_PRIORITY 2
+
+#define CLI_TASK_PRIORITY 1
+#define DEFAULT_TASK_PRIORITY 1

--- a/src/apps/native_serial_bridge/uart_network_device.cpp
+++ b/src/apps/native_serial_bridge/uart_network_device.cpp
@@ -163,6 +163,7 @@ NetworkDevice uart_network_device(uint8_t task_priority) {
   // Configure and init the PLUART driver.
   PLUART::init(task_priority);
   PLUART::setBaud(UART_SBC_BAUD);
+  PLUART::setUseLineBuffer(false);
   PLUART::setUseByteStreamBuffer(true);
 
   static NetworkDeviceTrait const trait = {

--- a/src/apps/native_serial_bridge/uart_network_device.cpp
+++ b/src/apps/native_serial_bridge/uart_network_device.cpp
@@ -1,0 +1,185 @@
+#include "uart_network_device.h"
+
+#include "FreeRTOS.h"
+#include "frame_codec.h"
+#include "payload_uart.h"
+#include "task.h"
+
+#include <stdio.h>
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// Internal context
+// ---------------------------------------------------------------------------
+
+/// FreeRTOS stack depth for the frame RX task (words = 4 B each on ARM32).
+/// Must accommodate:
+///   wire accumulation buffer (~1536 B) + l2 output buffer (1522 B) +
+///   frame_decode() stack-local decoded buffer (1528 B) + call overhead.
+static constexpr uint32_t UART_RX_TASK_STACK_DEPTH = 2048U;
+
+/// Default UART baud rate for the SBC link (8N1, no flow control).
+static constexpr uint32_t UART_SBC_BAUD = 115200U;
+
+struct UartDeviceCtx {
+  NetworkDeviceCallbacks callbacks; ///< Filled in by bm_l2_init after creation.
+  TaskHandle_t rx_task_handle;
+  uint8_t rx_task_priority;
+};
+
+static UartDeviceCtx s_ctx;
+
+// ---------------------------------------------------------------------------
+// RX task — COBS byte accumulation → frame_decode → callbacks->receive
+// ---------------------------------------------------------------------------
+
+static void uart_rx_task(void *arg) {
+  UartDeviceCtx *ctx = static_cast<UartDeviceCtx *>(arg);
+
+  // Wire-format accumulation buffer (COBS bytes, no delimiter).
+  static uint8_t wire_buf[FRAME_CODEC_MAX_WIRE_SIZE];
+  size_t wire_len = 0;
+
+  // Decoded L2 output buffer.
+  static uint8_t l2_buf[FRAME_CODEC_MAX_L2_SIZE];
+
+  while (true) {
+    if (!PLUART::byteAvailable()) {
+      // Yield to other tasks; 1 ms granularity is fine for serial data rates.
+      vTaskDelay(pdMS_TO_TICKS(1));
+      continue;
+    }
+
+    uint8_t b = PLUART::readByte();
+
+    if (b == 0x00) {
+      // Frame delimiter — attempt to decode whatever we've accumulated.
+      if (wire_len > 0) {
+        size_t l2_len = frame_decode(l2_buf, sizeof(l2_buf), wire_buf, wire_len);
+        if (l2_len > 0) {
+          if (ctx->callbacks.receive) {
+            ctx->callbacks.receive(1U, l2_buf, l2_len);
+          }
+        } else {
+          printf("uart_rx: frame_decode failed (wire_len=%zu)\n", wire_len);
+        }
+      }
+      wire_len = 0;
+    } else {
+      // Accumulate into the wire buffer.
+      if (wire_len < sizeof(wire_buf)) {
+        wire_buf[wire_len++] = b;
+      } else {
+        // Buffer overflow — discard and wait for next delimiter.
+        printf("uart_rx: wire buffer overflow, discarding frame\n");
+        wire_len = 0;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NetworkDeviceTrait implementations
+// ---------------------------------------------------------------------------
+
+static BmErr uart_send(void *self, uint8_t *data, size_t length, uint8_t port) {
+  (void)self;
+  (void)port; // Single port — ignore port selector.
+
+  static uint8_t wire_buf[FRAME_CODEC_MAX_WIRE_SIZE];
+  size_t wire_len = frame_encode(wire_buf, sizeof(wire_buf), data, length);
+  if (wire_len == 0) {
+    return BmEINVAL;
+  }
+  PLUART::write(wire_buf, wire_len);
+  return BmOK;
+}
+
+static BmErr uart_enable(void *self) {
+  UartDeviceCtx *ctx = static_cast<UartDeviceCtx *>(self);
+
+  PLUART::enable();
+
+  // Report link-up on port index 0 (our single port).
+  if (ctx->callbacks.link_change) {
+    ctx->callbacks.link_change(0U, true);
+  }
+
+  // Start the frame RX decoder task.
+  BaseType_t rc = xTaskCreate(uart_rx_task, "uart_rx", UART_RX_TASK_STACK_DEPTH, ctx,
+                              ctx->rx_task_priority, &ctx->rx_task_handle);
+  if (rc != pdPASS) {
+    printf("uart_enable: failed to create uart_rx task\n");
+    return BmENOMEM;
+  }
+
+  return BmOK;
+}
+
+static BmErr uart_disable(void *self) {
+  UartDeviceCtx *ctx = static_cast<UartDeviceCtx *>(self);
+
+  PLUART::disable();
+
+  if (ctx->rx_task_handle) {
+    vTaskDelete(ctx->rx_task_handle);
+    ctx->rx_task_handle = nullptr;
+  }
+
+  if (ctx->callbacks.link_change) {
+    ctx->callbacks.link_change(0U, false);
+  }
+
+  return BmOK;
+}
+
+static BmErr uart_enable_port(void *self, uint8_t port_num) {
+  (void)self;
+  (void)port_num;
+  return BmOK; // Always enabled.
+}
+
+static BmErr uart_disable_port(void *self, uint8_t port_num) {
+  (void)self;
+  (void)port_num;
+  return BmOK; // No-op.
+}
+
+static uint8_t uart_num_ports(void) { return 1U; }
+
+static BmErr uart_handle_interrupt(void *self) {
+  (void)self;
+  return BmOK; // UART uses its own ISR — nothing to do here.
+}
+
+// ---------------------------------------------------------------------------
+// Public factory function
+// ---------------------------------------------------------------------------
+
+NetworkDevice uart_network_device(uint8_t task_priority) {
+  memset(&s_ctx, 0, sizeof(s_ctx));
+  s_ctx.rx_task_priority = task_priority;
+
+  // Configure and init the PLUART driver.
+  PLUART::init(task_priority);
+  PLUART::setBaud(UART_SBC_BAUD);
+  PLUART::setUseByteStreamBuffer(true);
+
+  static NetworkDeviceTrait const trait = {
+      .send = uart_send,
+      .enable = uart_enable,
+      .disable = uart_disable,
+      .enable_port = uart_enable_port,
+      .disable_port = uart_disable_port,
+      .retry_negotiation = nullptr,
+      .num_ports = uart_num_ports,
+      .port_stats = nullptr,
+      .handle_interrupt = uart_handle_interrupt,
+  };
+
+  return NetworkDevice{
+      .self = &s_ctx,
+      .trait = &trait,
+      .callbacks = &s_ctx.callbacks,
+  };
+}

--- a/src/apps/native_serial_bridge/uart_network_device.h
+++ b/src/apps/native_serial_bridge/uart_network_device.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/// @file uart_network_device.h
+/// @brief UART (PLUART) implementation of NetworkDeviceTrait.
+///
+/// Wraps the firmware's PLUART driver as a single-port Bristlemouth network
+/// device. Port 1 maps to the PLUART serial link.
+///
+/// Frames are COBS+CRC-32C encoded/decoded by frame_codec.h.
+///
+/// Usage:
+///   NetworkDevice uart_dev = uart_network_device(task_priority);
+///   // Pass uart_dev to your composite device or bm_l2_init.
+
+#include "network_device.h"
+#include <stdint.h>
+
+/// Create a UART (PLUART) NetworkDevice.
+///
+/// Calls PLUART::init(), sets baud to 115200, and enables byte-stream mode.
+/// Does NOT enable the link — the link comes up when the enable() trait is
+/// called (typically triggered by bm_l2_init).
+///
+/// @param task_priority  FreeRTOS priority for PLUART's internal HAL task.
+///                       The frame RX decoder task runs at this priority too.
+/// @return A NetworkDevice wrapping PLUART as a single-port (port 1) device.
+NetworkDevice uart_network_device(uint8_t task_priority);


### PR DESCRIPTION
## What changed?

Added `native_serial_bridge` dev kit app, which treats the PLUART as a 3rd Bristlemouth port. If you run a Raspberry Pi on the other end of that UART with an app built from the `bm_sbc` repo, then this new dev kit app bridges the Bristlemouth traffice between the hardware motes with ADINs and processes running on the pi.

## How does it make Bristlemouth better?



## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
