### PR TITLE
Use canonical metrics log decoder from bm_common_messages

### DIFF
--- a/tools/scripts/misc/decode_metrics.py
+++ b/tools/scripts/misc/decode_metrics.py
@@ -1,79 +1,59 @@
+"""
+Decode a Bristlemouth network_metrics.log to CSV for inspection.
+
+ADIN component "adin_port_stats_<port>" fields (cumulative since boot):
+  sqi/mse/lq/rxe/sye/fc/len/algn  (see the shared decoder for meaning)
+  mse==0 means no link partner even though lq/sqi read "good".
+"""
+
 import argparse
-import base64
-import re
+import sys
+from pathlib import Path
 import pandas as pd
-import cbor2
+
+# Shared, canonical decoder lives with the schema (vendored via bm_core).
+
+sys.path.append(
+    str(
+        Path(__file__).resolve().parents[3] / "src/lib/bm_core/bm_common_messages/tools"
+    )
+)
+from decode_metrics_log import decode_metrics_log
 
 LINK_QUALITY = {0: "poor", 1: "marginal", 2: "good"}
-LINE_RE = re.compile(r"^(?P<ts>\S+)\s*\|\s*(?P<node>\S+)/metrics\s+(?P<b64>[A-Za-z0-9+/=]+)")
-
-"""
-Each reply is a base64-encoded CBOR envelope:
-  { "version": <v>, "node_id": <id>, "uptime_ms": <ms>,
-    "data": { "<component>": { "<field>": <value>, ... }, ... } }
-
-The decoder is generic: every component becomes a row and its fields become
-columns, so new component types are captured with no changes here. Component-
-specific niceties are layered on top only where they apply (see load_metrics).
-
-Today the only producer is the ADIN2111 driver, which reports one component per
-port, "adin_port_stats_<port>", with these fields (cumulative since boot):
-  sqi  - Signal Quality Indicator 0-7 (7 best)
-  mse  - raw MSE_VAL register (lower = cleaner signal; no units)
-  lq   - link quality enum: 0 poor / 1 marginal / 2 good
-  rxe  - frame-check RX (bad-CRC) error count
-  sye  - symbol error count
-  fc   - false-carrier count (noise on an idle line)
-  len  - frame length-error count
-  algn - frame alignment-error count
-Note: an idle port with no link partner reports sqi=7/mse=0 - not a real "good" link.
-Counters are monotonic; diff consecutive samples per (node, component) for a rate.
-The leading log field is a millisecond tick from the bridge (not wall-clock time).
-"""
 
 
 def load_metrics(log_path: str) -> pd.DataFrame:
     rows = []
-    with open(log_path, "r") as f:
-        for line in f:
-            m = LINE_RE.match(line)
-            if not m:
-                continue
-            try:
-                env = cbor2.loads(base64.b64decode(m.group("b64")))
-            except Exception:
-                continue  # skip malformed lines
-
-            tick = m.group("ts").rstrip("t")
-            tick_ms = int(tick) if tick.isdigit() else None
-            node = env.get("node_id")
-            node_id = f"{node:016x}" if isinstance(node, int) else m.group("node")
-
-            # Generic: every component becomes a row and its fields become
-            # columns, so new component types need no changes here.
-            for component, fields in env.get("data", {}).items():
-                if not isinstance(fields, dict):
-                    continue
-                row = {
-                    "tick_ms": tick_ms,
-                    "node_id": node_id,
-                    "version": env.get("version"),
-                    "uptime_ms": env.get("uptime_ms"),
-                    "component": component,
-                }
-                row.update(fields)
-                # Component-specific niceties, added only where they apply:
-                if component.startswith("adin_port_stats_"):
-                    row["port"] = int(component.rsplit("_", 1)[1])
-                if "lq" in fields:
-                     # mse==0 means no link partner (idle port), even though lq/sqi read "good"
-                    row["lq_label"] = "no-link" if fields.get("mse") == 0 else LINK_QUALITY.get(fields["lq"], "?")
-                rows.append(row)
+    for r in decode_metrics_log(log_path):
+        row = {
+            "tick_ms": r["tick_ms"],
+            "timestamp_utc": r["timestamp_utc"],
+            "node_id": r["node_id"],
+            "version": r["version"],
+            "uptime_ms": r["uptime_ms"],
+            "component": r["component"],
+        }
+        fields = r["fields"]
+        row.update(fields)
+        # Component-specific niceties, added only where they apply:
+        if r["component"].startswith("adin_port_stats_"):
+            row["port"] = int(r["component"].rsplit("_", 1)[1])
+        if "lq" in fields:
+            # mse==0 means no link partner even though lq/sqi read "good"
+            row["lq_label"] = (
+                "no-link"
+                if fields.get("mse") == 0
+                else LINK_QUALITY.get(fields["lq"], "?")
+            )
+        rows.append(row)
     return pd.DataFrame(rows)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Decode a Bristlemouth network_metrics.log")
