### PR TITLE
Add bm_config.h to app includes

### DIFF
--- a/src/apps/bm_soft_module/app_main.cpp
+++ b/src/apps/bm_soft_module/app_main.cpp
@@ -17,6 +17,7 @@
 
 #include "app_pub_sub.h"
 #include "app_util.h"
+#include "bm_config.h"
 #include "bristlefin.h"
 #include "bristlemouth_client.h"
 #include "bsp.h"

--- a/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
+++ b/src/apps/bristleback_apps/bristleback_apps_common/app_main.cpp
@@ -17,6 +17,7 @@
 
 #include "app_pub_sub.h"
 #include "app_util.h"
+#include "bm_config.h"
 #include "bristlemouth_client.h"
 #include "bsp.h"
 #include "cli.h"

--- a/src/apps/mote_bristlefin/app_main.cpp
+++ b/src/apps/mote_bristlefin/app_main.cpp
@@ -16,6 +16,7 @@
 
 #include "app_pub_sub.h"
 #include "app_util.h"
+#include "bm_config.h"
 #include "bristlefin.h"
 #include "bristlemouth_client.h"
 #include "bsp.h"

--- a/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
+++ b/src/apps/rs232_expander_apps/rs232_expander_apps_common/app_main.cpp
@@ -16,6 +16,7 @@
 
 #include "app_pub_sub.h"
 #include "app_util.h"
+#include "bm_config.h"
 #include "bristlemouth_client.h"
 #include "bsp.h"
 #include "cli.h"


### PR DESCRIPTION
## What changed?
- Added #include "bm_config.h" to the four app app_main.cpp files that call memory_metrics_init()


## How does it make Bristlemouth better?
- Without the include, `bm_metrics_enabled` was undefined in those units, so #if (bm_metrics_enabled != 0) silently compiled the memory-metrics registration out.


## Where should reviewers focus?



## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
