### PR TITLE
LIS2MDL Driver

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -77,6 +77,7 @@ set(LIB_FILES
     ${LIB_DIR}/drivers/ina232.cpp
     ${LIB_DIR}/drivers/bq25820.cpp
     ${LIB_DIR}/drivers/lsm6dsv.cpp
+    ${LIB_DIR}/drivers/lis2mdl.cpp
     ${LIB_DIR}/drivers/nau7802.cpp
     ${LIB_DIR}/drivers/ms5803.cpp
     ${LIB_DIR}/drivers/pca9535.c

--- a/src/lib/drivers/lis2mdl.cpp
+++ b/src/lib/drivers/lis2mdl.cpp
@@ -1,0 +1,67 @@
+#include "lis2mdl.h"
+#include "app_util.h"
+#include "bm_config.h"
+
+#define lis2mdl_return_on_err(f)                                                               \
+  ({                                                                                           \
+    int32_t err = (f);                                                                         \
+    if (err != 0) {                                                                            \
+      bm_debug("lis2mdl err %d:%" PRId32 "\n", __LINE__, err);                                 \
+      return BmEACCES;                                                                         \
+    }                                                                                          \
+  })
+
+BmErr LIS2MDL::init(void) {
+  BmErr err = q_create_static(&m_reading_queue, m_readings_buf, sizeof(m_readings_buf));
+  if (err != BmOK) {
+    return err;
+  }
+
+  m_queue_mut = bm_mutex_create();
+  if (!m_queue_mut) {
+    return BmENOMEM;
+  }
+
+  // Validate the LIS2MDL device ID
+  uint8_t whoami = 0;
+  lis2mdl_return_on_err(lis2mdl_device_id_get(&m_ctx, &whoami));
+  if (whoami != LIS2MDL_ID) {
+    return BmENODEV;
+  }
+
+  lis2mdl_return_on_err(lis2mdl_sw_reset(&m_ctx));
+  lis2mdl_return_on_err(lis2mdl_block_data_update_set(&m_ctx, PROPERTY_ENABLE));
+  lis2mdl_return_on_err(lis2mdl_offset_temp_comp_set(&m_ctx, PROPERTY_ENABLE));
+  lis2mdl_return_on_err(lis2mdl_drdy_on_pin_set(&m_ctx, PROPERTY_ENABLE));
+  lis2mdl_return_on_err(lis2mdl_operating_mode_set(&m_ctx, LIS2MDL_CONTINUOUS_MODE));
+  lis2mdl_return_on_err(lis2mdl_power_mode_set(&m_ctx, m_cfg.mode));
+  lis2mdl_return_on_err(lis2mdl_data_rate_set(&m_ctx, m_cfg.sample_rate));
+
+  return BmOK;
+}
+
+BmErr LIS2MDL::set_data(const uint8_t *buf, size_t len) {
+
+  if (!buf || len < EXPECTED_DATA_LENGTH) {
+    return BmEINVAL;
+  }
+
+  int16_t datax = static_cast<int16_t>(le_uint8_to_uint16(&buf[0]));
+  int16_t datay = static_cast<int16_t>(le_uint8_to_uint16(&buf[2]));
+  int16_t dataz = static_cast<int16_t>(le_uint8_to_uint16(&buf[4]));
+
+  //TODO: should we put timestamps here?
+  //
+  LIS2MDLReading reading = {
+      .timestamp_ns = 0,
+      .x = lis2mdl_from_lsb_to_mgauss(datax),
+      .y = lis2mdl_from_lsb_to_mgauss(datay),
+      .z = lis2mdl_from_lsb_to_mgauss(dataz),
+  };
+
+  bm_semaphore_take(m_queue_mut, BM_MAX_DELAY_UINT32);
+  q_enqueue(&m_reading_queue, &reading, sizeof(LIS2MDLReading));
+  bm_semaphore_give(m_queue_mut);
+
+  return BmOK;
+}

--- a/src/lib/drivers/lis2mdl.cpp
+++ b/src/lib/drivers/lis2mdl.cpp
@@ -11,15 +11,26 @@
     }                                                                                          \
   })
 
