### PR TITLE
Fixes Invalid Instruction After Waking Up From Sleep

### DIFF
--- a/src/lib/common/lptimTick_u5.c
+++ b/src/lib/common/lptimTick_u5.c
@@ -453,6 +453,7 @@ void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
             //
             __DSB();
             enter_sleep_mode();
+            __NOP();
             __ISB();
          }
          configPOST_SLEEP_PROCESSING( (const TickType_t)xExpectedIdleTime );


### PR DESCRIPTION

## What changed?
Add a `_NOP()` instruction after exiting sleep mode. 


## How does it make Bristlemouth better?
Prevents a `UsageFault` that could occur when the mote wakes from sleep, where the CPU would attempt to execute an invalid instruction.

## Why is this happening?
There is no documented errata for this issue, but debugging showed the mote was hitting this exception on wake.
Evaluating the [CFSR](https://developer.arm.com/documentation/ddi0403/d/System-Level-Architecture/System-Address-Map/System-Control-Space--SCS-/Configurable-Fault-Status-Register--CFSR?lang=en) register showed a `UsageFault` set at bit 0, indicating the CPU attempted to execute an invalid instruction:

<img width="412" height="98" alt="image" src="https://github.com/user-attachments/assets/53c73e4b-2ee7-4b32-8d4f-1acc5b6fb695" />
<img width="1322" height="759" alt="image" src="https://github.com/user-attachments/assets/a3ef2993-1d33-4c35-b72b-07fd9a570571" />

Indicating that an instruction was attempted to be executed that was invalid.

This was occurring upon the entry of the following [function](https://github.com/bristlemouth/bm_protocol/blob/0989713378142ad27e8f52ebfc66ca9d02ee558d/src/lib/common/lpm_u5.c#L154):

```c
     configPOST_SLEEP_PROCESSING( (const TickType_t)xExpectedIdleTime );
```

I validated this by loading code that reports the Program Counter (PC) and Link Register (LR) to a Sofar Ocean Spotter's SD card. On reset, the captured PC/LR values map to these lines in the built binary:

<img width="963" height="27" alt="image" src="https://github.com/user-attachments/assets/ae179713-5139-4f46-8261-63f4d6626803" />

<img width="1124" height="222" alt="image" src="https://github.com/user-attachments/assets/e8f831b9-1a27-4211-9282-593c114815b2" />

## Where should reviewers focus?

An [ST forum report](https://community.st.com/stm32-mcus-embedded-software-32/stm32u5a5-instruction-fault-after-wfi-158950) describes matching behavior on an STM32U5 variant. I'll post our solution there and push to get this into the next errata revision.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
