### PR TITLE
Feature/client power subscribe app

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -268,6 +268,13 @@
             "cacheVariables": {
                 "APP": "sub_example"
             }
+        },
+        {
+            "name": "power-sub-example",
+            "inherits": "hello-world",
+            "cacheVariables": {
+                "APP": "power_sub_example"
+            }
         }
     ],
     "buildPresets": [
@@ -434,6 +441,11 @@
         {
             "configurePreset": "sub-example",
             "name": "sub-example",
+            "jobs": 8
+        },
+        {
+            "configurePreset": "power-sub-example",
+            "name": "power-sub-example",
             "jobs": 8
         }
     ]

--- a/src/apps/bm_devkit/power_sub_example/CMakeLists.txt
+++ b/src/apps/bm_devkit/power_sub_example/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(APP_DIR ${CMAKE_CURRENT_SOURCE_DIR} PARENT_SCOPE)
+
+set(APP_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/user_code/user_code.cpp
+)
+
+set(APP_INCLUDES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/user_code
+)
+
+set(APP_LIBS
+)
+
+set(APP_DEFINES
+    APP_NAME="${APP_NAME}"
+    # Add network stress test functions
+    STRESS_TEST_ENABLE
+)
+
+# Send APP_DEFINES to parent scope (otherwise we can't append to the
+# list above)
+set(APP_DEFINES "${APP_DEFINES}" PARENT_SCOPE)
+set(APP_LIBS "${APP_LIBS}" PARENT_SCOPE)
+set(APP_FILES "${APP_FILES}" PARENT_SCOPE)
+set(APP_INCLUDES "${APP_INCLUDES}" PARENT_SCOPE)

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
@@ -22,9 +22,7 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
                                         const uint8_t *data, uint16_t data_len, uint8_t type,
                                         uint8_t version) {
   (void)topic_len;
-  (void)data_len;
   (void)topic;
-  (void)node_id;
   (void)type;
 
   /*
@@ -41,7 +39,7 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
   PowerBatteryAveragesMsg::Data d = {};
   CborError err = PowerBatteryAveragesMsg::decode(d, data, data_len);
   if (err == CborNoError) {
-    printf("Spotter battery averages data:\n");
+    printf("Node ID %" PRIx64 " battery averages data:\n", node_id);
     printf("\tpower_reading_type: %d\n", d.power_reading_type);
     printf("\tstatus: %d\n", d.status);
     printf("\tnum_samples: %lu\n", d.num_samples);
@@ -61,23 +59,14 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
   } else {
     printf("Failed to decode the battery averages message!\n");
   }
-  bm_free(d.cell_voltage_v_avg);
-  bm_free(d.cell_voltage_v_max);
-  bm_free(d.cell_voltage_v_min);
-  bm_free(d.cell_voltage_v_stdev);
-  bm_free(d.cell_temperature_c_avg);
-  bm_free(d.cell_temperature_c_max);
-  bm_free(d.cell_temperature_c_min);
-  bm_free(d.cell_temperature_c_stdev);
+  PowerBatteryAveragesMsg::free(d);
 }
 
 static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                       const uint8_t *data, uint16_t data_len, uint8_t type,
                                       uint8_t version) {
   (void)topic_len;
-  (void)data_len;
   (void)topic;
-  (void)node_id;
   (void)type;
 
   if (version != PowerSolarAveragesMsg::VERSION) {
@@ -95,7 +84,7 @@ static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint1
       protected since this callback run in the middleware task.
     */
 
-    printf("Spotter solar averages data:\n");
+    printf("Node ID %" PRIx64 " solar averages data:\n", node_id);
     printf("\tnum_samples: %lu\n", d.num_samples);
     printf("\taveraging_window_length_s: %.3f\n", d.averaging_window_length_s);
     printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
@@ -124,18 +113,7 @@ static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint1
   } else {
     printf("Failed to decode the solar averages message!\n");
   }
