### PR TITLE
Grab The Node ID From Hydrotwin Topic Rather Than Embedded In The Message

### DIFF
--- a/src/apps/bridge/sensor_drivers/borealisSensor.cpp
+++ b/src/apps/bridge/sensor_drivers/borealisSensor.cpp
@@ -427,10 +427,18 @@ void BorealisSensor::borealisSubCallback(uint64_t node_id, const char *topic,
     sub_type = HYDROTWIN_HDR;
   }
 
-  if (sub_type < BOREALIS_SUB_COUNT) {
-    borealis = static_cast<Borealis_t *>(
-        sensorControllerFindSensorById(node_id, SENSOR_TYPE_BOREALIS));
+  if (sub_type == BOREALIS_SUB_COUNT) {
+    return;
   }
+
+  // Obtain Node ID from topic as Pi on Borealis 2 has a different node ID and
+  // will publish data with an unexpected node ID value
+  uint64_t borealis_mote_node_id = 0;
+  static const uint8_t offset = sizeof("sensor/") - 1;
+  borealis_mote_node_id = strtoull(&topic[offset], nullptr, 16);
+
+  borealis = static_cast<Borealis_t *>(
+      sensorControllerFindSensorById(borealis_mote_node_id, SENSOR_TYPE_BOREALIS));
 
   bm_debug("Borealis data received from node %016" PRIx64 ", on topic: %.*s\n", node_id,
            topic_len, topic);


### PR DESCRIPTION
## What changed?
Rather than using the node ID in a Bristlemouth publish message to determine which hydrotwin topic this publication belongs to, use the Node ID embedded in the topic of the publication.


## How does it make Bristlemouth better?
Allows Hydrotwin HDR and LDR messages to be logged onto Sofar's Spotter.


## Where should reviewers focus?
I decided to use `strtoull`, but am open to other options (note I tried `sscanf` but the ARM compiler does not support grabbing 64bit integer values).


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
