### PR TITLE
Build Borealis V2 in release, maintain V1 builds

### DIFF
--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -157,6 +157,16 @@
     build_type: Release
   sign: false
 
+- name: borealisV2
+  type: ext_fw
+  repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
+  sha: 624b349
+  args:
+    app: borealisV2
+    bsp: bm_mote_v1.0
+    build_type: Release
+  sign: false
+
 - name: mavlink_bridge_release
   type: build_fw
   args:

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -157,12 +157,12 @@
     build_type: Release
   sign: false
 
-- name: borealisV2
+- name: borealis2
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
   sha: 624b349
   args:
-    app: borealisV2
+    app: borealis2
     bsp: bm_mote_v1.0
     build_type: Release
   sign: false


### PR DESCRIPTION
## What changed?
Adds a Borealis V2 build to the release builds.


## How does it make Bristlemouth better?


## Where should reviewers focus?



## Checklist

- [x] Add or update unit tests for changed code
- [x] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [x] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
