### PR TITLE
FIFO Fix To Update Control Registers

### DIFF
--- a/src/lib/common/serial.c
+++ b/src/lib/common/serial.c
@@ -262,11 +262,14 @@ void serialEnable(SerialHandle_t *handle) {
     if (handle->rxStreamBuffer) {
       xStreamBufferReset(handle->rxStreamBuffer);
       if (handle->fifoEnabled) {
+        // Control registers can only be written when peripheral is disabled
+        LL_USART_Disable(handle->device);
         LL_USART_EnableIT_IDLE(handle->device);
         LL_USART_EnableIT_RXFT(handle->device);
         LL_USART_EnableIT_RXFF(handle->device);
         LL_USART_SetRXFIFOThreshold(handle->device, LL_USART_FIFOTHRESHOLD_1_2);
         LL_USART_EnableFIFO(handle->device);
+        LL_USART_Enable(handle->device);
       } else {
         // Enable Uart RX interrupt
         usart_EnableIT_RXNE((USART_TypeDef *)handle->device);


### PR DESCRIPTION
## What changed?
Disable serial peripheral before updating FIFO registers.
Enable once done.


## How does it make Bristlemouth better?
Reduces the need for external code paths from `serialEnable` to disable and enable the uart peripheral.


## Where should reviewers focus?
Trivial change, but want to know if this is the best way to handle it. The peripheral could get disabled then enabled and the beginning and end of the functions respectively, but I feel like that changes the sequence of events for how other peripherals that do not utilize the FIFO.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