-  bm_free(d.panel_temperatures_average);
-  bm_free(d.panel_temperatures_max);
-  bm_free(d.panel_temperatures_min);
-  bm_free(d.panel_temperatures_stdev);
-  bm_free(d.panel_voltages_average);
-  bm_free(d.panel_voltages_max);
-  bm_free(d.panel_voltages_min);
-  bm_free(d.panel_voltages_stdev);
-  bm_free(d.panel_currents_average);
-  bm_free(d.panel_currents_max);
-  bm_free(d.panel_currents_min);
-  bm_free(d.panel_currents_stdev);
+  PowerSolarAveragesMsg::free(d);
 }
 
 void setup(void) {

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
@@ -1,0 +1,189 @@
+#include "user_code.h"
+#include "bm_os.h"
+#include "power_battery_msg.h"
+#include "power_battery_averages_msg.h"
+#include "power_solar_reading_msg.h"
+#include "power_solar_averages_msg.h"
+#include "pubsub.h"
+#include "uptime.h"
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+This application demonstrates how to subscribe to a data topic over bristlemouth via the bm_sub function.
+The application subscribes to the topic "pubsub_example" and prints the received message to the console.
+The callback function subscribe_callback is called when a message is received.
+To test this application, you will need to run the pub_example application on another node.
+*/
+
+
+// TODO - Update these!
+// The topic type is a identifier for the topic to encode different data types, we don't need to worry about this value for the tutorial.
+static constexpr uint32_t EXAMPLE_SUBSCRIBE_TOPIC_TYPE = (1);
+// The topic version is a version number for the topic, in case things change we don't need to worry about this value for the tutorial.
+static constexpr uint32_t EXAMPLE_SUBSCRIBE_TOPIC_VERSION = (1);
+// This is the topic to subscribe to, the publisher will need to publish to this topic (see the application pub_example)
+static const char *const POWER_BATTERY_AVGS_TOPIC = "sensor/*/power/battery/avgs";
+static const char *const POWER_SOLAR_TOPIC = "sensor/*/power/solar";
+static const char *const POWER_SOLAR_AVGS_TOPIC = "sensor/*/power/solar/avgs";
+
+static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                           const uint8_t *data, uint16_t data_len, uint8_t type,
+                           uint8_t version) {
+  (void)topic_len;
+  (void)data_len;
+  (void)topic;
+  (void)node_id;
+
+  if (type != 1 || version != 1) {
+    printf("version or type incorrect\n");
+    return;
+  }
+
+  PowerBatteryAveragesMsg::Data d = {};
+  CborError err = PowerBatteryAveragesMsg::decode(d, data, data_len);
+  if (err == CborNoError) {
+    printf("Spotter battery averages data:\n");
+    printf("\tpower_reading_type: %d\n", d.power_reading_type);
+    printf("\tstatus: %d\n", d.status);
+    printf("\tnum_samples: %lu\n", d.num_samples);
+    printf("\taveraging_window_length_s: %f\n", d.averaging_window_length_s);
+    printf("\tnum_cell_voltages: %d\n", d.num_cell_voltages);
+    for (uint8_t i = 0; i < d.num_cell_voltages; i++) {
+      printf("\tcell %d - voltage avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
+             i, d.cell_voltage_v_avg[i], d.cell_voltage_v_max[i],
+             d.cell_voltage_v_min[i], d.cell_voltage_v_stdev[i]);
+    }
+    printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
+    for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
+      printf("\tcell %d - temp avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
+             i, d.cell_temperature_c_avg[i], d.cell_temperature_c_max[i],
+             d.cell_temperature_c_min[i], d.cell_temperature_c_stdev[i]);
+    }
+  } else {
+    printf("Failed to decode the battery averages message!\n");
+  }
+  bm_free(d.cell_voltage_v_avg);
+  bm_free(d.cell_voltage_v_max);
+  bm_free(d.cell_voltage_v_min);
+  bm_free(d.cell_voltage_v_stdev);
+  bm_free(d.cell_temperature_c_avg);
+  bm_free(d.cell_temperature_c_max);
+  bm_free(d.cell_temperature_c_min);
+  bm_free(d.cell_temperature_c_stdev);
+}
+
+static void power_solar_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                           const uint8_t *data, uint16_t data_len, uint8_t type,
+                           uint8_t version) {
+  (void)topic_len;
+  (void)data_len;
+  (void)topic;
+  (void)node_id;
+
+  if (type != 1 || version != 1) {
+    printf("version or type incorrect\n");
+    return;
+  }
+
+  PowerSolarReadingMsg::Data d = {};
+  CborError err = PowerSolarReadingMsg::decode(d, data, data_len);
+  if (err == CborNoError) {
+    printf("Spotter solar reading data:\n");
+    printf("\tpower_reading_type: %d\n", d.power_reading_type);
+    printf("\tstatus: %d\n", d.status);
+    printf("\tvoltage_v: %.3f\n", d.voltage_v);
+    printf("\tcurrent_a: %.3f\n", d.current_a);
+    printf("\tmpp_position: %.3f\n", d.mpp_position);
+    printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
+    for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
+      printf("\ttemp_sensor %d - temp: %.3f\n",
+             i, d.panel_temperatures[i]);
+    }
+    printf("\tnum_lines: %d\n", d.num_lines);
+    for (uint8_t i = 0; i < d.num_lines; i++) {
+      printf("\tline %d - voltage: %.3f, current: %.3f\n",
+             i, d.panel_voltages[i], d.panel_currents[i]);
+    }
+  } else {
+    printf("Failed to decode the solar reading message!\n");
+  }
+  bm_free(d.panel_temperatures);
+  bm_free(d.panel_voltages);
+  bm_free(d.panel_currents);
+}
+
+// static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
+//                            const uint8_t *data, uint16_t data_len, uint8_t type,
+//                            uint8_t version) {
+//   (void)topic_len;
+//   (void)data_len;
+//   (void)topic;
+//   (void)node_id;
+
+//   if (type != 1 || version != 1) {
+//     printf("version or type incorrect\n");
+//     return;
+//   }
+
+//   PowerSolarAveragesMsg::Data d = {};
+//   CborError err = PowerSolarAveragesMsg::decode(d, data, data_len);
+//   if (err == CborNoError) {
+//     printf("Spotter solar averages data:\n");
+//     printf("\tnum_samples: %lu\n", d.num_samples);
+//     printf("\taveraging_window_length_s: %.3f\n", d.averaging_window_length_s);
+//     printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
+//     printf("\tnum_lines: %d\n", d.num_lines);
+
+//     printf("\tPanel Temperatures:\n");
+//     for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
+//       printf("\t  sensor %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
+//              i, d.panel_temperatures_average[i], d.panel_temperatures_max[i],
+//              d.panel_temperatures_min[i], d.panel_temperatures_stdev[i]);
+//     }
+
+//     printf("\tPanel Voltages:\n");
+//     for (uint8_t i = 0; i < d.num_lines; i++) {
+//       printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
+//              i, d.panel_voltages_average[i], d.panel_voltages_max[i],
+//              d.panel_voltages_min[i], d.panel_voltages_stdev[i]);
+//     }
+
+//     printf("\tPanel Currents:\n");
+//     for (uint8_t i = 0; i < d.num_lines; i++) {
+//       printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
+//              i, d.panel_currents_average[i], d.panel_currents_max[i],
+//              d.panel_currents_min[i], d.panel_currents_stdev[i]);
+//     }
+//   } else {
+//     printf("Failed to decode the solar averages message!\n");
+//   }
+//   bm_free(d.panel_temperatures_average);
+//   bm_free(d.panel_temperatures_max);
+//   bm_free(d.panel_temperatures_min);
+//   bm_free(d.panel_temperatures_stdev);
+//   bm_free(d.panel_voltages_average);
+//   bm_free(d.panel_voltages_max);
+//   bm_free(d.panel_voltages_min);
+//   bm_free(d.panel_voltages_stdev);
+//   bm_free(d.panel_currents_average);
+//   bm_free(d.panel_currents_max);
+//   bm_free(d.panel_currents_min);
+//   bm_free(d.panel_currents_stdev);
+// }
+
+void setup(void) {
+  /* USER ONE-TIME SETUP CODE GOES HERE */
+  // Subscribe to the topic and provide the callback function to be called when a message is received.
+  bm_sub(POWER_BATTERY_AVGS_TOPIC, power_battery_avgs_callback);
+  // bm_sub(POWER_SOLAR_AVGS_TOPIC, power_solar_avgs_callback);
+  bm_sub(POWER_SOLAR_TOPIC, power_solar_callback);
+}
+
+void loop(void) {
+  // Nothing to do!
+  // The callback function will be called independently from this loop
+  // when a message is received.
+}

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
@@ -1,9 +1,8 @@
 #include "user_code.h"
 #include "bm_os.h"
