### PR TITLE
Allow RBR To Recognize Device When Bootstraping And Hotswaping

### DIFF
--- a/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/bristleback_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -72,7 +72,7 @@ void RbrSensor::maybeProbeType(uint64_t last_power_on_time) {
       RBR_READING_PERIOD_MS / 2 + PROBE_WINDOW_WIDTH_MS / 2;
   bool lower_window = now > _last_data_time + window_start_time;
   bool upper_window = now < _last_data_time + window_end_time;
-  bool can_transmit = lower_window && upper_window;
+  bool can_transmit = (lower_window && upper_window) || _type == BmRbrDataMsg::UNKNOWN;
 
   if (now - _lastProbeTime >= _minProbePeriodMs &&
       now - last_power_on_time >= _minProbePeriodMs && can_transmit) {
@@ -96,9 +96,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       handleOutputformat(_payload_buffer, read_len);
     } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
       success = handleDataString(_payload_buffer, read_len, d);
-      if (success) {
-        _last_data_time = uptimeGetMs();
-      }
+      _last_data_time = uptimeGetMs();
     } else {
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid line from sensor: %.*s\n", read_len,
                   _payload_buffer);

--- a/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
+++ b/src/apps/rs232_expander_apps/bm_rbr/user_code/rbr_sensor.cpp
@@ -72,7 +72,7 @@ void RbrSensor::maybeProbeType(uint64_t last_power_on_time) {
       RBR_READING_PERIOD_MS / 2 + PROBE_WINDOW_WIDTH_MS / 2;
   bool lower_window = now > _last_data_time + window_start_time;
   bool upper_window = now < _last_data_time + window_end_time;
-  bool can_transmit = lower_window && upper_window;
+  bool can_transmit = (lower_window && upper_window) || _type == BmRbrDataMsg::UNKNOWN;
 
   if (now - _lastProbeTime >= _minProbePeriodMs &&
       now - last_power_on_time >= _minProbePeriodMs && can_transmit) {
@@ -96,9 +96,7 @@ bool RbrSensor::getData(BmRbrDataMsg::Data &d) {
       handleOutputformat(_payload_buffer, read_len);
     } else if (BmRbrSensorUtil::validSensorDataString(_payload_buffer, read_len)) {
       success = handleDataString(_payload_buffer, read_len, d);
-      if (success) {
-        _last_data_time = uptimeGetMs();
-      }
+      _last_data_time = uptimeGetMs();
     } else {
       spotter_log(0, RBR_RAW_LOG, USE_TIMESTAMP, "Invalid line from sensor: %.*s\n", read_len,
                   _payload_buffer);


### PR DESCRIPTION
## What changed?
Check the last time data has been received from the RBR agnostic of the value being properly parsed.
Always probe for attached RBR if `_type` is `UNKNOWN`.


## How does it make Bristlemouth better?
This allows the RBR application to set the RBR if one has not been set yet and reinstates hot swapping RBR modules as this bug also broke that functionality.

This happened due to the fact that `_last_data_time` would never get set because `handleDataString` would always return `false` (the function could not parse the string because the application did not know the `_type` of RBR attached).
`_last_data_time` should be set no matter if `handleDataString` returns `true` or `false` as this variable is meant to be used to determine when **valid** data was last received, not if the data was **parsed** properly. This allows the application to properly probe the RBR sensor.

## Testing

The following setup was used for testing:

- RS232 RBR module on v0.13.11-rc.3
- 1 RBR coda³ T.D
- 1 RBR coda³ T

Initially I deleted the `rbrCodaType` config in the system configs:

<img width="2561" height="246" alt="Screenshot 2026-05-26 at 10 14 13 AM" src="https://github.com/user-attachments/assets/f0788fbf-8353-431a-8a4e-48c98ff86d8f" />

I would repeatedly get `attempting FTL recovery` print statements and **the `rbrCodaType` would never get set**.


<img width="2557" height="352" alt="Screenshot 2026-05-26 at 10 14 02 AM" src="https://github.com/user-attachments/assets/253efc28-c74c-4b4b-bdb1-86a5f00ae787" />

I then proceeded to flash the fix in this PR.
Immediately the `rbrCodaType` was set:

<img width="2552" height="311" alt="Screenshot 2026-05-26 at 10 15 58 AM" src="https://github.com/user-attachments/assets/6f1eee80-f4f1-408c-b2b8-a008639468f6" />


I then hot swapped from the RBR coda³ T.D to the RBR coda³ T and was able to see the config get set and changed upon the next probing window:

<img width="2555" height="244" alt="Screenshot 2026-05-26 at 10 34 11 AM" src="https://github.com/user-attachments/assets/63127381-e12b-451c-8e49-aae185c5a0cf" />

<img width="2555" height="317" alt="Screenshot 2026-05-26 at 10 34 38 AM" src="https://github.com/user-attachments/assets/231e0857-c59c-4bc8-81fb-636acf3cfbe1" />

I then hot-swapped back to the RBR coda³ T.D and it was properly recognized and the configuration was set upon the next probing window:

<img width="2550" height="191" alt="Screenshot 2026-05-26 at 10 35 18 AM" src="https://github.com/user-attachments/assets/fc1d7d7c-cda8-4f11-a7e7-f76e2e1c62cc" >


## Where should reviewers focus?

I added an extra safety rail when the `_type` is not set (`UNKNOWN`).
Do you believe this is needed?
It could mess with the probing window, but also data should not be getting transmitted up Bristlemouth if `_type` is not set.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
