### PR TITLE
Fix bug where spotter_tx_data success prints a failure

### DIFF
--- a/src/lib/debug/debug_spotter.cpp
+++ b/src/lib/debug/debug_spotter.cpp
@@ -130,7 +130,7 @@ static BaseType_t cmd_spotter_fn(char *writeBuffer, size_t writeBufferLen,
       configASSERT(data);
       memcpy(data, dataStr, dataLen);
       data[dataLen] = 0;
-      if (spotter_tx_data(data, dataLen, type)) {
+      if (spotter_tx_data(data, dataLen, type) == BmOK) {
         printf("Sucessfully sent data transmit request\n");
       } else {
         printf("Failed to send data transmit request\n");


### PR DESCRIPTION
## What changed?
Changes conditional check to print success results if `spotter_tx_data` transmits successfully.


## How does it make Bristlemouth better?
Prevents confusion when running the `spotter txdata` command.


## Where should reviewers focus?
Rubber stamp.


## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
