### PR TITLE
Allow For Increased Baudrate On LPUART

### DIFF
--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -328,16 +328,13 @@ void configTxPinAlternate(void) {
 void enable(void) {
   USART_TypeDef *dev = static_cast<USART_TypeDef *>(uart_handle.device);
 
-  // Clear data in read register
-  (void)LL_LPUART_ReceiveData8(dev);
-
   LL_LPUART_Enable(dev);
+
+  serialEnable(&uart_handle);
 
   // Clear any pending NVIC bit from the disabled period, then re-enable
   NVIC_ClearPendingIRQ(LPUART1_IRQn);
   NVIC_EnableIRQ(LPUART1_IRQn);
-
-  serialEnable(&uart_handle);
 }
 
 void disable(void) {

--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -1,4 +1,5 @@
 #include "payload_uart.h"
+#include "bm_usart.h"
 #include "spotter.h"
 #include "stm32_io.h"
 #include "stm32_rtc.h"
@@ -260,9 +261,26 @@ void write(uint8_t *buffer, size_t len) {
 }
 
 void setBaud(uint32_t new_baud_rate) {
-  LL_LPUART_SetBaudRate(static_cast<USART_TypeDef *>(uart_handle.device),
-                        LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE),
-                        LL_LPUART_PRESCALER_DIV8, new_baud_rate);
+  USART_TypeDef *dev = static_cast<USART_TypeDef *>(uart_handle.device);
+  static constexpr uint32_t baud_rate_div8_max_speed = 115200;
+  uint32_t div = LL_LPUART_PRESCALER_DIV8;
+
+  if (new_baud_rate > baud_rate_div8_max_speed) {
+    div = LL_LPUART_PRESCALER_DIV1;
+  }
+
+  bool was_enabled = uart_handle.enabled;
+
+  disable();
+
+  // Prescaler and BRR must both be written while peripheral is disabled (UE=0)
+  LL_LPUART_SetPrescaler(dev, div);
+  LL_LPUART_SetBaudRate(dev, LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE), div,
+                        new_baud_rate);
+
+  if (was_enabled) {
+    enable();
+  }
 }
 
 void setEvenParity(void) {
@@ -307,9 +325,31 @@ void configTxPinAlternate(void) {
   }
 }
 
-void enable(void) { serialEnable(&uart_handle); }
+void enable(void) {
+  USART_TypeDef *dev = static_cast<USART_TypeDef *>(uart_handle.device);
 
-void disable(void) { serialDisable(&uart_handle); }
+  // Clear data in read register
+  (void)LL_LPUART_ReceiveData8(dev);
+
+  LL_LPUART_Enable(dev);
+
+  // Clear any pending NVIC bit from the disabled period, then re-enable
+  NVIC_ClearPendingIRQ(LPUART1_IRQn);
+  NVIC_EnableIRQ(LPUART1_IRQn);
+
+  serialEnable(&uart_handle);
+}
+
+void disable(void) {
+  USART_TypeDef *dev = static_cast<USART_TypeDef *>(uart_handle.device);
+
+  // Disable LPUART1 IRQ at NVIC level to prevent any ISR activity during reconfiguration
+  NVIC_DisableIRQ(LPUART1_IRQn);
+
+  LL_LPUART_Disable(dev);
+
+  serialDisable(&uart_handle);
+}
 
 // variable definitions
 static uint8_t lpUart1Buffer[LPUART1_LINE_BUFF_LEN];


### PR DESCRIPTION
## What changed?
If the desired baud rate is above 115200, set the LPUART clock prescaler to 1 before setting the baud rate register.
Disables and potentially re-enabled the peripheral before setting the prescaler and baud rate registers.

## How does it make Bristlemouth better?
This updates the LPUART peripheral clock prescaler, which is necessary for increasing the baudrate above 666kBd.

The math for calculating the baud is (ref: 67.4.8 in [rm0456](https://www.st.com/resource/en/reference_manual/rm0456-stm32u5-series-armbased-32bit-mcus-stmicroelectronics.pdf)):

$$
\text{baud} = \frac{256f_{clk}}{BRR}
$$

Where $BRR$ is the baud rate register and $f_{clk}$ is the prescaled peripheral clock.
Before this change the clock prescaler is defaulted to $8$.
The clock used for this peripheral is the HSI (High Speed Internal) oscillator, which operates at 16MHz.
With a prescaler of 1, the baud rate can max out at 5.333MBd.

In order to write to the prescale and baud rate register, the UE bit (responsible for enabling the peripheral) has to be set to 0. This is explained in sections 67.6.7 of rm0456 (note auto baudrate detection mode is not supported by LPUART and is a typo):

<img width="775" height="94" alt="image" src="https://github.com/user-attachments/assets/aac94f36-02d7-4f2d-91ad-e24538e9a748" />

And section 67.6.13:

<img width="757" height="69" alt="image" src="https://github.com/user-attachments/assets/615493b4-738b-45c5-9261-245e97449fb4" />

## Where should reviewers focus?

Ask questions if the flow does not make sense! A few key items to note:

1. When the peripheral is disabled, the interrupts should also be disabled, a fault will occur if the peripheral is disabled and an interrupt occurs after disabling the peripheral (this was examined when attempting to set the baud rate during runtime after two devices have started communicating to one another).
2. Prior to re-enabling the peripheral, the data is flushed to avoid handling malformed data.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