+    parser = argparse.ArgumentParser(
+        description="Decode a Bristlemouth network_metrics.log"
+    )
     parser.add_argument("log_file", help="path to network_metrics.log")
     args = parser.parse_args()
 
@@ -81,6 +61,7 @@ def main() -> None:
     csv_path = args.log_file.rsplit(".", 1)[0] + ".csv"
     df.to_csv(csv_path, index=False)
     print(f"Wrote {csv_path} ({len(df)} rows)")
+
 
 if __name__ == "__main__":
     main()

--- a/tools/scripts/misc/decode_metrics.py
+++ b/tools/scripts/misc/decode_metrics.py
@@ -23,44 +23,61 @@ from decode_metrics_log import decode_metrics_log
 LINK_QUALITY = {0: "poor", 1: "marginal", 2: "good"}
 
 
-def load_metrics(log_path: str) -> pd.DataFrame:
-    rows = []
+def load_metrics_by_component(log_path: str) -> dict[str, pd.DataFrame]:
+    """Decode a network_metrics.log into one DataFrame per component family."""
+    groups: dict[str, list[dict]] = {}
     for r in decode_metrics_log(log_path):
+        comp = r["component"]
+        # Fold a trailing "_<n>" into a `port` column
+        family, _, tail = comp.rpartition("_")
+        if family and tail.isdigit():
+            port = int(tail)
+        else:
+            family, port = comp, None
+
         row = {
             "tick_ms": r["tick_ms"],
             "timestamp_utc": r["timestamp_utc"],
             "node_id": r["node_id"],
             "version": r["version"],
             "uptime_ms": r["uptime_ms"],
-            "component": r["component"],
         }
+        if port is not None:
+            row["port"] = port
         fields = r["fields"]
         row.update(fields)
-        # Component-specific niceties, added only where they apply:
-        if r["component"].startswith("adin_port_stats_"):
-            row["port"] = int(r["component"].rsplit("_", 1)[1])
         if "lq" in fields:
-            # mse==0 means no link partner even though lq/sqi read "good"
             row["lq_label"] = (
                 "no-link"
                 if fields.get("mse") == 0
                 else LINK_QUALITY.get(fields["lq"], "?")
             )
-        rows.append(row)
-    return pd.DataFrame(rows)
+        groups.setdefault(family, []).append(row)
+
+    tables = {}
+    for name, rows in groups.items():
+        df = pd.DataFrame(rows).dropna(axis=1, how="all")  # drop empty columns
+        sort_cols = [c for c in ("node_id", "port", "tick_ms") if c in df.columns]
+        tables[name] = df.sort_values(sort_cols).reset_index(drop=True)
+    return tables
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Decode a Bristlemouth network_metrics.log"
+        description="Decode a Bristlemouth network_metrics.log to per-component CSVs"
     )
     parser.add_argument("log_file", help="path to network_metrics.log")
     args = parser.parse_args()
 
-    df = load_metrics(args.log_file)
-    csv_path = args.log_file.rsplit(".", 1)[0] + ".csv"
-    df.to_csv(csv_path, index=False)
-    print(f"Wrote {csv_path} ({len(df)} rows)")
+    base = args.log_file.rsplit(".", 1)[0]
+    tables = load_metrics_by_component(args.log_file)
+    if not tables:
+        print("No decodable metrics found.")
+        return
+    for name, df in tables.items():
+        out = f"{base}_{name}.csv"
+        df.to_csv(out, index=False)
+        print(f"Wrote {out} ({len(df)} rows)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed?
- tools/scripts/misc/decode_metrics.py drops its own decode loop and imports the shared decoder; keeps only its pandas/CSV + ADIN-label layer.

## How does it make Bristlemouth better?
- Removes a duplicate decoder and the debug tool now can't misalign with the schema.


## Where should reviewers focus?
- This PR depends on [bm_core bump](https://github.com/bristlemouth/bm_core/pull/153) and the core decoder [PR for bm_common_messages](https://github.com/bristlemouth/bm_common_messages/pull/66)


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
