### PR TITLE
Updates borealis2 commit hash to latest main

### DIFF
--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -160,7 +160,7 @@
 - name: borealis2
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
-  sha: 624b349
+  sha: aefeefa
   args:
     app: borealis2
     bsp: bm_mote_v1.0


### PR DESCRIPTION
## What changed?
Uses latest borealis2 commit hash.


## How does it make Bristlemouth better?
Allows for a release candidate with the latest borealis2 mote code.


## Where should reviewers focus?
Validate it aligns with the latest borealis2 main commit hash.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
