### PR TITLE
Added BNO085 SPI driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "src/third_party/lis2mdl"]
 	path = src/third_party/lis2mdl
 	url = https://github.com/STMicroelectronics/lis2mdl-pid.git
+[submodule "src/third_party/ceva_sh2"]
+	path = src/third_party/ceva_sh2
+	url = https://github.com/ceva-dsp/sh2.git

--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -16,16 +16,14 @@ Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
       _serviceTaskHandle(NULL),
       _eventCallback(NULL),
       _sensorCallback(NULL),
-      _cookie(nullptr),
       _initialized(false),
       _resetSeen(false) {
 }
 
 BmErr Bno085::init(sh2_EventCallback_t *eventCallback,
-                  sh2_SensorCallback_t *sensorCallback, void *cookie) {
+                  sh2_SensorCallback_t *sensorCallback) {
     _eventCallback = eventCallback;
     _sensorCallback = sensorCallback;
-    _cookie = cookie;
     printf("BNO085: Creating service task\n");
 
     return xTaskCreate(serviceTask, "BNO085", configMINIMAL_STACK_SIZE * 8,
@@ -92,7 +90,7 @@ void Bno085::serviceTask(void *arg) {
 
     // Set sensor callback
     if (instance->_sensorCallback) {
-        sh2_setSensorCallback(instance->_sensorCallback, instance->_cookie);
+        sh2_setSensorCallback(instance->_sensorCallback, instance);
     }
 
     instance->_initialized = true;
@@ -168,7 +166,7 @@ void Bno085::eventHandler(void *cookie, sh2_AsyncEvent_t *event) {
         self->_resetSeen = true;   // serviceTask re-applies sensor config
     }
     if (self->_eventCallback) {
-        self->_eventCallback(self->_cookie, event);   // forward to the app callback
+        self->_eventCallback(self, event);   // forward to the app callback
     }
 }
 

--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -5,9 +5,6 @@
 #include "string.h"
 #include "watchdog.h"
 
-// Initialize static instance pointer
-Bno085* Bno085::_instance = nullptr;
-
 Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
                IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin)
     : _interface(spi),
@@ -21,18 +18,16 @@ Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
       _sensorCallback(NULL),
       _initialized(false),
       _resetSeen(false) {
-         configASSERT(_instance == nullptr);
-         _instance = this;
 }
 
-bool Bno085::init(sh2_EventCallback_t *eventCallback,
+BmErr Bno085::init(sh2_EventCallback_t *eventCallback,
                   sh2_SensorCallback_t *sensorCallback) {
     _eventCallback = eventCallback;
     _sensorCallback = sensorCallback;
     printf("BNO085: Creating service task\n");
 
     return xTaskCreate(serviceTask, "BNO085", configMINIMAL_STACK_SIZE * 8,
-                       this, BNO085_TASK_PRIORITY, &_serviceTaskHandle) == pdPASS;
+                       this, BNO085_TASK_PRIORITY, &_serviceTaskHandle) == pdPASS ? BmOK : BmENOMEM;
 }
 
 bool Bno085::intCallback(const void *pinHandle, uint8_t value, void *args) {
@@ -51,9 +46,13 @@ bool Bno085::resetSensor() {
     IOWrite(_wakePin, 1);
     IOWrite(_csPin, 1);
     IOWrite(_rstPin, 0);
+    if (!waitForInt(1, pdMS_TO_TICKS(10))) {
+        printf("BNO085: reset - INT did not deassert during reset\n");
+        return false;
+    }
     vTaskDelay(pdMS_TO_TICKS(10));
     IOWrite(_rstPin, 1);
-    if (!waitForIntLow(pdMS_TO_TICKS(500))) {
+    if (!waitForInt(0, pdMS_TO_TICKS(500))) {
         printf("BNO085: reset - NO INT within 500ms\n");
         return false;
     }
@@ -61,12 +60,12 @@ bool Bno085::resetSensor() {
     return true;
 }
 
-bool Bno085::waitForIntLow(TickType_t timeout) {
+bool Bno085::waitForInt(uint8_t level, TickType_t timeout) {
     TickType_t start = xTaskGetTickCount();
-    uint8_t level = 1;
+    uint8_t currentLevel = 0;
     do {
-        IORead(_intPin, &level);
-        if (!level) return true;
+        IORead(_intPin, &currentLevel);
+        if (currentLevel == level) return true;
         vTaskDelay(1);
     } while ((xTaskGetTickCount() - start) < timeout);
     return false;
@@ -77,15 +76,12 @@ void Bno085::serviceTask(void *arg) {
     Bno085* instance = static_cast<Bno085*>(arg);
 
     // Setup HAL
-    sh2_Hal_t hal = {};
-    hal.open = Bno085::open;
-    hal.close = Bno085::close;
-    hal.read = Bno085::read;
-    hal.write = Bno085::write;
-    hal.getTimeUs = Bno085::getTimeUs;
-
-    // Open sensor hub
-    int status = sh2_open(&hal, Bno085::eventHandler, instance);
+    instance->_hal.open = Bno085::open;
+    instance->_hal.close = Bno085::close;
+    instance->_hal.read = Bno085::read;
+    instance->_hal.write = Bno085::write;
+    instance->_hal.getTimeUs = Bno085::getTimeUs;
+    int status = sh2_open(&instance->_hal, Bno085::eventHandler, instance);
     if (status != SH2_OK) {
         printf("BNO085: Failed to open sensor hub: %d\n", status);
         vTaskDelete(NULL);
@@ -121,9 +117,9 @@ void Bno085::serviceTask(void *arg) {
     }
 }
 
-bool Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us) {
+BmErr Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us) {
     if (!_initialized) {
-        return false;
+        return BmENODEV;
     }
 
     sh2_SensorConfig_t config = {};
@@ -132,10 +128,10 @@ bool Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us
     int status = sh2_setSensorConfig(sensorId, &config);
     if (status != SH2_OK) {
         printf("BNO085: sh2_setSensorConfig(id=%d) failed: %d\n", sensorId, status);
-        return false;
+        return BmEIO;
     }
     printf("BNO085: sh2_setSensorConfig(id=%d) OK\n", sensorId);
-    return true;
+    return BmOK;
 }
 
 void Bno085::enableSensors() {
@@ -145,7 +141,7 @@ void Bno085::enableSensors() {
         { SH2_MAGNETIC_FIELD_CALIBRATED, "magnetometer" },
     };
     for (auto &w : wanted) {
-        if (configureSensor(w.id, 100000)) {   // 10 Hz
+        if (configureSensor(w.id, 100000) == BmOK) {   // 10 Hz
             printf("BNO085: %s enabled @ 10 Hz\n", w.name);
         } else {
             printf("BNO085: failed to enable %s\n", w.name);
@@ -155,8 +151,7 @@ void Bno085::enableSensors() {
 
 int Bno085::open(sh2_Hal_t *self) {
     (void)self;
-    if (!_instance) return SH2_ERR;
-    return _instance->resetSensor() ? SH2_OK : SH2_ERR;
+    return reinterpret_cast<Bno085*>(self)->resetSensor() ? SH2_OK : SH2_ERR;
 }
 
 void Bno085::close(sh2_Hal_t *self) {
@@ -177,25 +172,17 @@ void Bno085::eventHandler(void *cookie, sh2_AsyncEvent_t *event) {
 
 int Bno085::read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len, uint32_t *t_us) {
     (void)self;
-    // Use the static instance pointer
-    if (!_instance) {
-        return 0;
-    }
-    return _instance->readBytes(pBuffer, len, t_us);
+    return reinterpret_cast<Bno085*>(self)->readBytes(pBuffer, len, t_us);
 }
 
 int Bno085::write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len) {
     (void)self;
-    // Use the static instance pointer
-    if (!_instance) {
-        return 0;
-    }
-    return _instance->writeBytes(pBuffer, len);
+    return reinterpret_cast<Bno085*>(self)->writeBytes(pBuffer, len);
 }
 
 uint32_t Bno085::getTimeUs(sh2_Hal_t *self) {
     (void)self;
-    return uptimeGetMs() * 1000;
+    return uptimeGetMicroSeconds();
 }
 
 // Instance methods
@@ -214,7 +201,7 @@ int Bno085::readBytes(uint8_t *pBuffer, unsigned len, uint32_t *t_us) {
     }
     uint16_t cargoLength = (pBuffer[0] | (pBuffer[1] << 8)) & 0x7FFF;
     if (cargoLength < 4 || cargoLength > len) return 0;
-    if (t_us) *t_us = uptimeGetMs() * 1000;
+    if (t_us) *t_us = uptimeGetMicroSeconds();
     return cargoLength;
 }
 
@@ -222,7 +209,7 @@ int Bno085::writeBytes(uint8_t *pBuffer, unsigned len) {
     watchdogFeed();
     IOWrite(_wakePin, 0);
     int written = -1;
-    if (waitForIntLow(pdMS_TO_TICKS(1000)) &&
+    if (waitForInt(0, pdMS_TO_TICKS(1000)) &&
         spiTx(_interface, _csPin, len, pBuffer, 100) == SPI_OK) {
         written = (int)len;
     } else {

--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -16,14 +16,16 @@ Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
       _serviceTaskHandle(NULL),
       _eventCallback(NULL),
       _sensorCallback(NULL),
+      _cookie(nullptr),
       _initialized(false),
       _resetSeen(false) {
 }
 
 BmErr Bno085::init(sh2_EventCallback_t *eventCallback,
-                  sh2_SensorCallback_t *sensorCallback) {
+                  sh2_SensorCallback_t *sensorCallback, void *cookie) {
     _eventCallback = eventCallback;
     _sensorCallback = sensorCallback;
+    _cookie = cookie;
     printf("BNO085: Creating service task\n");
 
     return xTaskCreate(serviceTask, "BNO085", configMINIMAL_STACK_SIZE * 8,
@@ -90,7 +92,7 @@ void Bno085::serviceTask(void *arg) {
 
     // Set sensor callback
     if (instance->_sensorCallback) {
-        sh2_setSensorCallback(instance->_sensorCallback, NULL);
+        sh2_setSensorCallback(instance->_sensorCallback, instance->_cookie);
     }
 
     instance->_initialized = true;
@@ -166,7 +168,7 @@ void Bno085::eventHandler(void *cookie, sh2_AsyncEvent_t *event) {
         self->_resetSeen = true;   // serviceTask re-applies sensor config
     }
     if (self->_eventCallback) {
-        self->_eventCallback(self, event);   // forward to the app callback
+        self->_eventCallback(self->_cookie, event);   // forward to the app callback
     }
 }
 

--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -1,0 +1,233 @@
+#include "bno085.h"
+#include "uptime.h"
+#include "debug.h"
+#include "bsp.h"
+#include "string.h"
+#include "watchdog.h"
+
+// Initialize static instance pointer
+Bno085* Bno085::_instance = nullptr;
+
+Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
+               IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin)
+    : _interface(spi),
+      _csPin(csPin),
+      _intPin(intPin),
+      _rstPin(rstPin),
+      _bootPin(bootPin),
+      _wakePin(wakePin),
+      _serviceTaskHandle(NULL),
+      _eventCallback(NULL),
+      _sensorCallback(NULL),
+      _initialized(false),
+      _resetSeen(false) {
+         configASSERT(_instance == nullptr);
+         _instance = this;
+}
+
+bool Bno085::init(sh2_EventCallback_t *eventCallback,
+                  sh2_SensorCallback_t *sensorCallback) {
+    _eventCallback = eventCallback;
+    _sensorCallback = sensorCallback;
+    printf("BNO085: Creating service task\n");
+
+    return xTaskCreate(serviceTask, "BNO085", configMINIMAL_STACK_SIZE * 8,
+                       this, 21, &_serviceTaskHandle) == pdPASS;
+}
+
+bool Bno085::intCallback(const void *pinHandle, uint8_t value, void *args) {
+    (void)pinHandle; (void)value;
+    Bno085 *self = static_cast<Bno085 *>(args);
+    BaseType_t woken = pdFALSE;
+    if (self->_serviceTaskHandle) vTaskNotifyGiveFromISR(self->_serviceTaskHandle, &woken);
+    portYIELD_FROM_ISR(woken);
+    return woken == pdTRUE;
+}
+
+// Hardware reset + SPI startup state. Straps latch on the RISING edge of RST, so the bus must
+// be idle at that moment: WAKE and CS held high while releasing reset.
+bool Bno085::resetSensor() {
+    IOWrite(_bootPin, 1);
+    IOWrite(_wakePin, 1);
+    IOWrite(_csPin, 1);
+    IOWrite(_rstPin, 0);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    IOWrite(_rstPin, 1);
+    if (!waitForIntLow(pdMS_TO_TICKS(500))) {
+        printf("BNO085: reset - NO INT within 500ms\n");
+        return false;
+    }
+    printf("BNO085: reset - INT asserted OK\n");
+    return true;
+}
+
+bool Bno085::waitForIntLow(TickType_t timeout) {
+    TickType_t start = xTaskGetTickCount();
+    uint8_t level = 1;
+    do {
+        IORead(_intPin, &level);
+        if (!level) return true;
+        vTaskDelay(1);
+    } while ((xTaskGetTickCount() - start) < timeout);
+    return false;
+}
+
+void Bno085::serviceTask(void *arg) {
+    printf("BNO085: serviceTask started, calling sh2_open\n");
+    Bno085* instance = static_cast<Bno085*>(arg);
+
+    // Setup HAL
+    sh2_Hal_t hal = {};
+    hal.open = Bno085::open;
+    hal.close = Bno085::close;
+    hal.read = Bno085::read;
+    hal.write = Bno085::write;
+    hal.getTimeUs = Bno085::getTimeUs;
+
+    // Open sensor hub
+    int status = sh2_open(&hal, Bno085::eventHandler, instance);
+    if (status != SH2_OK) {
+        printf("BNO085: Failed to open sensor hub: %d\n", status);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    // Set sensor callback
+    if (instance->_sensorCallback) {
+        sh2_setSensorCallback(instance->_sensorCallback, NULL);
+    }
+
+    instance->_initialized = true;
+    // BM_INT is EXTI0/falling in the BSP; hook our handler onto it.
+    IORegisterCallback(instance->_intPin, Bno085::intCallback, instance);
+
+    instance->_resetSeen = false;
+    instance->enableSensors();
+
+    // Main service loop
+    while (1) {
+        // Wait for notification from ISR (INT pin asserted)
+        // Timeout after 100ms to periodically check even if no interrupt
+        ulTaskNotifyTake(pdTRUE, 100);
+
+        watchdogFeed();
+        sh2_service();
+
+        if (instance->_resetSeen) {
+            instance->_resetSeen = false;
+            printf("BNO085: reset detected - re-enabling sensors\n");
+            instance->enableSensors();
+        }
+    }
+}
+
+bool Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us) {
+    if (!_initialized) {
+        return false;
+    }
+
+    sh2_SensorConfig_t config = {};
+    config.reportInterval_us = reportInterval_us;
+
+    int status = sh2_setSensorConfig(sensorId, &config);
+    if (status != SH2_OK) {
+        printf("BNO085: sh2_setSensorConfig(id=%d) failed: %d\n", sensorId, status);
+        return false;
+    }
+    printf("BNO085: sh2_setSensorConfig(id=%d) OK\n", sensorId);
+    return true;
+}
+
+void Bno085::enableSensors() {
+    const struct { sh2_SensorId_t id; const char *name; } wanted[] = {
+        { SH2_ACCELEROMETER,             "accelerometer" },
+        { SH2_GYROSCOPE_CALIBRATED,      "gyroscope" },
+        { SH2_MAGNETIC_FIELD_CALIBRATED, "magnetometer" },
+    };
+    for (auto &w : wanted) {
+        if (configureSensor(w.id, 100000)) {   // 10 Hz
+            printf("BNO085: %s enabled @ 10 Hz\n", w.name);
+        } else {
+            printf("BNO085: failed to enable %s\n", w.name);
+        }
+    }
+}
+
+int Bno085::open(sh2_Hal_t *self) {
+    (void)self;
+    if (!_instance) return SH2_ERR;
+    return _instance->resetSensor() ? SH2_OK : SH2_ERR;
+}
+
+void Bno085::close(sh2_Hal_t *self) {
+    (void)self;
+    // Nothing special needed
+}
+
+void Bno085::eventHandler(void *cookie, sh2_AsyncEvent_t *event) {
+    Bno085 *self = static_cast<Bno085 *>(cookie);
+    if (!self || !event) return;
+    if (event->eventId == SH2_RESET) {
+        self->_resetSeen = true;   // serviceTask re-applies sensor config
+    }
+    if (self->_eventCallback) {
+        self->_eventCallback(self, event);   // forward to the app callback
+    }
+}
+
+int Bno085::read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len, uint32_t *t_us) {
+    (void)self;
+    // Use the static instance pointer
+    if (!_instance) {
+        return 0;
+    }
+    return _instance->readBytes(pBuffer, len, t_us);
+}
+
+int Bno085::write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len) {
+    (void)self;
+    // Use the static instance pointer
+    if (!_instance) {
+        return 0;
+    }
+    return _instance->writeBytes(pBuffer, len);
+}
+
+uint32_t Bno085::getTimeUs(sh2_Hal_t *self) {
+    (void)self;
+    return uptimeGetMs() * 1000;
+}
+
+// Instance methods
+int Bno085::readBytes(uint8_t *pBuffer, unsigned len, uint32_t *t_us) {
+    watchdogFeed();
+    uint8_t level = 1;
+    IORead(_intPin, &level);
+    if (level) {
+        return 0;   // no data available; let sh2_service poll again
+    }
+    memset(pBuffer, 0, len);
+
+    if (spiRx(_interface, _csPin, len, pBuffer, 100) != SPI_OK) {
+        printf("BNO085: spiRx FAILED\n");
+        return 0;
+    }
+    uint16_t cargoLength = (pBuffer[0] | (pBuffer[1] << 8)) & 0x7FFF;
+    if (cargoLength < 4 || cargoLength > len) return 0;
+    if (t_us) *t_us = uptimeGetMs() * 1000;
+    return cargoLength;
+}
+
+int Bno085::writeBytes(uint8_t *pBuffer, unsigned len) {
+    watchdogFeed();
+    IOWrite(_wakePin, 0);
+    int written = -1;
+    if (waitForIntLow(pdMS_TO_TICKS(1000)) &&
+        spiTx(_interface, _csPin, len, pBuffer, 100) == SPI_OK) {
+        written = (int)len;
+    } else {
+        printf("BNO085: TX failed (wake/SPI), len=%u\n", len);
+    }
+    IOWrite(_wakePin, 1);
+    return written;
+}

--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -32,7 +32,7 @@ bool Bno085::init(sh2_EventCallback_t *eventCallback,
     printf("BNO085: Creating service task\n");
 
     return xTaskCreate(serviceTask, "BNO085", configMINIMAL_STACK_SIZE * 8,
-                       this, 21, &_serviceTaskHandle) == pdPASS;
+                       this, BNO085_TASK_PRIORITY, &_serviceTaskHandle) == pdPASS;
 }
 
 bool Bno085::intCallback(const void *pinHandle, uint8_t value, void *args) {

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -1,0 +1,58 @@
+#pragma once
+extern "C" {
+  #include "sh2.h"
+  #include "sh2_hal.h"
+  #include "sh2_err.h"
+  #include "sh2_SensorValue.h"
+}
+#include "io.h"
+#include "protected_spi.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+class Bno085 {
+public:
+    // SPI bus + chip-select + INT + the three control pins (RST/BOOTN/WAKE)
+    Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
+           IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin);
+
+    bool init(sh2_EventCallback_t *eventCallback,
+              sh2_SensorCallback_t *sensorCallback);
+
+    bool configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
+
+    // HAL functions (called by sh2 library)
+    static int open(sh2_Hal_t *self);
+    static void close(sh2_Hal_t *self);
+    static int read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len, uint32_t *t_us);
+    static int write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
+    static uint32_t getTimeUs(sh2_Hal_t *self);
+
+private:
+    static void serviceTask(void *arg);
+    static bool intCallback(const void *pinHandle, uint8_t value, void *args);
+    static void eventHandler(void *cookie, sh2_AsyncEvent_t *event); // reset recovery
+
+    bool resetSensor();
+    bool waitForIntLow(TickType_t timeout);
+    int  readBytes(uint8_t *pBuffer, unsigned len, uint32_t *t_us);
+    int  writeBytes(uint8_t *pBuffer, unsigned len);
+    void enableSensors();
+
+    SPIInterface_t* _interface;
+    IOPinHandle_t *_csPin;
+    IOPinHandle_t *_intPin;
+    IOPinHandle_t *_rstPin;
+    IOPinHandle_t *_bootPin;
+    IOPinHandle_t *_wakePin;
+    TaskHandle_t _serviceTaskHandle;
+
+    sh2_EventCallback_t *_eventCallback;
+    sh2_SensorCallback_t *_sensorCallback;
+
+    bool _initialized;
+    bool _resetSeen;
+
+    // Static instance pointer for HAL callbacks
+    static Bno085* _instance;
+};

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -22,7 +22,7 @@ public:
            IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin);
 
     BmErr init(sh2_EventCallback_t *eventCallback,
-              sh2_SensorCallback_t *sensorCallback, void *cookie = nullptr);
+              sh2_SensorCallback_t *sensorCallback);
 
     BmErr configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
 private:
@@ -55,7 +55,6 @@ private:
 
     sh2_EventCallback_t *_eventCallback;
     sh2_SensorCallback_t *_sensorCallback;
-    void *_cookie;
 
     bool _initialized;
     bool _resetSeen;

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -22,7 +22,7 @@ public:
            IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin);
 
     BmErr init(sh2_EventCallback_t *eventCallback,
-              sh2_SensorCallback_t *sensorCallback);
+              sh2_SensorCallback_t *sensorCallback, void *cookie = nullptr);
 
     BmErr configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
 private:
@@ -55,6 +55,7 @@ private:
 
     sh2_EventCallback_t *_eventCallback;
     sh2_SensorCallback_t *_sensorCallback;
+    void *_cookie;
 
     bool _initialized;
     bool _resetSeen;

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -9,6 +9,7 @@ extern "C" {
 #include "protected_spi.h"
 #include "FreeRTOS.h"
 #include "task.h"
+#include "util.h"
 
 #ifndef BNO085_TASK_PRIORITY
 #define BNO085_TASK_PRIORITY 21
@@ -20,11 +21,11 @@ public:
     Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
            IOPinHandle_t *rstPin, IOPinHandle_t *bootPin, IOPinHandle_t *wakePin);
 
-    bool init(sh2_EventCallback_t *eventCallback,
+    BmErr init(sh2_EventCallback_t *eventCallback,
               sh2_SensorCallback_t *sensorCallback);
 
-    bool configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
-
+    BmErr configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
+private:
     // HAL functions (called by sh2 library)
     static int open(sh2_Hal_t *self);
     static void close(sh2_Hal_t *self);
@@ -32,18 +33,19 @@ public:
     static int write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
     static uint32_t getTimeUs(sh2_Hal_t *self);
 
-private:
     static void serviceTask(void *arg);
     static bool intCallback(const void *pinHandle, uint8_t value, void *args);
     static void eventHandler(void *cookie, sh2_AsyncEvent_t *event); // reset recovery
 
     bool resetSensor();
-    bool waitForIntLow(TickType_t timeout);
+    bool waitForInt(uint8_t level,TickType_t timeout);
     int  readBytes(uint8_t *pBuffer, unsigned len, uint32_t *t_us);
     int  writeBytes(uint8_t *pBuffer, unsigned len);
     void enableSensors();
 
+    sh2_Hal_t _hal;
     SPIInterface_t* _interface;
+
     IOPinHandle_t *_csPin;
     IOPinHandle_t *_intPin;
     IOPinHandle_t *_rstPin;
@@ -56,7 +58,4 @@ private:
 
     bool _initialized;
     bool _resetSeen;
-
-    // Static instance pointer for HAL callbacks
-    static Bno085* _instance;
 };

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -10,6 +10,10 @@ extern "C" {
 #include "FreeRTOS.h"
 #include "task.h"
 
+#ifndef BNO085_TASK_PRIORITY
+#define BNO085_TASK_PRIORITY 21
+#endif
+
 class Bno085 {
 public:
     // SPI bus + chip-select + INT + the three control pins (RST/BOOTN/WAKE)


### PR DESCRIPTION
## What changed?
Added a SPI driver for the BNO085 IMU and the CEVA sh2 submodule it depends on. It supports configurable sensor reports (accelerometer, gyroscope, magnetometer).

## How does it make Bristlemouth better?
Enables the BNO085 IMU on the Mote board over SPI. Previously the only BNO085 integration was I2C on the devkit. This is the reusable driver; app integration will come in follow-up PRs.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
