### PR TITLE
Get Latest Timestamp In LIS2MDL/Sensor Hub Items For LSM6DSV

### DIFF
--- a/src/lib/drivers/abstract/abstract_st_sensor.h
+++ b/src/lib/drivers/abstract/abstract_st_sensor.h
@@ -43,7 +43,8 @@ public:
   // Used to set data for the sensor externally from the driver, this is useful
   // for sensor hub applications (where a sensor is accessed through another
   // sensor, such as the LSM6DSV)
-  virtual BmErr set_data(const uint8_t *buf, size_t len) {
+  virtual BmErr set_data(uint64_t timestamp_ns, const uint8_t *buf, size_t len) {
+    (void)timestamp_ns;
     (void)buf;
     (void)len;
     return BmOK;

--- a/src/lib/drivers/lis2mdl.cpp
+++ b/src/lib/drivers/lis2mdl.cpp
@@ -63,6 +63,7 @@ BmErr LIS2MDL::init(void) {
           sensor hub functionality. This will enqueue the data directly from
           there as it is required in AbstractSensorInterface. 
 
+ @param timestamp_ns timestamp in nanoseconds the reading was taken
  @param buf data received from the sensor hub
  @param len length of data in bytes
 
@@ -70,7 +71,7 @@ BmErr LIS2MDL::init(void) {
          BmEINVAL if input arguments are invalid
          BmENOMEM if not enough space in the queue's buffer for incoming data
  */
-BmErr LIS2MDL::set_data(const uint8_t *buf, size_t len) {
+BmErr LIS2MDL::set_data(uint64_t timestamp_ns, const uint8_t *buf, size_t len) {
 
   if (!buf || len < EXPECTED_DATA_LENGTH) {
     return BmEINVAL;
@@ -83,7 +84,7 @@ BmErr LIS2MDL::set_data(const uint8_t *buf, size_t len) {
   //TODO: should we put timestamps here?
   //
   LIS2MDLReading reading = {
-      .ns = 0,
+      .ns = timestamp_ns,
       .x = lis2mdl_from_lsb_to_mgauss(datax),
       .y = lis2mdl_from_lsb_to_mgauss(datay),
       .z = lis2mdl_from_lsb_to_mgauss(dataz),

--- a/src/lib/drivers/lis2mdl.h
+++ b/src/lib/drivers/lis2mdl.h
@@ -20,7 +20,7 @@ public:
 
   using AbstractSensorInterface::AbstractSensorInterface;
   BmErr init(void) override;
-  BmErr set_data(const uint8_t *buf, size_t len) override;
+  BmErr set_data(uint64_t timestamp_ns, const uint8_t *buf, size_t len) override;
   BmErr get_reading(LIS2MDLReading *reading);
 
   LSM6DSV::LSM6DSVSensorHub m_sensor_hub = {

--- a/src/lib/drivers/lsm6dsv.cpp
+++ b/src/lib/drivers/lsm6dsv.cpp
@@ -432,7 +432,8 @@ BmErr LSM6DSV::stream_handle(void) {
       uint8_t sensor_set_idx = tag - LSM6DSV_SENSORHUB_SLAVE0_TAG;
       AbstractSensorInterface *sensor = m_sensor_hub[sensor_set_idx].sensor;
       if (sensor) {
-        sensor->set_data(data, data_byte_count);
+        // Use the latest sample's timestamp
+        sensor->set_data(reading.ns, data, data_byte_count);
       }
     }
   }


### PR DESCRIPTION
## What changed?
Adds logic to allow for LSM6DSV's sensor hub items to have timestamps associated with their reading.


## How does it make Bristlemouth better?
Provides a timestamp with sensor hub readings to correlate when the reading was taken.


## Where should reviewers focus?
The LSM6DSV's driver will attempt to sample the sensor hub at a rate as close to the sampling done for the accelerometer and gyroscope, meaning the timestamps should be fairly accurate. Let me know your thoughts on this (@mbella-sofar).


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
