### PR TITLE
Adds a memory_stats metrics component

### DIFF
--- a/src/apps/bm_devkit/bmdk_common/app_main.cpp
+++ b/src/apps/bm_devkit/bmdk_common/app_main.cpp
@@ -42,6 +42,7 @@ extern "C" {
 #include "gpdma.h"
 #include "gpioISR.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "ms5803.h"
 #include "nvmPartition.h"
 #include "pca9535.h"
@@ -392,6 +393,9 @@ static void defaultTask(void *parameters) {
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
   bcl_init();
+#if (bm_metrics_enabled != 0)
+  memory_metrics_init();
+#endif
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
                   strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsCheckIntervalS",

--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -38,6 +38,7 @@
 #include "gpioISR.h"
 #include "l2.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "ms5803.h"
 #include "nvmPartition.h"
 #include "pca9535.h"
@@ -389,6 +390,9 @@ static void defaultTask(void *parameters) {
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugDfuInit(&dfu_partition);
   bcl_init();
+#if (bm_metrics_enabled != 0)
+  memory_metrics_init();
+#endif
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
                   strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsCheckIntervalS",

--- a/src/apps/bridge/app_main.cpp
+++ b/src/apps/bridge/app_main.cpp
@@ -45,6 +45,7 @@
 #include "gpioISR.h"
 #include "l2.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "messages/neighbors.h"
 #include "metrics_sampler.h"
 #include "ncp_uart.h"
@@ -445,7 +446,8 @@ static void defaultTask(void *parameters) {
   topology_sampler_init(&bridge_power_controller);
   #if (bm_metrics_enabled != 0)
   metrics_sampler_init();
-  #endif
+  memory_metrics_init();
+#endif
   debug_ncp_init();
   debugBmServiceInit();
   sys_info_service_init();

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -38,6 +38,7 @@
 #include "l2.h"
 #include "loadCellSampler.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "ms5803.h"
 #include "nvmPartition.h"
 #include "pca9535.h"
@@ -364,6 +365,9 @@ static void defaultTask(void *parameters) {
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
   bcl_init();
+#if (bm_metrics_enabled != 0)
+  memory_metrics_init();
+#endif
   debugConfigurationInit();
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
                   strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -37,6 +37,7 @@
 #include "gpioISR.h"
 #include "l2.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "ms5803.h"
 #include "nvmPartition.h"
 #include "pca9535.h"
@@ -362,6 +363,9 @@ static void defaultTask(void *parameters) {
   debugNvmCliInit(&debug_cli_partition, &dfu_partition);
   debugDfuInit(&dfu_partition);
   bcl_init();
+#if (bm_metrics_enabled != 0)
+  memory_metrics_init();
+#endif
   debugConfigurationInit();
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
                   strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -36,6 +36,7 @@
 #include "gpioISR.h"
 #include "l2.h"
 #include "memfault_platform_core.h"
+#include "memory_metrics.h"
 #include "nvmPartition.h"
 #include "pcap.h"
 #include "printf.h"
@@ -310,6 +311,9 @@ static void defaultTask(void *parameters) {
   debugPlUartCliInit();
   debugDfuInit(&dfu_partition);
   bcl_init();
+#if (bm_metrics_enabled != 0)
+  memory_metrics_init();
+#endif
   debugConfigurationInit();
   get_config_uint(BM_CFG_PARTITION_SYSTEM, "sensorsPollIntervalMs",
                   strlen("sensorsPollIntervalMs"), &sys_cfg_sensorsPollIntervalMs);

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIB_FILES
     ${LIB_DIR}/common/OrderedSeparatorLineParser.cpp
     ${LIB_DIR}/common/lpm_u5.c
     ${LIB_DIR}/common/lptimTick_u5.c
+    ${LIB_DIR}/common/memory_metrics.c
     ${LIB_DIR}/common/metrics_log.cpp
     ${LIB_DIR}/common/nvmPartition.cpp
     ${LIB_DIR}/common/pcap.c

--- a/src/lib/common/memory_metrics.c
+++ b/src/lib/common/memory_metrics.c
@@ -1,0 +1,60 @@
+#include "memory_metrics.h"
+#include "bm_messages_helper.h"
+#include "FreeRTOS.h"
+#include "metrics_service.h"
+#include "util.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#define MEMORY_COMPONENT_KEY "memory_stats"
+
+typedef struct {
+  uint32_t heap_free; // bytes currently available
+  uint32_t heap_min_free; // low-water mark of available bytes (leak signal)
+  uint32_t heap_largest_block; // largest contiguous free block (fragmentation)
+  uint32_t heap_total_allocs;  // cumulative successful pvPortMalloc calls since boot
+  uint32_t heap_total_frees;   // cumulative successful vPortFree calls since boot
+} MemoryValues;
+
+typedef struct {
+  const char *name;
+  BmField type;
+  size_t offset; // location of the value within MemoryValues
+} MemoryFieldDesc;
+
+static const MemoryFieldDesc mem_fields[] = {
+  {"heap_free", BM_FIELD_UINT32, offsetof(MemoryValues, heap_free)},
+  {"heap_min_free", BM_FIELD_UINT32, offsetof(MemoryValues, heap_min_free)},
+  {"heap_largest_block", BM_FIELD_UINT32, offsetof(MemoryValues, heap_largest_block)},
+  {"heap_total_allocs", BM_FIELD_UINT32, offsetof(MemoryValues, heap_total_allocs)},
+  {"heap_total_frees", BM_FIELD_UINT32, offsetof(MemoryValues, heap_total_frees)},
+};
+
+#define MEMORY_FIELD_COUNT array_size(mem_fields)
+
+static MemoryValues mem_values;
+static BmEncoderTableEntry mem_lut[MEMORY_FIELD_COUNT];
+
+static BmErr memory_metrics_data(const char *metric_key, const BmEncoderTableEntry **lut,
+                                 size_t *num_fields) {
+  (void)metric_key;
+  HeapStats_t s;
+  vPortGetHeapStats(&s);
+  mem_values.heap_free = (uint32_t)s.xAvailableHeapSpaceInBytes;
+  mem_values.heap_min_free = (uint32_t)s.xMinimumEverFreeBytesRemaining;
+  mem_values.heap_largest_block = (uint32_t)s.xSizeOfLargestFreeBlockInBytes;
+
+  *lut = mem_lut;
+  *num_fields = MEMORY_FIELD_COUNT;
+  return BmOK;
+}
+
+BmErr memory_metrics_init(void) {
+  for (size_t f = 0; f < MEMORY_FIELD_COUNT; f++) {
+    mem_lut[f].key = mem_fields[f].name;
+    mem_lut[f].type = mem_fields[f].type;
+    mem_lut[f].value_source = (const uint8_t *)&mem_values + mem_fields[f].offset;
+  }
+  return metrics_service_add_component(MEMORY_COMPONENT_KEY, memory_metrics_data,
+                                       MEMORY_FIELD_COUNT);
+}

--- a/src/lib/common/memory_metrics.c
+++ b/src/lib/common/memory_metrics.c
@@ -43,6 +43,8 @@ static BmErr memory_metrics_data(const char *metric_key, const BmEncoderTableEnt
   mem_values.heap_free = (uint32_t)s.xAvailableHeapSpaceInBytes;
   mem_values.heap_min_free = (uint32_t)s.xMinimumEverFreeBytesRemaining;
   mem_values.heap_largest_block = (uint32_t)s.xSizeOfLargestFreeBlockInBytes;
+  mem_values.heap_total_allocs = (uint32_t)s.xNumberOfSuccessfulAllocations;
+  mem_values.heap_total_frees = (uint32_t)s.xNumberOfSuccessfulFrees;
 
   *lut = mem_lut;
   *num_fields = MEMORY_FIELD_COUNT;

--- a/src/lib/common/memory_metrics.h
+++ b/src/lib/common/memory_metrics.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "util.h"
+
+BmErr memory_metrics_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tools/scripts/misc/decode_metrics.py
+++ b/tools/scripts/misc/decode_metrics.py
@@ -3,6 +3,7 @@ import base64
 import re
 import pandas as pd
 import cbor2
+from datetime import datetime, timezone
 
 LINK_QUALITY = {0: "poor", 1: "marginal", 2: "good"}
 LINE_RE = re.compile(r"^(?P<ts>\S+)\s*\|\s*(?P<node>\S+)/metrics\s+(?P<b64>[A-Za-z0-9+/=]+)")
@@ -28,8 +29,27 @@ port, "adin_port_stats_<port>", with these fields (cumulative since boot):
   algn - frame alignment-error count
 Note: an idle port with no link partner reports sqi=7/mse=0 - not a real "good" link.
 Counters are monotonic; diff consecutive samples per (node, component) for a rate.
-The leading log field is a millisecond tick from the bridge (not wall-clock time).
+The leading log field is added by the Spotter: either a boot-
+relative millisecond tick (RTC-less) or an ISO-8601 UTC timestamp (GPS/RTC time).
 """
+
+
+def _parse_log_time(ts: str):
+    """Parse the Spotter's leading log field.
+
+    Returns (tick_ms, timestamp_utc):
+      tick_ms       - milliseconds; a boot-relative tick, or Unix epoch ms when the
+                      source is a UTC timestamp.
+      timestamp_utc - ISO-8601 UTC string when wall-clock time is available, else None.
+    """
+    tick = ts.rstrip("t")
+    if tick.isdigit():
+        return int(tick), None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return int(dt.timestamp() * 1000), dt.astimezone(timezone.utc).isoformat()
+    except ValueError:
+        return None, None
 
 
 def load_metrics(log_path: str) -> pd.DataFrame:
@@ -43,9 +63,7 @@ def load_metrics(log_path: str) -> pd.DataFrame:
                 env = cbor2.loads(base64.b64decode(m.group("b64")))
             except Exception:
                 continue  # skip malformed lines
-
-            tick = m.group("ts").rstrip("t")
-            tick_ms = int(tick) if tick.isdigit() else None
+            tick_ms, timestamp_utc = _parse_log_time(m.group("ts"))
             node = env.get("node_id")
             node_id = f"{node:016x}" if isinstance(node, int) else m.group("node")
 
@@ -56,6 +74,7 @@ def load_metrics(log_path: str) -> pd.DataFrame:
                     continue
                 row = {
                     "tick_ms": tick_ms,
+                    "timestamp_utc": timestamp_utc,
                     "node_id": node_id,
                     "version": env.get("version"),
                     "uptime_ms": env.get("uptime_ms"),

--- a/tools/scripts/misc/decode_metrics.py
+++ b/tools/scripts/misc/decode_metrics.py
@@ -1,105 +1,84 @@
+"""
+Decode a Bristlemouth network_metrics.log to CSV for inspection.
+
+ADIN component "adin_port_stats_<port>" fields (cumulative since boot):
+  sqi/mse/lq/rxe/sye/fc/len/algn  (see the shared decoder for meaning)
+  mse==0 means no link partner even though lq/sqi read "good".
+"""
+
 import argparse
-import base64
-import re
+import sys
+from pathlib import Path
 import pandas as pd
-import cbor2
-from datetime import datetime, timezone
+
+# Shared, canonical decoder lives with the schema (vendored via bm_core).
+
+sys.path.append(
+    str(
+        Path(__file__).resolve().parents[3] / "src/lib/bm_core/bm_common_messages/tools"
+    )
+)
+from decode_metrics_log import decode_metrics_log
 
 LINK_QUALITY = {0: "poor", 1: "marginal", 2: "good"}
-LINE_RE = re.compile(r"^(?P<ts>\S+)\s*\|\s*(?P<node>\S+)/metrics\s+(?P<b64>[A-Za-z0-9+/=]+)")
-
-"""
-Each reply is a base64-encoded CBOR envelope:
-  { "version": <v>, "node_id": <id>, "uptime_ms": <ms>,
-    "data": { "<component>": { "<field>": <value>, ... }, ... } }
-
-The decoder is generic: every component becomes a row and its fields become
-columns, so new component types are captured with no changes here. Component-
-specific niceties are layered on top only where they apply (see load_metrics).
-
-Today the only producer is the ADIN2111 driver, which reports one component per
-port, "adin_port_stats_<port>", with these fields (cumulative since boot):
-  sqi  - Signal Quality Indicator 0-7 (7 best)
-  mse  - raw MSE_VAL register (lower = cleaner signal; no units)
-  lq   - link quality enum: 0 poor / 1 marginal / 2 good
-  rxe  - frame-check RX (bad-CRC) error count
-  sye  - symbol error count
-  fc   - false-carrier count (noise on an idle line)
-  len  - frame length-error count
-  algn - frame alignment-error count
-Note: an idle port with no link partner reports sqi=7/mse=0 - not a real "good" link.
-Counters are monotonic; diff consecutive samples per (node, component) for a rate.
-The leading log field is added by the Spotter: either a boot-
-relative millisecond tick (RTC-less) or an ISO-8601 UTC timestamp (GPS/RTC time).
-"""
 
 
-def _parse_log_time(ts: str):
-    """Parse the Spotter's leading log field.
+def load_metrics_by_component(log_path: str) -> dict[str, pd.DataFrame]:
+    """Decode a network_metrics.log into one DataFrame per component family."""
+    groups: dict[str, list[dict]] = {}
+    for r in decode_metrics_log(log_path):
+        comp = r["component"]
+        # Fold a trailing "_<n>" into a `port` column
+        family, _, tail = comp.rpartition("_")
+        if family and tail.isdigit():
+            port = int(tail)
+        else:
+            family, port = comp, None
 
-    Returns (tick_ms, timestamp_utc):
-      tick_ms       - milliseconds; a boot-relative tick, or Unix epoch ms when the
-                      source is a UTC timestamp.
-      timestamp_utc - ISO-8601 UTC string when wall-clock time is available, else None.
-    """
-    tick = ts.rstrip("t")
-    if tick.isdigit():
-        return int(tick), None
-    try:
-        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        return int(dt.timestamp() * 1000), dt.astimezone(timezone.utc).isoformat()
-    except ValueError:
-        return None, None
+        row = {
+            "tick_ms": r["tick_ms"],
+            "timestamp_utc": r["timestamp_utc"],
+            "node_id": r["node_id"],
+            "version": r["version"],
+            "uptime_ms": r["uptime_ms"],
+        }
+        if port is not None:
+            row["port"] = port
+        fields = r["fields"]
+        row.update(fields)
+        if "lq" in fields:
+            row["lq_label"] = (
+                "no-link"
+                if fields.get("mse") == 0
+                else LINK_QUALITY.get(fields["lq"], "?")
+            )
+        groups.setdefault(family, []).append(row)
 
-
-def load_metrics(log_path: str) -> pd.DataFrame:
-    rows = []
-    with open(log_path, "r") as f:
-        for line in f:
-            m = LINE_RE.match(line)
-            if not m:
-                continue
-            try:
-                env = cbor2.loads(base64.b64decode(m.group("b64")))
-            except Exception:
-                continue  # skip malformed lines
-            tick_ms, timestamp_utc = _parse_log_time(m.group("ts"))
-            node = env.get("node_id")
-            node_id = f"{node:016x}" if isinstance(node, int) else m.group("node")
-
-            # Generic: every component becomes a row and its fields become
-            # columns, so new component types need no changes here.
-            for component, fields in env.get("data", {}).items():
-                if not isinstance(fields, dict):
-                    continue
-                row = {
-                    "tick_ms": tick_ms,
-                    "timestamp_utc": timestamp_utc,
-                    "node_id": node_id,
-                    "version": env.get("version"),
-                    "uptime_ms": env.get("uptime_ms"),
-                    "component": component,
-                }
-                row.update(fields)
-                # Component-specific niceties, added only where they apply:
-                if component.startswith("adin_port_stats_"):
-                    row["port"] = int(component.rsplit("_", 1)[1])
-                if "lq" in fields:
-                     # mse==0 means no link partner (idle port), even though lq/sqi read "good"
-                    row["lq_label"] = "no-link" if fields.get("mse") == 0 else LINK_QUALITY.get(fields["lq"], "?")
-                rows.append(row)
-    return pd.DataFrame(rows)
+    tables = {}
+    for name, rows in groups.items():
+        df = pd.DataFrame(rows).dropna(axis=1, how="all")  # drop empty columns
+        sort_cols = [c for c in ("node_id", "port", "tick_ms") if c in df.columns]
+        tables[name] = df.sort_values(sort_cols).reset_index(drop=True)
+    return tables
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Decode a Bristlemouth network_metrics.log")
+    parser = argparse.ArgumentParser(
+        description="Decode a Bristlemouth network_metrics.log to per-component CSVs"
+    )
     parser.add_argument("log_file", help="path to network_metrics.log")
     args = parser.parse_args()
 
-    df = load_metrics(args.log_file)
-    csv_path = args.log_file.rsplit(".", 1)[0] + ".csv"
-    df.to_csv(csv_path, index=False)
-    print(f"Wrote {csv_path} ({len(df)} rows)")
+    base = args.log_file.rsplit(".", 1)[0]
+    tables = load_metrics_by_component(args.log_file)
+    if not tables:
+        print("No decodable metrics found.")
+        return
+    for name, df in tables.items():
+        out = f"{base}_{name}.csv"
+        df.to_csv(out, index=False)
+        print(f"Wrote {out} ({len(df)} rows)")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What changed?

- Adds a `memory_stats` metrics component to the generic metrics registry, reporting FreeRTOS heap health (`heap_free`, `heap_min_free`, `heap_largest_block` `heap_total_allocs`, `heap_total_frees`, in bytes).

## How does it make Bristlemouth better?

- Adds fleet-wide heap visibility per node and proves the generic registry takes a second producer cleanly.
- `heap_min_free` is a low-water leak signal, `heap_largest_block` catches fragmentation and `allocs` − `frees` gives a count-based leak signal.

## Where should reviewers focus?

- Placement: lives in bm_protocol (not bm_core)
- Field choice: five of the seven `HeapStats_t` fields


- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.