-#include "power_battery_msg.h"
 #include "power_battery_averages_msg.h"
-#include "power_solar_reading_msg.h"
 #include "power_solar_averages_msg.h"
+#include "power_solar_reading_msg.h"
 #include "pubsub.h"
 #include "uptime.h"
 #include <inttypes.h>
@@ -11,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
+// TODO - update this comment!!!
 /*
 This application demonstrates how to subscribe to a data topic over bristlemouth via the bm_sub function.
 The application subscribes to the topic "pubsub_example" and prints the received message to the console.
@@ -18,27 +18,22 @@ The callback function subscribe_callback is called when a message is received.
 To test this application, you will need to run the pub_example application on another node.
 */
 
-
-// TODO - Update these!
-// The topic type is a identifier for the topic to encode different data types, we don't need to worry about this value for the tutorial.
-static constexpr uint32_t EXAMPLE_SUBSCRIBE_TOPIC_TYPE = (1);
-// The topic version is a version number for the topic, in case things change we don't need to worry about this value for the tutorial.
-static constexpr uint32_t EXAMPLE_SUBSCRIBE_TOPIC_VERSION = (1);
 // This is the topic to subscribe to, the publisher will need to publish to this topic (see the application pub_example)
 static const char *const POWER_BATTERY_AVGS_TOPIC = "sensor/*/power/battery/avgs";
