### PR TITLE
BNO085 driver: configure SPI mode 3 and sample rate

### DIFF
--- a/src/lib/drivers/bno085.cpp
+++ b/src/lib/drivers/bno085.cpp
@@ -17,7 +17,8 @@ Bno085::Bno085(SPIInterface_t *spi, IOPinHandle_t *csPin, IOPinHandle_t *intPin,
       _eventCallback(NULL),
       _sensorCallback(NULL),
       _initialized(false),
-      _resetSeen(false) {
+      _resetSeen(false),
+      _reportInterval_us(100000) {
 }
 
 BmErr Bno085::init(sh2_EventCallback_t *eventCallback,
@@ -81,6 +82,7 @@ void Bno085::serviceTask(void *arg) {
     instance->_hal.read = Bno085::read;
     instance->_hal.write = Bno085::write;
     instance->_hal.getTimeUs = Bno085::getTimeUs;
+    instance->configureSpiMode();
     int status = sh2_open(&instance->_hal, Bno085::eventHandler, instance);
     if (status != SH2_OK) {
         printf("BNO085: Failed to open sensor hub: %d\n", status);
@@ -117,6 +119,12 @@ void Bno085::serviceTask(void *arg) {
     }
 }
 
+void Bno085::configureSpiMode() {
+    _interface->handle->Init.CLKPolarity = SPI_POLARITY_HIGH;  // CPOL = 1
+    _interface->handle->Init.CLKPhase    = SPI_PHASE_2EDGE;    // CPHA = 1  -> mode 3
+    HAL_SPI_Init(_interface->handle);
+}
+
 BmErr Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us) {
     if (!_initialized) {
         return BmENODEV;
@@ -134,6 +142,8 @@ BmErr Bno085::configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_u
     return BmOK;
 }
 
+void Bno085::setReportInterval(uint32_t interval_us) { _reportInterval_us = interval_us; }
+
 void Bno085::enableSensors() {
     const struct { sh2_SensorId_t id; const char *name; } wanted[] = {
         { SH2_ACCELEROMETER,             "accelerometer" },
@@ -141,8 +151,8 @@ void Bno085::enableSensors() {
         { SH2_MAGNETIC_FIELD_CALIBRATED, "magnetometer" },
     };
     for (auto &w : wanted) {
-        if (configureSensor(w.id, 100000) == BmOK) {   // 10 Hz
-            printf("BNO085: %s enabled @ 10 Hz\n", w.name);
+        if (configureSensor(w.id, _reportInterval_us) == BmOK) {
+            printf("BNO085: %s enabled @ %lu Hz\n", w.name, 1000000 / _reportInterval_us);
         } else {
             printf("BNO085: failed to enable %s\n", w.name);
         }

--- a/src/lib/drivers/bno085.h
+++ b/src/lib/drivers/bno085.h
@@ -25,6 +25,7 @@ public:
               sh2_SensorCallback_t *sensorCallback);
 
     BmErr configureSensor(sh2_SensorId_t sensorId, uint32_t reportInterval_us);
+    void setReportInterval(uint32_t interval_us);
 private:
     // HAL functions (called by sh2 library)
     static int open(sh2_Hal_t *self);
@@ -42,6 +43,7 @@ private:
     int  readBytes(uint8_t *pBuffer, unsigned len, uint32_t *t_us);
     int  writeBytes(uint8_t *pBuffer, unsigned len);
     void enableSensors();
+    void configureSpiMode();   // BNO085 requires SPI mode 3; BSP default is mode 0
 
     sh2_Hal_t _hal;
     SPIInterface_t* _interface;
@@ -58,4 +60,5 @@ private:
 
     bool _initialized;
     bool _resetSeen;
+    uint32_t _reportInterval_us;
 };


### PR DESCRIPTION
## What changed?
SPI mode is now set by the driver itself: configureSpiMode() runs at startup and puts the bus in mode 3, which the BNO085 requires. 
Report rate is now configurable: added setReportInterval() and a _reportInterval_us member.

## How does it make Bristlemouth better?
The driver is now more self-contained as it no longer depends on a board-wide SPI-mode change to work. Consumers can now pick a sample rate, making the driver reusable across applications.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
