### PR TITLE
Adds a serial_example config for the spotter_log_console period

### DIFF
--- a/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
+++ b/src/apps/bm_devkit/serial_payload_example/user_code/user_code.cpp
@@ -12,6 +12,7 @@
 #include "task_priorities.h"
 #include "uptime.h"
 #include "usart.h"
+#define DEFAULT_CONSOLE_PRINT_INTERVAL_MS 10000
 
 #define LED_ON_TIME_MS 20
 #define LED_PERIOD_MS 1000
@@ -19,6 +20,7 @@
 #define DEFAULT_LINE_TERM 10 // newline, '\n', 0x0A
 #define BYTES_CLUSTER_MS 50  // used for console printing convenience
 #define DEFAULT_UART_MODE MODE_RS232
+static u_int32_t console_print_interval_ms_config = DEFAULT_CONSOLE_PRINT_INTERVAL_MS;
 
 // A timer variable we can set to trigger a pulse on LED2 when we get payload serial data
 static int32_t ledLinePulse = -1;
@@ -37,6 +39,8 @@ void setup(void) {
   get_config_uint(BM_CFG_PARTITION_USER, "plUartLineTerm", strlen("plUartLineTerm"),
                   &line_term_config);
   get_config_uint(BM_CFG_PARTITION_USER, "plUartMode", strlen("plUartMode"), &uart_mode_config);
+  get_config_uint(BM_CFG_PARTITION_USER, "plConsolePeriodMs", strlen("plConsolePeriodMs"),
+                  &console_print_interval_ms_config);
   if (uart_mode_config >= MODE_MAX) {
     printf("ERROR - PLUART UART MODE %lu is not supported. Reverting to MODE_RS232\n",
            uart_mode_config);
@@ -176,8 +180,14 @@ void loop(void) {
     // Print the payload data to a file, to the spotter_log_console console, and to the printf console.
     spotter_log(0, "payload_data.log", USE_TIMESTAMP, "tick: %llu, rtc: %s, line: %.*s\n",
                uptimeGetMs(), rtcTimeBuffer, read_len, payload_buffer);
-    spotter_log_console(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(), rtcTimeBuffer,
-              read_len, payload_buffer);
+    static u_int32_t last_console_print_ms = 0;
+    u_int32_t now_ms = (u_int32_t)uptimeGetMs();
+    if (console_print_interval_ms_config == 0 ||
+        (now_ms - last_console_print_ms) >= console_print_interval_ms_config) {
+      last_console_print_ms = now_ms;
+      spotter_log_console(0, "[payload] | tick: %llu, rtc: %s, line: %.*s", uptimeGetMs(),
+                          rtcTimeBuffer, read_len, payload_buffer);
+    }
     printf("[payload-line] | tick: %llu, rtc: %s, line: %.*s\n", uptimeGetMs(), rtcTimeBuffer,
            read_len, payload_buffer);
 


### PR DESCRIPTION
## What changed?
Added a user-partition config, plConsolePeriodMs, that sets the minimum time (ms) between [payload] lines sent to the Spotter console via spotter_log_console.

Usage:
bm cfg set <serial_example_node_id> u u plConsolePeriodMs 10000
bm cfg commit <serial_example_node_id> u

## How does it make Bristlemouth better?
A fast payload sensor floods the Spotter console with [payload] lines, making it hard to read output or type bm/cfg commands during devkit work. This gives users a runtime knob to slow the console spam without losing any logged data and without editing/reflashing firmware.

## Where should reviewers focus?
This is a quality of life change and would help users not have so much console noise during the [RS232 Guide](https://bristlemouth.notion.site/Bristlemouth-Dev-Kit-Guide-Integrating-an-RS232-Serial-Sensor-8d5658a0b51a4b238a716ed8ef10539d). 

As the guides are currently being updated, this change may not land until a later Bristlemouth update. Another way to use this code would be to directly include it in the guide, teaching the user how to add a config themselves. Since the guide and this change are both fairly lightweight, this is a viable option.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