-static const char *const POWER_SOLAR_TOPIC = "sensor/*/power/solar";
+// static const char *const POWER_SOLAR_TOPIC = "sensor/*/power/solar";
 static const char *const POWER_SOLAR_AVGS_TOPIC = "sensor/*/power/solar/avgs";
 
 static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
-                           const uint8_t *data, uint16_t data_len, uint8_t type,
-                           uint8_t version) {
+                                        const uint8_t *data, uint16_t data_len, uint8_t type,
+                                        uint8_t version) {
   (void)topic_len;
   (void)data_len;
   (void)topic;
   (void)node_id;
+  (void)type;
 
-  if (type != 1 || version != 1) {
-    printf("version or type incorrect\n");
+  if (version != PowerBatteryAveragesMsg::VERSION) {
+    printf("version incorrect\n");
     return;
   }
 
@@ -52,14 +47,14 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
     printf("\taveraging_window_length_s: %f\n", d.averaging_window_length_s);
     printf("\tnum_cell_voltages: %d\n", d.num_cell_voltages);
     for (uint8_t i = 0; i < d.num_cell_voltages; i++) {
-      printf("\tcell %d - voltage avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
-             i, d.cell_voltage_v_avg[i], d.cell_voltage_v_max[i],
-             d.cell_voltage_v_min[i], d.cell_voltage_v_stdev[i]);
+      printf("\tcell %d - voltage avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n", i,
+             d.cell_voltage_v_avg[i], d.cell_voltage_v_max[i], d.cell_voltage_v_min[i],
+             d.cell_voltage_v_stdev[i]);
     }
     printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
     for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
-      printf("\tcell %d - temp avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
-             i, d.cell_temperature_c_avg[i], d.cell_temperature_c_max[i],
+      printf("\tcell %d - temp avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n", i,
+             d.cell_temperature_c_avg[i], d.cell_temperature_c_max[i],
              d.cell_temperature_c_min[i], d.cell_temperature_c_stdev[i]);
     }
   } else {
@@ -75,47 +70,7 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
   bm_free(d.cell_temperature_c_stdev);
 }
 
-static void power_solar_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
-                           const uint8_t *data, uint16_t data_len, uint8_t type,
-                           uint8_t version) {
-  (void)topic_len;
-  (void)data_len;
-  (void)topic;
-  (void)node_id;
-
-  if (type != 1 || version != 1) {
-    printf("version or type incorrect\n");
-    return;
-  }
-
-  PowerSolarReadingMsg::Data d = {};
-  CborError err = PowerSolarReadingMsg::decode(d, data, data_len);
-  if (err == CborNoError) {
-    printf("Spotter solar reading data:\n");
-    printf("\tpower_reading_type: %d\n", d.power_reading_type);
-    printf("\tstatus: %d\n", d.status);
-    printf("\tvoltage_v: %.3f\n", d.voltage_v);
-    printf("\tcurrent_a: %.3f\n", d.current_a);
-    printf("\tmpp_position: %.3f\n", d.mpp_position);
-    printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
-    for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
-      printf("\ttemp_sensor %d - temp: %.3f\n",
-             i, d.panel_temperatures[i]);
-    }
-    printf("\tnum_lines: %d\n", d.num_lines);
-    for (uint8_t i = 0; i < d.num_lines; i++) {
-      printf("\tline %d - voltage: %.3f, current: %.3f\n",
-             i, d.panel_voltages[i], d.panel_currents[i]);
-    }
-  } else {
-    printf("Failed to decode the solar reading message!\n");
-  }
-  bm_free(d.panel_temperatures);
-  bm_free(d.panel_voltages);
-  bm_free(d.panel_currents);
-}
-
-// static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
+// static void power_solar_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
 //                            const uint8_t *data, uint16_t data_len, uint8_t type,
 //                            uint8_t version) {
 //   (void)topic_len;