+/*!
+ @brief Initialize the LIS2MDL driver
+
+ @details This function performs the following:
+            - Creates a queue to hold LIS2MDLReading data
+            - Validates the LIS2MDL device exists
+            - Performs a software reset on the device
+            - Compensates for temperature when performing readings
+            - Enables the data is ready by driving the INT line low
+            - Configures customizable power mode and data rate
+
+ @return BmOK on success
+         BmENOMEM if there is insufficient memory to create mutexes/semaphore
+         BmENODEV if the device is not found
+         BmEACCES if bus operations fail when attempting communication to imu
+ */
 BmErr LIS2MDL::init(void) {
   BmErr err = q_create_static(&m_reading_queue, m_readings_buf, sizeof(m_readings_buf));
   if (err != BmOK) {
     return err;
-  }
-
-  m_queue_mut = bm_mutex_create();
-  if (!m_queue_mut) {
-    return BmENOMEM;
   }
 
   // Validate the LIS2MDL device ID
@@ -27,6 +38,11 @@ BmErr LIS2MDL::init(void) {
   lis2mdl_return_on_err(lis2mdl_device_id_get(&m_ctx, &whoami));
   if (whoami != LIS2MDL_ID) {
     return BmENODEV;
+  }
+
+  m_queue_mut = bm_mutex_create();
+  if (!m_queue_mut) {
+    return BmENOMEM;
   }
 
   lis2mdl_return_on_err(lis2mdl_sw_reset(&m_ctx));
@@ -40,6 +56,20 @@ BmErr LIS2MDL::init(void) {
   return BmOK;
 }
 
+/*!
+ @brief Set data on the device from Sensor Hub Application
+
+ @details If using the LIS2MDL from the LSM6DSV's (or another ST product's)
+          sensor hub functionality. This will enqueue the data directly from
+          there as it is required in AbstractSensorInterface. 
+
+ @param buf data received from the sensor hub
+ @param len length of data in bytes
+
+ @return BmOK on success
+         BmEINVAL if input arguments are invalid
+         BmENOMEM if not enough space in the queue's buffer for incoming data
+ */
 BmErr LIS2MDL::set_data(const uint8_t *buf, size_t len) {
 
   if (!buf || len < EXPECTED_DATA_LENGTH) {
@@ -53,15 +83,41 @@ BmErr LIS2MDL::set_data(const uint8_t *buf, size_t len) {
   //TODO: should we put timestamps here?
   //
   LIS2MDLReading reading = {
-      .timestamp_ns = 0,
+      .ns = 0,
       .x = lis2mdl_from_lsb_to_mgauss(datax),
       .y = lis2mdl_from_lsb_to_mgauss(datay),
       .z = lis2mdl_from_lsb_to_mgauss(dataz),
   };
 
   bm_semaphore_take(m_queue_mut, BM_MAX_DELAY_UINT32);
-  q_enqueue(&m_reading_queue, &reading, sizeof(LIS2MDLReading));
+  BmErr err = q_enqueue(&m_reading_queue, &reading, sizeof(LIS2MDLReading));
   bm_semaphore_give(m_queue_mut);
 
-  return BmOK;
+  return err;
+}
+
+/*!
+ @brief Obtain reading from device
+
+ @param reading pointer to structure to hold the singular reading.
+
+ @return BmOK on success
+         BmEINVAL if input arguments are invalid
+         BmENODEV if the device does not exist
+         BmENODATA if there are no elements in the queue to dequeue
+ */
+BmErr LIS2MDL::get_reading(LIS2MDLReading *reading) {
+  if (!reading) {
+    return BmEINVAL;
+  }
+
+  if (!m_queue_mut) {
+    return BmENODEV;
+  }
+
+  bm_semaphore_take(m_queue_mut, BM_MAX_DELAY_UINT32);
+  BmErr err = q_dequeue(&m_reading_queue, reading, sizeof(LIS2MDLReading));
+  bm_semaphore_give(m_queue_mut);
+
+  return err;
 }

--- a/src/lib/drivers/lis2mdl.h
+++ b/src/lib/drivers/lis2mdl.h
@@ -1,0 +1,51 @@
+#ifndef __LIS2MDL_H__
+#define __LIS2MDL_H__
+
+#include "abstract_st_sensor.h"
+#include "lsm6dsv.h"
+
+class LIS2MDL : public AbstractSensorInterface {
+public:
+  typedef struct {
+    lis2mdl_odr_t sample_rate;
+    lis2mdl_lp_t mode;
+  } Cfg;
+
+  typedef struct {
+    uint64_t timestamp_ns;
+    float x;
+    float y;
+    float z;
+  } LIS2MDLReading;
+
+  using AbstractSensorInterface::AbstractSensorInterface;
+  BmErr init(void) override;
+  BmErr set_data(const uint8_t *buf, size_t len) override;
+  BmErr get_reading(LIS2MDLReading *reading);
+
+  LSM6DSV::LSM6DSVSensorHub m_sensor_hub = {
+      .sensor = this,
+      .reg = LIS2MDL_OUTX_L_REG,
+      .len = EXPECTED_DATA_LENGTH,
+  };
+
+private:
+  Cfg m_cfg = {
+      .sample_rate = LIS2MDL_ODR_100Hz,
+      .mode = LIS2MDL_HIGH_RESOLUTION,
+  };
+
+  static constexpr uint8_t EXPECTED_DATA_LENGTH = 6;
+
+  static constexpr uint16_t DATA_SIZE_BYTES = 6;
+  static constexpr uint16_t QUEUE_COUNT = 128;
+  static constexpr uint16_t QUEUE_BUF_SIZE =
+      (sizeof(QItem) + sizeof(LIS2MDLReading)) * QUEUE_COUNT;
+  uint8_t m_readings_buf[QUEUE_BUF_SIZE];
+  Q m_reading_queue;
+
+  BmSemaphore m_queue_mut = NULL;
+  ;
+};
+
+#endif

--- a/src/lib/drivers/lis2mdl.h
+++ b/src/lib/drivers/lis2mdl.h
@@ -12,7 +12,7 @@ public:
   } Cfg;
 
   typedef struct {
-    uint64_t timestamp_ns;
+    uint64_t ns;
     float x;
     float y;
     float z;
@@ -45,7 +45,6 @@ private:
   Q m_reading_queue;
 
   BmSemaphore m_queue_mut = NULL;
-  ;
 };
 
 #endif


### PR DESCRIPTION
## What changed?
Adds driver for LIS2MDL magnetometer.


## How does it make Bristlemouth better?
Allows the magnetometer to data to be captured by the LSM6DSV's sensor hub feature.


## Where should reviewers focus?
To determine how all of this works you will want to look at the following files:

- `src/lib/drivers/lsm6dsv.cpp`
- `src/lib/drivers/abstract/abstract_st_sensor.cpp`

The following datasheet can also be viewed for further information on functionality.
[lis2mdl.pdf](https://github.com/user-attachments/files/29909213/lis2mdl.pdf)



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
