### PR TITLE
chore: ignore user presets and worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ doc/
 *.idea*
 tmpbuild_*/
 *.pyc
+.worktrees
 
 *.swp
 .cache/
@@ -19,6 +20,7 @@ tools/bin/mpy-cross
 cli-cmake-debug-build/
 *build/
 preset-builds
+CMakeUserPresets.json
 
 src/bsp/pluteus_v3.1/*.s
 src/bsp/pluteus_v3.1/*.ld

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -90,7 +90,7 @@
             "cacheVariables": {
                 "APP": "bringup_bridge",
                 "BSP": "bridge_v1_0"
-                }
+            }
         },
         {
             "name": "bringup-mote",


### PR DESCRIPTION
## What changed?

Ignored `CMakeUserPresets.json` and `.worktrees`.

## How does it make Bristlemouth better?

Allows one to set up personal cmake presets that aren't meant to be shared, for example if they depend on file paths unique to the local machine.

In particular this has helped me by allowing my working copy to be clean, so that I don't get "dirty" encoded into firmware versions that I'm testing. I previously had a handful of unique presets as well as worktrees shown in `git status` output.

## Where should reviewers focus?

Rubber stamp. The changes to .gitignore are the only meaningful ones. The changes to CMakePresets.json are whitespace only, from automatic formatter in VS Code.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
