### PR TITLE
Add Break Callback To Serial Module

### DIFF
--- a/src/apps/adin_test/app_main.cpp
+++ b/src/apps/adin_test/app_main.cpp
@@ -102,6 +102,7 @@ SerialHandle_t usart1 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -124,6 +125,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -145,6 +147,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -97,6 +97,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -119,6 +120,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -140,6 +142,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // TODO - make a getter API for these

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -94,6 +94,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -116,6 +117,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -137,6 +139,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -113,6 +113,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -135,6 +136,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -156,6 +158,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;

--- a/src/apps/bringup_bridge/app_main.cpp
+++ b/src/apps/bringup_bridge/app_main.cpp
@@ -81,6 +81,7 @@ SerialHandle_t usart1 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 #endif /// DEBUG_USE_USART1
 
@@ -104,6 +105,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // "bristlemouth" USB serial - Use TBD
@@ -126,6 +128,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 static const DebugI2C_t debugI2CInterfaces[] = {

--- a/src/apps/bringup_mote/app_main.cpp
+++ b/src/apps/bringup_mote/app_main.cpp
@@ -91,6 +91,7 @@ SerialHandle_t lpuart1 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 #endif // DEBUG_USE_LPUART1
 
@@ -114,6 +115,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 #endif /// DEBUG_USE_USART3
 
@@ -137,6 +139,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // "bristlemouth" USB serial - Use TBD
@@ -159,6 +162,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 static const DebugI2C_t debugI2CInterfaces[] = {{1, &i2c1}};

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -90,6 +90,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -112,6 +113,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -133,6 +135,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -89,6 +89,7 @@ SerialHandle_t usart3 = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 // Serial console USB device
@@ -111,6 +112,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -132,6 +134,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -86,6 +86,7 @@ SerialHandle_t usbCLI = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 SerialHandle_t usbPcap = {
@@ -107,6 +108,7 @@ SerialHandle_t usbPcap = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/lib/common/bm_usart.h
+++ b/src/lib/common/bm_usart.h
@@ -9,6 +9,30 @@ static inline void usart_ClearFlag_ORE(USART_TypeDef *USARTx){
   WRITE_REG(USARTx->ICR, USART_ICR_ORECF);
 }
 
+static inline uint32_t usart_IsActiveFlag_FE(USART_TypeDef *USARTx) {
+  return ((READ_BIT(USARTx->ISR, USART_ISR_FE) == (USART_ISR_FE)) ? 1UL : 0UL);
+}
+
+static inline void usart_ClearFlag_FE(USART_TypeDef *USARTx){
+  WRITE_REG(USARTx->ICR, USART_ICR_FECF);
+}
+
+static inline uint32_t usart_IsActiveFlag_NE(USART_TypeDef *USARTx) {
+  return ((READ_BIT(USARTx->ISR, USART_ISR_NE) == (USART_ISR_FE)) ? 1UL : 0UL);
+}
+
+static inline void usart_ClearFlag_NE(USART_TypeDef *USARTx){
+  WRITE_REG(USARTx->ICR, USART_ICR_NECF);
+}
+
+static inline void usart_DisableIT_EIE(USART_TypeDef *USARTx){
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_EIE);
+}
+
+static inline void usart_EnableIT_EIE(USART_TypeDef *USARTx){
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_EIE);
+}
+
 static inline uint32_t usart_IsActiveFlag_RXNE(USART_TypeDef *USARTx) {
   return ((READ_BIT(USARTx->ISR, USART_ISR_RXNE_RXFNE) == (USART_ISR_RXNE_RXFNE)) ? 1UL : 0UL);
 }