@@ -128,58 +83,99 @@ static void power_solar_callback(uint64_t node_id, const char *topic, uint16_t t
 //     return;
 //   }
 
-//   PowerSolarAveragesMsg::Data d = {};
-//   CborError err = PowerSolarAveragesMsg::decode(d, data, data_len);
+//   PowerSolarReadingMsg::Data d = {};
+//   CborError err = PowerSolarReadingMsg::decode(d, data, data_len);
 //   if (err == CborNoError) {
-//     printf("Spotter solar averages data:\n");
-//     printf("\tnum_samples: %lu\n", d.num_samples);
-//     printf("\taveraging_window_length_s: %.3f\n", d.averaging_window_length_s);
+//     printf("Spotter solar reading data:\n");
+//     printf("\tpower_reading_type: %d\n", d.power_reading_type);
+//     printf("\tstatus: %d\n", d.status);
+//     printf("\tvoltage_v: %.3f\n", d.voltage_v);
+//     printf("\tcurrent_a: %.3f\n", d.current_a);
+//     printf("\tmpp_position: %.3f\n", d.mpp_position);
 //     printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
-//     printf("\tnum_lines: %d\n", d.num_lines);
-
-//     printf("\tPanel Temperatures:\n");
 //     for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
-//       printf("\t  sensor %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
-//              i, d.panel_temperatures_average[i], d.panel_temperatures_max[i],
-//              d.panel_temperatures_min[i], d.panel_temperatures_stdev[i]);
+//       printf("\ttemp_sensor %d - temp: %.3f\n",
+//              i, d.panel_temperatures[i]);
 //     }
-
-//     printf("\tPanel Voltages:\n");
+//     printf("\tnum_lines: %d\n", d.num_lines);
 //     for (uint8_t i = 0; i < d.num_lines; i++) {
-//       printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
-//              i, d.panel_voltages_average[i], d.panel_voltages_max[i],
-//              d.panel_voltages_min[i], d.panel_voltages_stdev[i]);
-//     }
-
-//     printf("\tPanel Currents:\n");
-//     for (uint8_t i = 0; i < d.num_lines; i++) {
-//       printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n",
-//              i, d.panel_currents_average[i], d.panel_currents_max[i],
-//              d.panel_currents_min[i], d.panel_currents_stdev[i]);
+//       printf("\tline %d - voltage: %.3f, current: %.3f\n",
+//              i, d.panel_voltages[i], d.panel_currents[i]);
 //     }
 //   } else {
-//     printf("Failed to decode the solar averages message!\n");
+//     printf("Failed to decode the solar reading message!\n");
 //   }
-//   bm_free(d.panel_temperatures_average);
-//   bm_free(d.panel_temperatures_max);
-//   bm_free(d.panel_temperatures_min);
-//   bm_free(d.panel_temperatures_stdev);
-//   bm_free(d.panel_voltages_average);
-//   bm_free(d.panel_voltages_max);
-//   bm_free(d.panel_voltages_min);
-//   bm_free(d.panel_voltages_stdev);
-//   bm_free(d.panel_currents_average);
-//   bm_free(d.panel_currents_max);
-//   bm_free(d.panel_currents_min);
-//   bm_free(d.panel_currents_stdev);
+//   bm_free(d.panel_temperatures);
+//   bm_free(d.panel_voltages);
+//   bm_free(d.panel_currents);
 // }
+
+static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
+                                      const uint8_t *data, uint16_t data_len, uint8_t type,
+                                      uint8_t version) {
+  (void)topic_len;
+  (void)data_len;
+  (void)topic;
+  (void)node_id;
+  (void)type;
+
+  if (version != PowerSolarAveragesMsg::VERSION) {
+    printf("version or type incorrect\n");
+    return;
+  }
+
+  PowerSolarAveragesMsg::Data d = {};
+  CborError err = PowerSolarAveragesMsg::decode(d, data, data_len);
+  if (err == CborNoError) {
+    printf("Spotter solar averages data:\n");
+    printf("\tnum_samples: %lu\n", d.num_samples);
+    printf("\taveraging_window_length_s: %.3f\n", d.averaging_window_length_s);
+    printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
+    printf("\tnum_lines: %d\n", d.num_lines);
+
+    printf("\tPanel Temperatures:\n");
+    for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
+      printf("\t  sensor %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n", i,
+             d.panel_temperatures_average[i], d.panel_temperatures_max[i],
+             d.panel_temperatures_min[i], d.panel_temperatures_stdev[i]);
+    }
+
+    printf("\tPanel Voltages:\n");
+    for (uint8_t i = 0; i < d.num_lines; i++) {
+      printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n", i,
+             d.panel_voltages_average[i], d.panel_voltages_max[i], d.panel_voltages_min[i],
+             d.panel_voltages_stdev[i]);
+    }
+
+    printf("\tPanel Currents:\n");
+    for (uint8_t i = 0; i < d.num_lines; i++) {
+      printf("\t  line %d - avg: %.3f, max: %.3f, min: %.3f, stdev: %.3f\n", i,
+             d.panel_currents_average[i], d.panel_currents_max[i], d.panel_currents_min[i],
+             d.panel_currents_stdev[i]);
+    }
+  } else {
+    printf("Failed to decode the solar averages message!\n");
+  }
+  bm_free(d.panel_temperatures_average);
+  bm_free(d.panel_temperatures_max);
+  bm_free(d.panel_temperatures_min);
+  bm_free(d.panel_temperatures_stdev);
+  bm_free(d.panel_voltages_average);
+  bm_free(d.panel_voltages_max);
+  bm_free(d.panel_voltages_min);
+  bm_free(d.panel_voltages_stdev);
+  bm_free(d.panel_currents_average);
+  bm_free(d.panel_currents_max);
+  bm_free(d.panel_currents_min);
+  bm_free(d.panel_currents_stdev);
+}
 
 void setup(void) {
   /* USER ONE-TIME SETUP CODE GOES HERE */
   // Subscribe to the topic and provide the callback function to be called when a message is received.
   bm_sub(POWER_BATTERY_AVGS_TOPIC, power_battery_avgs_callback);
-  // bm_sub(POWER_SOLAR_AVGS_TOPIC, power_solar_avgs_callback);
-  bm_sub(POWER_SOLAR_TOPIC, power_solar_callback);
+  bm_sub(POWER_SOLAR_AVGS_TOPIC, power_solar_avgs_callback);
+  // bm_sub(POWER_SOLAR_TOPIC, power_solar_callback);
 }
 
 void loop(void) {

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
@@ -81,7 +81,7 @@ static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint1
     /*
       Print out the data. Here you could take actions based on the power data.
       If you are passing variables in/out of this function they must be mutex
-      protected since this callback run in the middleware task.
+      protected since this callback is run in the middleware task.
     */
 
     printf("Node ID %" PRIx64 " solar averages data:\n", node_id);

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.cpp
@@ -2,7 +2,6 @@
 #include "bm_os.h"
 #include "power_battery_averages_msg.h"
 #include "power_solar_averages_msg.h"
-#include "power_solar_reading_msg.h"
 #include "pubsub.h"
 #include "uptime.h"
 #include <inttypes.h>
@@ -10,17 +9,13 @@
 #include <stdio.h>
 #include <string.h>
 
-// TODO - update this comment!!!
 /*
-This application demonstrates how to subscribe to a data topic over bristlemouth via the bm_sub function.
-The application subscribes to the topic "pubsub_example" and prints the received message to the console.
-The callback function subscribe_callback is called when a message is received.
-To test this application, you will need to run the pub_example application on another node.
+This application demonstrates how to subscribe to power averages and solar averages topics
+over bristlemouth via the bm_sub function.
 */
 
 // This is the topic to subscribe to, the publisher will need to publish to this topic (see the application pub_example)
 static const char *const POWER_BATTERY_AVGS_TOPIC = "sensor/*/power/battery/avgs";
-// static const char *const POWER_SOLAR_TOPIC = "sensor/*/power/solar";
 static const char *const POWER_SOLAR_AVGS_TOPIC = "sensor/*/power/solar/avgs";
 
 static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
@@ -31,6 +26,12 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
   (void)topic;
   (void)node_id;
   (void)type;
+
+  /*
+      Print out the data. Here you could take actions based on the power data.
+      If you are passing variables in/out of this function they must be mutex
+      protected since this callback is run in the middleware task.
+    */
 
   if (version != PowerBatteryAveragesMsg::VERSION) {
     printf("version incorrect\n");
@@ -70,46 +71,6 @@ static void power_battery_avgs_callback(uint64_t node_id, const char *topic, uin
   bm_free(d.cell_temperature_c_stdev);
 }
 
-// static void power_solar_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
-//                            const uint8_t *data, uint16_t data_len, uint8_t type,
-//                            uint8_t version) {
-//   (void)topic_len;
-//   (void)data_len;
-//   (void)topic;
-//   (void)node_id;
-
-//   if (type != 1 || version != 1) {
-//     printf("version or type incorrect\n");
-//     return;
-//   }
-
-//   PowerSolarReadingMsg::Data d = {};
-//   CborError err = PowerSolarReadingMsg::decode(d, data, data_len);
-//   if (err == CborNoError) {
-//     printf("Spotter solar reading data:\n");
-//     printf("\tpower_reading_type: %d\n", d.power_reading_type);
-//     printf("\tstatus: %d\n", d.status);
-//     printf("\tvoltage_v: %.3f\n", d.voltage_v);
-//     printf("\tcurrent_a: %.3f\n", d.current_a);
-//     printf("\tmpp_position: %.3f\n", d.mpp_position);
-//     printf("\tnum_temp_sensors: %d\n", d.num_temp_sensors);
-//     for (uint8_t i = 0; i < d.num_temp_sensors; i++) {
-//       printf("\ttemp_sensor %d - temp: %.3f\n",
-//              i, d.panel_temperatures[i]);
-//     }
-//     printf("\tnum_lines: %d\n", d.num_lines);
-//     for (uint8_t i = 0; i < d.num_lines; i++) {
-//       printf("\tline %d - voltage: %.3f, current: %.3f\n",
-//              i, d.panel_voltages[i], d.panel_currents[i]);
-//     }
-//   } else {
-//     printf("Failed to decode the solar reading message!\n");
-//   }
-//   bm_free(d.panel_temperatures);
-//   bm_free(d.panel_voltages);
-//   bm_free(d.panel_currents);
-// }
-
 static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint16_t topic_len,
                                       const uint8_t *data, uint16_t data_len, uint8_t type,
                                       uint8_t version) {
@@ -127,6 +88,13 @@ static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint1
   PowerSolarAveragesMsg::Data d = {};
   CborError err = PowerSolarAveragesMsg::decode(d, data, data_len);
   if (err == CborNoError) {
+
+    /*
+      Print out the data. Here you could take actions based on the power data.
+      If you are passing variables in/out of this function they must be mutex
+      protected since this callback run in the middleware task.
+    */
+
     printf("Spotter solar averages data:\n");
     printf("\tnum_samples: %lu\n", d.num_samples);
     printf("\taveraging_window_length_s: %.3f\n", d.averaging_window_length_s);
@@ -172,10 +140,9 @@ static void power_solar_avgs_callback(uint64_t node_id, const char *topic, uint1
 
 void setup(void) {
   /* USER ONE-TIME SETUP CODE GOES HERE */
-  // Subscribe to the topic and provide the callback function to be called when a message is received.
+  // Subscribe to the topics and provide the callback functions to be called when a message is received.
   bm_sub(POWER_BATTERY_AVGS_TOPIC, power_battery_avgs_callback);
   bm_sub(POWER_SOLAR_AVGS_TOPIC, power_solar_avgs_callback);
-  // bm_sub(POWER_SOLAR_TOPIC, power_solar_callback);
 }
 
 void loop(void) {

--- a/src/apps/bm_devkit/power_sub_example/user_code/user_code.h
+++ b/src/apps/bm_devkit/power_sub_example/user_code/user_code.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void setup(void);
+void loop(void);

--- a/src/lib/bm_integration/bm_config.h
+++ b/src/lib/bm_integration/bm_config.h
@@ -7,4 +7,6 @@
 
 #define bm_debug(format, ...) printf(format, ##__VA_ARGS__)
 
+#define bm_noinit_ram_attribute section(".noinit")
+
 #endif /* __BM_CONFIG_H__ */

--- a/src/lib/bm_ncp/ncp_config.cpp
+++ b/src/lib/bm_ncp/ncp_config.cpp
@@ -202,8 +202,8 @@ BmErr _cfg_get_bcmp_cb(uint8_t *payload) {
   BmErr rval = BmOK;
   if (payload != NULL) {
     BmConfigValue *msg = reinterpret_cast<BmConfigValue *>(payload);
-    if (bm_serial_cfg_value(msg->header.source_node_id, msg->partition, msg->data_length,
-                            msg->data) != BM_SERIAL_OK) {
+    if (bm_serial_cfg_value(msg->header.source_node_id, (BmConfigPartition)msg->partition,
+                            msg->data_length, msg->data) != BM_SERIAL_OK) {
       printf("Failed to send get cfg response\n");
       rval = BmEBADMSG;
     }
@@ -217,8 +217,8 @@ BmErr _cfg_set_bcmp_cb(uint8_t *payload) {
   BmErr rval = BmOK;
   if (payload != NULL) {
     BmConfigValue *msg = reinterpret_cast<BmConfigValue *>(payload);
-    if (bm_serial_cfg_value(msg->header.source_node_id, msg->partition, msg->data_length,
-                            msg->data) != BM_SERIAL_OK) {
+    if (bm_serial_cfg_value(msg->header.source_node_id, (BmConfigPartition)msg->partition,
+                            msg->data_length, msg->data) != BM_SERIAL_OK) {
       printf("Failed to send set cfg response\n");
       rval = BmEBADMSG;
     }
@@ -232,9 +232,9 @@ BmErr _cfg_status_request_bcmp_cb(uint8_t *payload) {
   BmErr rval = BmOK;
   if (payload != NULL) {
     BmConfigStatusResponse *msg = reinterpret_cast<BmConfigStatusResponse *>(payload);
-    if (bm_serial_cfg_status_response(msg->header.source_node_id, msg->partition,
-                                      msg->committed, msg->num_keys,
-                                      msg->keyData) != BM_SERIAL_OK) {
+    if (bm_serial_cfg_status_response(msg->header.source_node_id,
+                                      (BmConfigPartition)msg->partition, msg->committed,
+                                      msg->num_keys, msg->keyData) != BM_SERIAL_OK) {
       printf("Failed to send status response\n");
       rval = BmEBADMSG;
     }
@@ -249,9 +249,9 @@ BmErr _cfg_key_del_bcmp_cb(uint8_t *payload) {
   BmErr rval = BmOK;
   if (payload != NULL) {
     BmConfigDeleteKeyResponse *msg = reinterpret_cast<BmConfigDeleteKeyResponse *>(payload);
-    if (bm_serial_cfg_delete_response(msg->header.source_node_id, msg->partition,
-                                      msg->key_length, msg->key,
-                                      msg->success) != BM_SERIAL_OK) {
+    if (bm_serial_cfg_delete_response(msg->header.source_node_id,
+                                      (BmConfigPartition)msg->partition, msg->key_length,
+                                      msg->key, msg->success) != BM_SERIAL_OK) {
       printf("Failed to send key del response\n");
       rval = BmEBADMSG;
     }
@@ -266,7 +266,8 @@ BmErr _cfg_clear_bcmp_cb(uint8_t *payload) {
 
   if (payload != NULL) {
     BmConfigClearResponse *msg = reinterpret_cast<BmConfigClearResponse *>(payload);
-    if (bm_serial_cfg_clear_response(msg->header.source_node_id, msg->partition,
+    if (bm_serial_cfg_clear_response(msg->header.source_node_id,
+                                     (BmConfigPartition)msg->partition,
                                      msg->success) != BM_SERIAL_OK) {
       printf("Failed to send config clear response\n");
       rval = BmEBADMSG;

--- a/tools/scripts/test/configs/mote.yaml
+++ b/tools/scripts/test/configs/mote.yaml
@@ -26,6 +26,15 @@
     use_bootloader: True
     defines: -DCMAKE_APP_TYPE=BMDK
 
+- name: power_sub_example on bm_mote_v1.0
+  type: build_fw
+  args:
+    app: power_sub_example
+    bsp: bm_mote_v1.0
+    build_type: Release
+    use_bootloader: True
+    defines: -DCMAKE_APP_TYPE=BMDK
+
 - name: rbr_coda_example on bm_mote_v1.0
   type: build_fw
   args:


### PR DESCRIPTION
## What changed?
This adds an example app for subscribing to power data. Specifically it subscribes to battery and solar averages, that for right now will be coming from Spotter. It then just prints out the data to the console like so:
```
Node ID 49e9141dd36502a4 battery averages data:
	power_reading_type: 2
	status: 0
	num_samples: 10
	averaging_window_length_s: 60.000000
	num_cell_voltages: 1
	cell 0 - voltage avg: 4.056, max: 23.284, min: 0.000, stdev: 0.000
	num_temp_sensors: 1
	cell 0 - temp avg: 0.000, max: 0.000, min: 0.000, stdev: 2.314e+251
Node ID 49e9141dd36502a4 solar averages data:
	num_samples: 20
	averaging_window_length_s: 120.000
	num_temp_sensors: 1
	num_lines: 1
	Panel Temperatures:
	  sensor 0 - avg: 4.056, max: 23.284, min: 0.000, stdev: 0.000
	Panel Voltages:
	  line 0 - avg: 0.000, max: 0.000, min: 0.000, stdev: 2.314e+251
	Panel Currents:
	  line 0 - avg: 0.000, max: 9.949e+10, min: 0.000, stdev: 3425.153
```


## How does it make Bristlemouth better?
Adds an example app for users to model their own power subscriptions off of!


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
