### PR TITLE
Prevent topology timer from never starting again

### DIFF
--- a/src/apps/bridge/topology_sampler.cpp
+++ b/src/apps/bridge/topology_sampler.cpp
@@ -63,7 +63,6 @@ typedef struct node_list {
 
 static BridgePowerController *_bridge_power_controller;
 static TimerHandle_t topology_timer;
-static bool _sampling_enabled;
 static bool _send_on_boot;
 static node_list_s _node_list;
 static QueueHandle_t _sys_info_queue;
@@ -580,7 +579,6 @@ void topology_sampler_init(BridgePowerController *power_controller) {
   // TODO - add unit tests with mocking timer callbacks
   configASSERT(power_controller);
   _bridge_power_controller = power_controller;
-  _sampling_enabled = false;
   _send_on_boot = true;
   int tmr_id = 2;
   _node_list.node_list_mutex = xSemaphoreCreateMutex();
@@ -625,7 +623,8 @@ void topology_sampler_task(void *parameters) {
       check_topology_report(1000);
       // Check if we are already sampling, if not, wait (using blocking waitForSignal) for power to turn on
       // if we are sampling, wait for power to turn off
-      if (!_sampling_enabled && _bridge_power_controller->waitForSignal(true, 0)) {
+      bool is_timer_active = xTimerIsTimerActive(topology_timer);
+      if (!is_timer_active && _bridge_power_controller->waitForSignal(true, 0)) {
         // lets wait 5 seconds for the devices on the bus to power up
         vTaskDelay(pdMS_TO_TICKS(BUS_POWER_ON_DELAY));
         bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
@@ -634,10 +633,7 @@ void topology_sampler_task(void *parameters) {
         // start the timer! here while the bus is powered we will sample topology every minute
         configASSERT(xTimerStart(topology_timer, 10));
 
-        _sampling_enabled = true;
-
-      } else if (_sampling_enabled && _bridge_power_controller->waitForSignal(false, 0)) {
-        _sampling_enabled = false;
+      } else if (is_timer_active && _bridge_power_controller->waitForSignal(false, 0)) {
         configASSERT(xTimerStop(topology_timer, 10));
         bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                        "Pausing sampling network topology until next duration...\n");


### PR DESCRIPTION
## What changed?
Remove shadow tracking variable causing the `topology_timer` to get stuck off.


## How does it make Bristlemouth better?
Post DFU update of a node on a Bristlemouth network, @towynlin saw that the topology reported to the Bridge applications NCP (Network Coprocessor) device (which is Sofar Ocean's Spotter) did not include the updated node or any nodes downstream from that node.
To note this occurred on a system where the bridge's `sampleIntervalMs` matched the `sampleDurationMs` (meaning power was on indefinitely to the network).
His system also had the `bridgePowerControllerEnabled` configuration deleted from the Bridge (when this is the case the 
`_bridge_power_controller->isPowerControlEnabled()` defaults to `true`) as it is planned to be deprecated in an up coming release (v0.14.0(?)).

In order for the bug to occur the following happens:

1. A DFU occurs, the bridge will disable the power controller (this ALSO turns the bus on indefinitely), and in the `topology_sampler_task`, the logic will enter the else statement at 641 (or 645 if looking at the previous commit):
  
  ```c
      if (_bridge_power_controller->isPowerControlEnabled()) {
        ...
      } else {
        // still need to wait after init period for the bus to be turned back on
        _bridge_power_controller->waitForSignal(true, portMAX_DELAY);
        // lets wait 5 seconds to make sure the devices on the bus are powered on
        vTaskDelay(pdMS_TO_TICKS(BUS_POWER_ON_DELAY));
        topology_sample();
        // start the timer! here while the bus is powered we will sample topology every minute
        configASSERT(xTimerStart(topology_timer, 10));
        // If DFU disabled the power controller before sampling began, we may have gotten here
        // incorrectly, so lets just check to make sure the power controller is disabled. If it
        // is re-enabled, then we will just loop back to the beginning of the for loop
        while (!_bridge_power_controller->isPowerControlEnabled()) {
          check_topology_report(1000);
        }
        // We should stop the timer if the power controller is re-enabled
        configASSERT(xTimerStop(topology_timer, 10));
      }
  ```

2. Once DFU completes, the power controller is re-enabled and the task enters the if branch — at which point topology_timer is stopped:

  ```c
    if (_bridge_power_controller->isPowerControlEnabled()) {
        check_topology_report(1000);
        // Check if we are already sampling, if not, wait (using blocking waitForSignal) for power to turn on
        // if we are sampling, wait for power to turn off
        if (!_sampling_enabled && _bridge_power_controller->waitForSignal(true, 0)) {
          // lets wait 5 seconds for the devices on the bus to power up
          vTaskDelay(pdMS_TO_TICKS(BUS_POWER_ON_DELAY));
          bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                         "Beginning sampling network topology...\n");
          topology_sample();
          // start the timer! here while the bus is powered we will sample topology every minute
          configASSERT(xTimerStart(topology_timer, 10));
  
          _sampling_enabled = true;
  
        } else if (_sampling_enabled && _bridge_power_controller->waitForSignal(false, 0)) {
          _sampling_enabled = false;
          configASSERT(xTimerStop(topology_timer, 10));
          bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, USE_HEADER,
                         "Pausing sampling network topology until next duration...\n");
        }
    }
  ```

3. The `topology_timer` is never started again because the `__sampling_enabled` variable is initially set to `true`prior to the DFU update and never set to `false`. Since power is indefinitely on (sampleIntervalMs == sampleDurationMs), neither sub-conditional can be satisfied: the first requires `!_sampling_enabled`, and the second requires `waitForSignal(false, 0)` — which only succeeds when network power is disabled.

  ```c
          if (!_sampling_enabled && _bridge_power_controller->waitForSignal(true, 0)) {
  
          ...
    
          } else if (_sampling_enabled && _bridge_power_controller->waitForSignal(false, 0)) {
  
          ...
  
          }
  ```
During this state, the second conditional is always waited upon but never succeed because `_bridge_power_controller->waitForSignal(false, 0)` waits until power on the network is disabled!

Fix considered:

1. Reset `_sampling_enabled` at the end of the else block when the power controller transitions back to enabled.
2. Use `xTimerIsTimerActive(topology_timer)` to determine whether the timer should be started or stopped.

Option 2 was chosen as _sampling_enabled is fragile — future additions or removals elsewhere in the task would require careful bookkeeping to keep it consistent.


## Where should reviewers focus?

@towynlin I performed a few DFU updates on the Spotter E-Box you provided me for testing, but it would be nice if you could also validate it with your eyes!

Is there any problems you could see with using the `xTimerIsTimerActive` API to track timer state rather than `_sampling_enabled`?

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