--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -377,6 +377,7 @@ SerialHandle_t uart_handle = {
     .flags = 0,
     .preTxCb = NULL,
     .postTxCb = NULL,
+    .breakISR = NULL,
 };
 
 BaseType_t init(uint8_t task_priority) {

--- a/src/lib/common/serial.c
+++ b/src/lib/common/serial.c
@@ -303,35 +303,6 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
 
   configASSERT(handle != NULL);
 
-  // If error drain the Receive Data Register, data is invalid
-  uint32_t isr = USART2->ISR;
-  if (isr & (USART_ISR_FE | USART_ISR_NE | USART_ISR_ORE)) {
-    while (USART2->ISR & USART_ISR_RXNE_RXFNE) {
-      volatile uint32_t dummy = USART2->RDR;
-      (void)dummy;
-    }
-  }
-
-  // Handle UART overrun error
-  if (usart_IsActiveFlag_ORE((USART_TypeDef *)handle->device)) {
-    // TODO - maybe differentiate overrun error from rx buffer full
-    handle->flags |= SERIAL_FLAG_RXDROP;
-    usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
-  }
-
-  // Clear noise error
-  if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
-    usart_ClearFlag_NE((USART_TypeDef *)handle->device);
-  }
-
-  // Handle framing error (break condition)
-  if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
-    if(handle->breakISR) {
-      handle->breakISR();
-    }
-    usart_ClearFlag_FE((USART_TypeDef *)handle->device);
-  }
-
   // Process received bytes
   if( usart_IsActiveFlag_RXNE((USART_TypeDef *)handle->device) &&
       usart_IsEnabledIT_RXNE((USART_TypeDef *)handle->device)){
@@ -364,6 +335,26 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
       if(handle->postTxCb){
         handle->postTxCb(handle);
       }
+  }
+
+  // Handle UART overrun error
+  if (usart_IsActiveFlag_ORE((USART_TypeDef *)handle->device)) {
+    // TODO - maybe differentiate overrun error from rx buffer full
+    handle->flags |= SERIAL_FLAG_RXDROP;
+    usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
+  }
+
+  // Clear noise error
+  if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
+    usart_ClearFlag_NE((USART_TypeDef *)handle->device);
+  }
+
+  // Handle framing error (break condition)
+  if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
+    if(handle->breakISR) {
+      handle->breakISR();
+    }
+    usart_ClearFlag_FE((USART_TypeDef *)handle->device);
   }
 
   // Let the RTOS know if a task needs to be woken up

--- a/src/lib/common/serial.c
+++ b/src/lib/common/serial.c
@@ -106,7 +106,6 @@ uint32_t serialGetBaudRate(SerialHandle_t *handle) {
 }
 
 // Handle break conditions
-typedef void (*HWBreakCb_t)(void);
 void serialEnableBreakHandle(SerialHandle_t *handle, HWBreakCb_t cb) {
   configASSERT(handle != NULL);
   configASSERT(cb != NULL);
@@ -304,6 +303,35 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
 
   configASSERT(handle != NULL);
 
+  // If error drain the Receive Data Register, data is invalid
+  uint32_t isr = USART2->ISR;
+  if (isr & (USART_ISR_FE | USART_ISR_NE | USART_ISR_ORE)) {
+    while (USART2->ISR & USART_ISR_RXNE_RXFNE) {
+      volatile uint32_t dummy = USART2->RDR;
+      (void)dummy;
+    }
+  }
+
+  // Handle UART overrun error
+  if (usart_IsActiveFlag_ORE((USART_TypeDef *)handle->device)) {
+    // TODO - maybe differentiate overrun error from rx buffer full
+    handle->flags |= SERIAL_FLAG_RXDROP;
+    usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
+  }
+
+  // Clear noise error
+  if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
+    usart_ClearFlag_NE((USART_TypeDef *)handle->device);
+  }
+
+  // Handle framing error (break condition)
+  if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
+    if(handle->breakISR) {
+      handle->breakISR();
+    }
+    usart_ClearFlag_FE((USART_TypeDef *)handle->device);
+  }
+
   // Process received bytes
   if( usart_IsActiveFlag_RXNE((USART_TypeDef *)handle->device) &&
       usart_IsEnabledIT_RXNE((USART_TypeDef *)handle->device)){
@@ -336,26 +364,6 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
       if(handle->postTxCb){
         handle->postTxCb(handle);
       }
-  }
-
-  // Handle UART overrun error
-  if (usart_IsActiveFlag_ORE((USART_TypeDef *)handle->device)) {
-    // TODO - maybe differentiate overrun error from rx buffer full
-    handle->flags |= SERIAL_FLAG_RXDROP;
-    usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
-  }
-
-  // Clear noise error
-  if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
-    usart_ClearFlag_NE((USART_TypeDef *)handle->device);
-  }
-
-  // Handle framing error (break condition)
-  if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
-    if(handle->breakISR) {
-      handle->breakISR();
-    }
-    usart_ClearFlag_FE((USART_TypeDef *)handle->device);
   }
 
   // Let the RTOS know if a task needs to be woken up

--- a/src/lib/common/serial.c
+++ b/src/lib/common/serial.c
@@ -105,6 +105,24 @@ uint32_t serialGetBaudRate(SerialHandle_t *handle) {
   return ret;
 }
 
