### PR TITLE
Use latest googletest release for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
     CPMAddPackage(
       NAME googletest
       GITHUB_REPOSITORY google/googletest
-      GIT_TAG release-1.11.0
+      GIT_TAG v1.17.0
     )
 
     set(ENABLE_TESTING ON)


### PR DESCRIPTION
## What changed?
Updates googletest release version used for unit tests. "Fixes" a compiler error that was triggered by more recent Xcode Command Line tools versions. Updating googletest seems to lower this down to a warning allowing the unit tests to be built and ran on a local Mac machine.

Before the PR this error was occuring: 
```
[  1%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/src/gtest-all.cc:38:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest.h:64:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:41:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:39:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:44:
/Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-printers.h:478:35: error: implicit conversion from 'char8_t' to 'char32_t' may change the
      meaning of the represented code unit [-Werror,-Wcharacter-conversion]
  478 |   PrintTo(ImplicitCast_<char32_t>(c), os);
      |           ~~~~~~~~~~~~~           ^
1 error generated.
make[2]: *** [_deps/googletest-build/googletest/CMakeFiles/gtest.dir/build.make:76: _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1110: _deps/googletest-build/googletest/CMakeFiles/gtest.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

After it now is just shown as a warning:
```
[  1%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/src/gtest-all.cc:38:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest.h:64:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:43:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:47:
In file included from /Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:49:
/Users/victorsowa/work/bm_protocol/cmake-build/test/_deps/googletest-src/googletest/include/gtest/gtest-printers.h:528:35: warning: implicit conversion from 'char8_t' to 'char32_t' may change
      the meaning of the represented code unit [-Wcharacter-conversion]
  528 |   PrintTo(ImplicitCast_<char32_t>(c), os);
      |           ~~~~~~~~~~~~~           ^
```

## How does it make Bristlemouth better?
Updates to the latest tooling and allows for building unit tests on latest MacOS/XCode versions.


## Where should reviewers focus?
Test it out locally and see if it works for you!


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
