### PR TITLE
Adds RX Fifo For Serial Interface

### DIFF
--- a/src/apps/adin_test/app_main.cpp
+++ b/src/apps/adin_test/app_main.cpp
@@ -103,6 +103,7 @@ SerialHandle_t usart1 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -126,6 +127,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -148,6 +150,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -98,6 +98,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -121,6 +122,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -143,6 +145,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // TODO - make a getter API for these

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -95,6 +95,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -118,6 +119,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -140,6 +142,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -114,6 +114,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -137,6 +138,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -159,6 +161,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 uint32_t sys_cfg_sensorsPollIntervalMs = DEFAULT_SENSORS_POLL_MS;

--- a/src/apps/bringup_bridge/app_main.cpp
+++ b/src/apps/bringup_bridge/app_main.cpp
@@ -82,6 +82,7 @@ SerialHandle_t usart1 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 #endif /// DEBUG_USE_USART1
 
@@ -106,6 +107,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // "bristlemouth" USB serial - Use TBD
@@ -129,6 +131,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 static const DebugI2C_t debugI2CInterfaces[] = {

--- a/src/apps/bringup_mote/app_main.cpp
+++ b/src/apps/bringup_mote/app_main.cpp
@@ -92,6 +92,7 @@ SerialHandle_t lpuart1 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 #endif // DEBUG_USE_LPUART1
 
@@ -116,6 +117,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 #endif /// DEBUG_USE_USART3
 
@@ -140,6 +142,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // "bristlemouth" USB serial - Use TBD
@@ -163,6 +166,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 static const DebugI2C_t debugI2CInterfaces[] = {{1, &i2c1}};

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -91,6 +91,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -114,6 +115,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -136,6 +138,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -90,6 +90,7 @@ SerialHandle_t usart3 = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 // Serial console USB device
@@ -113,6 +114,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -135,6 +137,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 extern "C" void USART3_IRQHandler(void) { serialGenericUartIRQHandler(&usart3); }

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -87,6 +87,7 @@ SerialHandle_t usbCLI = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 SerialHandle_t usbPcap = {
@@ -109,6 +110,7 @@ SerialHandle_t usbPcap = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
+    .fifoEnabled = false,
 };
 
 NvmPartition *userConfigurationPartition = NULL;

--- a/src/lib/common/payload_uart.cpp
+++ b/src/lib/common/payload_uart.cpp
@@ -328,9 +328,9 @@ void configTxPinAlternate(void) {
 void enable(void) {
   USART_TypeDef *dev = static_cast<USART_TypeDef *>(uart_handle.device);
 
-  LL_LPUART_Enable(dev);
-
   serialEnable(&uart_handle);
+
+  LL_LPUART_Enable(dev);
 
   // Clear any pending NVIC bit from the disabled period, then re-enable
   NVIC_ClearPendingIRQ(LPUART1_IRQn);
@@ -378,7 +378,8 @@ SerialHandle_t uart_handle = {
     .preTxCb = NULL,
     .postTxCb = NULL,
     .breakISR = NULL,
-};
+    .fifoEnabled = true,
+}; // namespace PLUART
 
 BaseType_t init(uint8_t task_priority) {
   // Create the stream buffer for the user bytes to be buffered into and read from

--- a/src/lib/common/serial.c
+++ b/src/lib/common/serial.c
@@ -261,8 +261,16 @@ void serialEnable(SerialHandle_t *handle) {
 
     if (handle->rxStreamBuffer) {
       xStreamBufferReset(handle->rxStreamBuffer);
-      // Enable Uart RX interrupt
-      usart_EnableIT_RXNE((USART_TypeDef *)handle->device);
+      if (handle->fifoEnabled) {
+        LL_USART_EnableIT_IDLE(handle->device);
+        LL_USART_EnableIT_RXFT(handle->device);
+        LL_USART_EnableIT_RXFF(handle->device);
+        LL_USART_SetRXFIFOThreshold(handle->device, LL_USART_FIFOTHRESHOLD_1_2);
+        LL_USART_EnableFIFO(handle->device);
+      } else {
+        // Enable Uart RX interrupt
+        usart_EnableIT_RXNE((USART_TypeDef *)handle->device);
+      }
     }
   }
 #endif
@@ -303,13 +311,25 @@ void serialGenericUartIRQHandler(SerialHandle_t *handle) {
 
   configASSERT(handle != NULL);
 
+  // When line is idle, data must be cleared
+  bool idle_int =
+      LL_USART_IsActiveFlag_IDLE(handle->device) && LL_USART_IsEnabledIT_IDLE(handle->device);
+  bool fifo_int = (LL_USART_IsActiveFlag_RXFF(handle->device) ||
+                   LL_USART_IsActiveFlag_RXFT(handle->device)) &&
+                  LL_USART_IsEnabledIT_RXFT(handle->device);
+  bool rx_int = usart_IsActiveFlag_RXNE((USART_TypeDef *)handle->device) &&
+                usart_IsEnabledIT_RXNE((USART_TypeDef *)handle->device);
   // Process received bytes
-  if( usart_IsActiveFlag_RXNE((USART_TypeDef *)handle->device) &&
-      usart_IsEnabledIT_RXNE((USART_TypeDef *)handle->device)){
+  if (idle_int || fifo_int || rx_int) {
+    while (LL_USART_IsActiveFlag_RXNE_RXFNE(handle->device)) {
+      uint8_t byte = usart_ReceiveData8((USART_TypeDef *)handle->device);
+      configASSERT(handle->rxBytesFromISR);
+      higherPriorityTaskWoken = handle->rxBytesFromISR(handle, &byte, 1);
+    }
 
-    uint8_t byte = usart_ReceiveData8((USART_TypeDef *)handle->device);
-    configASSERT(handle->rxBytesFromISR);
-    higherPriorityTaskWoken = handle->rxBytesFromISR(handle, &byte, 1);
+    if (idle_int) {
+      LL_USART_ClearFlag_IDLE(handle->device);
+    }
   }
 
   // TXE will set when Tx Data Reg (TDR) is empty. Process next byte to transmit

--- a/src/lib/common/serial.h
+++ b/src/lib/common/serial.h
@@ -86,6 +86,8 @@ typedef struct SerialHandle {
 
   // Break condition callback (called from ISR context)
   HWBreakCb_t breakISR;
+
+  bool fifoEnabled;
 } SerialHandle_t;
 
 // Dropped rx characters


### PR DESCRIPTION
## What changed?
Adds RX FIFO functionality and `SerialHandle_t` configuration to choose between using the Fifo or general purpose RX interrupt.


## How does it make Bristlemouth better?
Reduces the number of processor interrupt/wake up events by leveraging the UART FIFO on the STM32U5. This lessens the chance for data to get dropped while the processor is in STOP1 mode. Note it takes about 7-9 microseconds for the processor to wake up from STOP1 mode (we are using the [MSI at 24MHz as our wake up clock](https://github.com/bristlemouth/bm_protocol/blob/1595f804c5012d57619a2645d6661d288a5e96c5/src/lib/common/lpm_u5.c#L41-L48), see the [following](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.st.com/resource/en/datasheet/stm32u575ag.pdf&ved=2ahUKEwj3mNii26CVAxWqLzQIHVZeEc8QFnoECBkQAQ&usg=AOvVaw0IN4xj-_DzwFjecdhdTf7W)):
<img width="773" height="256" alt="image" src="https://github.com/user-attachments/assets/9bf284ba-1135-4920-98a4-f7b916d1df80" />
The FIFO can hold 8 elements, it is configured to fire an interrupt after it is half full, essentially reducing the number of times the interrupt fires by a factor of 4. It is configured as half full in case there is more data ingested on the RX line while in the interrupt, ensuring bytes do not get dropped.


## Testing

I ran a BorealisV2 unit with 1.5MBd communication between the SCARI DAQ Microcontroller and the Bristlemouth Mote:

```
2026-06-23T22:29:41.953Z | borealis mote firmware: ab539f930e-dirty
2026-06-23T22:29:49.644Z | gpzda_to_sys: adjusted time by 272419657 microseconds
2026-06-23T22:29:49.648Z | $GPZDA,222949.601659,23,06,2026,00,00*6C
2026-06-23T22:29:49.660Z | gpzda_to_sys: adjusted time by 13512 microseconds
2026-06-23T22:29:49.664Z | $GPZDA,222949.631252,23,06,2026,00,00*60
2026-06-23T22:29:49.667Z | defer_work: skipping
2026-06-23T22:29:49.675Z | scari: changing baud rate to 1500000
2026-06-23T22:29:49.726Z | $PCFG,31250.00,rec,usb,gram,spl,replay,baud1500000,gain0*6B
```

The SCARI was set up to transmit SPL and PGRAM messages to the Mote and through Bristlemouth.

Within the SD card contents, there were no indications of dropped packets due to checksum errors as previously added to the Borealis2 code by @victorsowa12.
The FIFO logic was able to keep up with the higher data rate!

When examining the dropped messages ON A SOFAR OCEAN SPOTTER in the `XXXX_SENS_IND.csv` file, there was a total of 21, which is about 0.0157% of the messages not reaching the Spotter's SD card. Note these messages could have been dropped in:

- The Bristlemouth network
- The UART communication between Sofar Ocean's Spotter and the Bridge
- NOT in the communication between SCARI and the mote as there would have been an indication in the `borealis_checksum.log` file which never appears in the `bm` directory.

Here is the output of an analysis of this file:

```
======================================================================
 /Volumes/NO NAME 4/log/0000_SENS_IND.csv
======================================================================

  node_app_name: borealis [type 1] (66821 readings, tick 9624-65712725 ms, median interval: 983.0 ms)
    Gaps (>1.10x median = >1081.3 ms): 11 event(s) (0.02%)
      tick 3222566.000 -> 3228465.000 (6 gaps)
      tick 10822334.000 -> 10827250.000 (5 gaps)

  node_app_name: borealis [type 2] (66823 readings, tick 9618-65713699 ms, median interval: 983.0 ms)
    Gaps (>1.10x median = >1081.3 ms): 10 event(s) (0.01%)
      tick 3222560.000 -> 3228459.000 (6 gaps)
      tick 10823312.000 -> 10827244.000 (4 gaps)
```

Attached below are some pertinent logs from this test(the full zipped directory from the test is larger than Github's allowable upload size of 30MB):

[0000_borealis.log.zip](https://github.com/user-attachments/files/29308850/0000_borealis.log.zip)
[0000_port_monitor.log.zip](https://github.com/user-attachments/files/29308852/0000_port_monitor.log.zip)
[0000_power.log.zip](https://github.com/user-attachments/files/29308853/0000_power.log.zip)
[0000_SENS_AGG.csv.zip](https://github.com/user-attachments/files/29308865/0000_SENS_AGG.csv.zip)
[0000_SENS_IND.csv.zip](https://github.com/user-attachments/files/29308866/0000_SENS_IND.csv.zip)



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
[0000_SENS_AGG.csv](https://github.com/user-attachments/files/29308856/0000_SENS_AGG.csv)