+// Handle break conditions
+typedef void (*HWBreakCb_t)(void);
+void serialEnableBreakHandle(SerialHandle_t *handle, HWBreakCb_t cb) {
+  configASSERT(handle != NULL);
+  configASSERT(cb != NULL);
+
+  // Enable interrupt on errors
+  usart_EnableIT_EIE((USART_TypeDef *)handle->device);
+  handle->breakISR = cb;
+}
+
+void serialDisableBreakHandle(SerialHandle_t *handle) {
+  configASSERT(handle != NULL);
+
+  usart_DisableIT_EIE((USART_TypeDef *)handle->device);
+  handle->breakISR = NULL;
+}
+
 // Receive character from uart rx interrupt and place in stream buffer
 // to be processed in serialGenericRxTask
 BaseType_t serialGenericRxBytesFromISR(SerialHandle_t *handle, uint8_t *buffer, size_t len) {
@@ -220,6 +238,16 @@ void serialEnable(SerialHandle_t *handle) {
       usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
     }
 
+    // Clear framing error
+    if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
+      usart_ClearFlag_FE((USART_TypeDef *)handle->device);
+    }
+
+    // Clear noise error
+    if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
+      usart_ClearFlag_NE((USART_TypeDef *)handle->device);
+    }
+
     if (handle->txStreamBuffer) {
       xStreamBufferReset(handle->txStreamBuffer);
     }
@@ -315,6 +343,19 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
     // TODO - maybe differentiate overrun error from rx buffer full
     handle->flags |= SERIAL_FLAG_RXDROP;
     usart_ClearFlag_ORE((USART_TypeDef *)handle->device);
+  }
+
+  // Clear noise error
+  if (usart_IsActiveFlag_NE((USART_TypeDef *)handle->device)) {
+    usart_ClearFlag_NE((USART_TypeDef *)handle->device);
+  }
+
+  // Handle framing error (break condition)
+  if (usart_IsActiveFlag_FE((USART_TypeDef *)handle->device)) {
+    if(handle->breakISR) {
+      handle->breakISR();
+    }
+    usart_ClearFlag_FE((USART_TypeDef *)handle->device);
   }
 
   // Let the RTOS know if a task needs to be woken up

--- a/src/lib/common/serial.h
+++ b/src/lib/common/serial.h
@@ -28,6 +28,8 @@ typedef struct {
   void (*lineCallback)(void *serialHandle, uint8_t *line, size_t len);
 } SerialLineBuffer_t;
 
+typedef void (*HWBreakCb_t)(void);
+
 typedef struct SerialHandle {
   // Pointer to hardware struct
   void *device;
@@ -81,6 +83,9 @@ typedef struct SerialHandle {
 
   // Function to run after tx (called from ISR context)
   void (*postTxCb)(struct SerialHandle *handle);
+
+  // Break condition callback (called from ISR context)
+  HWBreakCb_t breakISR;
 } SerialHandle_t;
 
 // Dropped rx characters
@@ -117,6 +122,10 @@ void serialTxTask(void *parameters);
 void startSerial();
 void serialSetBaudRate(SerialHandle_t *handle, uint32_t baud);
 uint32_t serialGetBaudRate(SerialHandle_t *handle);
+
+// Handle break conditions
+void serialEnableBreakHandle(SerialHandle_t *handle, HWBreakCb_t cb);
+void serialDisableBreakHandle(SerialHandle_t *handle);
 
 void serialGenericTx(SerialHandle_t *handle, uint8_t *data, size_t len, void *arg);
 void serialWrite(SerialHandle_t *handle, const uint8_t *buff, size_t len, void *arg);


### PR DESCRIPTION
## What changed?
Adds serial break character handler.
Sets `EIE` (Error Interrupt Enable) bit to be able to handle framing errors to recognize break events.
Statement within section 66.5.7/67.4.7 of the STM32U5x Reference Manual explains the usage of the framing error:
<img width="1038" height="118" alt="image" src="https://github.com/user-attachments/assets/a8f65bf7-d901-42d4-a754-6e5bbf2d6796" />

## How does it make Bristlemouth better?
Allows serial peripherals to recognize break characters and handle them accordingly, allowing the mote to synchronize events based on this new handler.

## Where should reviewers focus?
For Borealis V2 this is being used strictly in PLUART, should this be implemented only in the `payload_uart.cpp` file ? I do not see an immediate reason for needing this feature in any other serial peripherals at the moment, but this does provide flexibility for future initiatives (syncing NCP UART device with the bridge for example).


## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
