### PR TITLE
Reserve NUL byte in network config log chunk buffer

### DIFF
--- a/src/apps/bridge/network_config_logger.cpp
+++ b/src/apps/bridge/network_config_logger.cpp
@@ -24,7 +24,7 @@ static CborError print_stream_handler(void *out, const char *fmt, ...) {
   size_t space_left = CHUNK_SIZE - state->pos;
 
   // If cannot fit into chunked buffer, send now
-  if (space_left < static_cast<size_t>(n)) {
+  if (space_left < static_cast<size_t>(n) + 1) {
     size_t to_write = state->pos;
     bridgeLogPrint(BRIDGE_CFG, BM_COMMON_LOG_LEVEL_INFO, NO_HEADER, "%.*s", to_write,
                    state->buf);


### PR DESCRIPTION
## What changed?

`print_stream_handler` (network_config_logger.cpp) now reserves a byte for the NUL terminator in its chunk-flush test:

## How does it make Bristlemouth better?

`vsnprintf` reserves a byte for the NUL, so the old code dropped one character at every 1024-byte boundary of the `Bridge network config:` log line.

## Where should reviewers focus?

The branch guarantees `space_left >= n + 1`, so every fragment is written in full and `state->pos` stays correct.

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
