### PR TITLE
Allows Borealis2 To Be Built From CI Release

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -90,7 +90,9 @@ class AutoBuilder:
         if not config["name"].startswith("bootloader"):
             cmd += ["-DUSE_BOOTLOADER=1"]
 
-        if config["args"]["bsp"] == "bm_mote_bristleback_v1_0":
+        if config["args"].get("external_init", False) is True:
+            pass
+        elif config["args"]["bsp"] == "bm_mote_bristleback_v1_0":
             cmd += ["-DCMAKE_APP_TYPE=bristleback"]
         elif (
             config["args"]["bsp"] == "bm_mote_v1.0"

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -165,6 +165,7 @@
     app: borealis2
     bsp: bm_mote_v1.0
     build_type: Release
+    external_init: true
   sign: false
 
 - name: mavlink_bridge_release


### PR DESCRIPTION
## What changed?
borealis2 was failing the release build process.

## How does it make Bristlemouth better?
Allows release CI to pass.
This fix allows borealis2 to be built with an external `app_main`.

## Where should reviewers focus?
Running the `auto_build.py` script locally I get the following successful output:

```
Building: bringup_bridge_debug
Building: bringup_bridge_legacy
Building: bm_rbr_release
Building: seapoint_turbidity_release
Building: aanderaa_release
Building: aanderaa_salinity_release
Building: pme_do_sensor_release
Building: borealis
Repository successfully cloned to: /var/folders/ng/pgw86n2s5h7_njw4jwcwr_f80000gn/T/tmppf0eab0c/borealis
Building: borealis2
Repository successfully cloned to: /var/folders/ng/pgw86n2s5h7_njw4jwcwr_f80000gn/T/tmp532yy9na/borealis2
Building: mavlink_bridge_release
```


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
