### PR TITLE
Add Sensor Sampler To Sample Keller Sensor

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -99,6 +99,7 @@ set(LIB_FILES
     ${LIB_DIR}/sensor_sampler/sensorSampler.cpp
     ${LIB_DIR}/sensor_sampler/powerSampler.cpp
     ${LIB_DIR}/sensor_sampler/htuSampler.cpp
+    ${LIB_DIR}/sensor_sampler/kellerSampler.cpp
     ${LIB_DIR}/sensor_sampler/loadCellSampler.cpp
     ${LIB_DIR}/sensor_sampler/pressureSampler.cpp
     ${TINYUSB_FILES}

--- a/src/lib/drivers/protected/protected_i2c.h
+++ b/src/lib/drivers/protected/protected_i2c.h
@@ -31,8 +31,8 @@ typedef struct {
 
 bool i2cInit(I2CInterface_t *interface);
 I2CResponse_t i2cTxRx(I2CInterface_t *interface, uint8_t address, uint8_t *txBuff, size_t txLen, uint8_t *rxBuff, size_t rxLen, uint32_t timeoutMs);
-#define i2cTx(interface, address, buff, len, timeout) i2cTxRx(interface, address, buff, len, NULL, 0, timeout);
-#define i2cRx(interface, address, buff, len, timeout) i2cTxRx(interface, address, NULL, 0, buff, len, timeout);
+#define i2cTx(interface, address, buff, len, timeout) i2cTxRx(interface, address, buff, len, NULL, 0, timeout)
+#define i2cRx(interface, address, buff, len, timeout) i2cTxRx(interface, address, NULL, 0, buff, len, timeout)
 I2CResponse_t i2cProbe(I2CInterface_t *interface, uint8_t address, uint32_t timeoutMs);
 void i2cLoadLogCfg();
 

--- a/src/lib/sensor_sampler/kellerSampler.cpp
+++ b/src/lib/sensor_sampler/kellerSampler.cpp
@@ -1,0 +1,138 @@
+#include "kellerSampler.h"
+#include "task.h"
+#include "uptime.h"
+
+#ifndef KELLER_TASK_PRIORITY
+#define KELLER_TASK_PRIORITY 2
+#endif
+
+KellerSampler::KellerSampler(I2CInterface_t *i2c, IOPinHandle_t *int_pin, KellerSamplerCb cb)
+    : m_xld(this, NULL) {
+  m_ctx.i2c = i2c;
+  m_ctx.isr = int_pin;
+  m_ctx.cb = cb;
+}
+
+/*!
+ @brief Set the configuration used for the Keller sensor
+
+ @details Must be invoked before keller_sampler_add
+
+ @param cfg Configuration to set
+ */
+void KellerSampler::set_cfg(KellerSamplerCfg cfg) { m_cfg = cfg; }
+
+/*!
+ @brief Begin sensor communication handler
+ */
+void KellerSampler::begin(void) {}
+
+/*!
+ @brief Read from the sensor using I2C
+
+ @details The LSM6DSV requires the most significant bit to be set to 1 in order
+          to indicate a read from the device.
+
+ @param address Device address to read
+ @param buf Buffer size
+ @param len Length of buffer
+ @param arg unused
+
+ @return BmOK on success
+         BmErr on failure
+ */
+BmErr KellerSampler::read(uint8_t address, uint8_t *buf, size_t len, void *arg) {
+  (void)arg;
+
+  return static_cast<BmErr>(i2cRx(m_ctx.i2c, address, buf, len, 100));
+}
+
+/*!
+ @brief Write to the sensor using I2C
+
+ @param address Device address to write
+ @param buf Buffer size
+ @param len Length of buffer
+ @param arg unused
+
+ @return BmOK on success
+         BmErr on failure
+ */
+BmErr KellerSampler::write(uint8_t address, const uint8_t *buf, size_t len, void *arg) {
+  (void)arg;
+
+  return static_cast<BmErr>(i2cTx(m_ctx.i2c, address, const_cast<uint8_t *>(buf), len, 100));
+}
+
+/*!
+ @brief End sensor communication handler
+ */
+void KellerSampler::end(void) {}
+
+static bool xld_isr_handle(const void *pin, uint8_t value, void *args) {
+  (void)pin;
+  KellerSampler *sampler = static_cast<KellerSampler *>(args);
+
+  // Active high interrupt
+  if (value) {
+    sampler->m_xld.handle_interrupt();
+  }
+
+  return true;
+}
+
+/*!
+ @brief Keller sensor task
+
+ @details Will initialize/configure and handle taking readings from the sensor.
+
+ @param arg Sampler instance
+ */
+static void keller_task(void *arg) {
+  KellerSampler *sampler = static_cast<KellerSampler *>(arg);
+  XLD *xld = &sampler->m_xld;
+  KellerSamplerCb cb = sampler->m_ctx.cb;
+  uint32_t delay_ms = 1000 / sampler->m_cfg.sample_rate;
+
+  if (xld->init() != BmOK) {
+    vTaskDelete(NULL);
+    return;
+  }
+
+  float mbar;
+  float temp;
+  while (1) {
+    uint32_t uptime_begin = uptimeGetMs();
+    xld->request_reading();
+    if (xld->get_reading(&mbar, &temp) == BmOK && cb) {
+      cb(mbar, temp);
+    }
+    uint32_t uptime_end = uptimeGetMs();
+
+    // Delay taking in account the time needed for conversion
+    bm_delay(delay_ms - (uptime_end - uptime_begin));
+  }
+}
+
+/*!
+ @brief Add a keller sensor sampler
+
+ @details Configures interrupt for the sampler ISR pin and creates an instance
+          of a keller_task.
+
+ @param sampler Sampler instance to begin sampling
+
+ @return BmOK on success
+         BmErr on failure
+ */
+BmErr keller_sampler_add(KellerSampler *sampler) {
+  constexpr uint8_t max_sample_rate = 125;
+  if (!sampler || sampler->m_cfg.sample_rate > max_sample_rate) {
+    return BmEINVAL;
+  }
+
+  IORegisterCallback(sampler->m_ctx.isr, xld_isr_handle, sampler);
+
+  static constexpr uint32_t stack_size = 512;
+  return bm_task_create(keller_task, "keller", stack_size, sampler, KELLER_TASK_PRIORITY, NULL);
+}

--- a/src/lib/sensor_sampler/kellerSampler.h
+++ b/src/lib/sensor_sampler/kellerSampler.h
@@ -1,0 +1,42 @@
+#ifndef __KELLER_SAMPLER_H__
+#define __KELLER_SAMPLER_H__
+
+#include "io.h"
+#include "protected_i2c.h"
+#include "xld.h"
+
+typedef void (*KellerSamplerCb)(float mbar, float temp);
+typedef struct {
+  uint32_t sample_rate;
+} KellerSamplerCfg;
+
+class KellerSampler : public SensorInterfaceBus {
+public:
+  KellerSampler(I2CInterface_t *i2c, IOPinHandle_t *int_pin, KellerSamplerCb cb);
+
+  void set_cfg(KellerSamplerCfg cfg);
+
+  XLD m_xld;
+  struct {
+    I2CInterface_t *i2c;
+    IOPinHandle_t *isr;
+    KellerSamplerCb cb;
+  } m_ctx;
+
+  KellerSamplerCfg m_cfg = {
+      .sample_rate = 10,
+  };
+
+private:
+  // Max sample rate in hz
+  static constexpr uint8_t MAX_SAMPLE_RATE = 125;
+
+  void begin(void) override;
+  BmErr read(uint8_t address, uint8_t *buf, size_t len, void *arg) override;
+  BmErr write(uint8_t address, const uint8_t *buf, size_t len, void *arg) override;
+  void end(void) override;
+};
+
+BmErr keller_sampler_add(KellerSampler *sampler);
+
+#endif


### PR DESCRIPTION
## What changed?
Adds sampler to read from Keller XLD sensor devices.


## How does it make Bristlemouth better?
Allows applications to run a task that handles reading from Keller sensors.


## Where should reviewers focus?
I am not leveraging the `sensorSampler` here, but rather creating my own separate task.
This is mainly to avoid inducing latency when accessing other sensors as each read in the `sensorSampler` task is blocking and it takes up to 8ms to read from the Keller sensor.
Let me know your thoughts on this approach.

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
