### PR TITLE
Chore/update release naming

### DIFF
--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -201,7 +201,13 @@ class AutoBuilder:
         if self.version and len(self.version):
             cmd += [f"--version={self.version}"]
 
-        cmd += ["--output-name", config["name"]]
+        output_name = ""
+        if config["args"]["build_type"]:
+            output_name = f"{config["name"]}-{config["args"]["build_type"].lower()}"
+        else:
+            output_name = config["name"]
+
+        cmd += ["--output-name", output_name]
 
         result = self.run_command(cmd)
 
@@ -339,7 +345,7 @@ class AutoBuilder:
             self._setup_keys(tmpdirname)
 
             for name, config in self._configs.items():
-                print(f"Building: {name}")
+                print(f"Building: {name} - {config["args"]["build_type"]}")
                 external_dir_name = None
                 external_dir = self._setup_external_dir(config)
                 if external_dir:

--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -249,7 +249,6 @@ class AutoBuilder:
         try:
             # Run cmake setup commands
             self.setup_cmake_dir(config, ext_dir)
-
             # Compile firmware
             self.build_fw(config)
 
@@ -262,6 +261,7 @@ class AutoBuilder:
             if self.out_dir and os.path.exists(config["zip"]):
                 src = config["zip"]
                 dest = os.path.join(self.out_dir, os.path.basename(config["zip"]))
+                # dest = self.out_dir
                 print(f"Copying {src} to {dest}")
                 shutil.copy(src, dest)
 
@@ -398,7 +398,7 @@ if args.out_dir:
         print(f"Creating {args.out_dir}")
         pathlib.Path(args.out_dir).mkdir(parents=True, exist_ok=True)
 
-    builder.out_dir = args.out_dir
+    builder.out_dir = os.path.abspath(args.out_dir)
 
 builder.is_prod = args.prod
 builder.version = args.version

--- a/tools/scripts/release/auto_build.py
+++ b/tools/scripts/release/auto_build.py
@@ -255,6 +255,7 @@ class AutoBuilder:
         try:
             # Run cmake setup commands
             self.setup_cmake_dir(config, ext_dir)
+
             # Compile firmware
             self.build_fw(config)
 
@@ -267,7 +268,6 @@ class AutoBuilder:
             if self.out_dir and os.path.exists(config["zip"]):
                 src = config["zip"]
                 dest = os.path.join(self.out_dir, os.path.basename(config["zip"]))
-                # dest = self.out_dir
                 print(f"Copying {src} to {dest}")
                 shutil.copy(src, dest)
 

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -4,7 +4,7 @@
 #
 # NOTE: Changing the names for the builds in this file can break
 # automation steps that rely on these names remaining consistent.
-# Change carefully.
+# Change names carefully.
 #
 - name: bootloader_signing_required
   description: Production Bootloader - Requires Sofar Signed App Images

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -2,6 +2,10 @@
 # NOTE: Bootloader must be built first so it can be included in
 # unified image for later builds
 #
+# NOTE: Changing the names for the builds in this file can break
+# automation steps that rely on these names remaining consistent.
+# Change carefully.
+#
 - name: bootloader_signing_required
   description: Production Bootloader - Requires Sofar Signed App Images
   type: build_fw

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -147,7 +147,7 @@
     build_type: Release
   sign: false
 
-- name: borealis
+- name: borealis-release
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
   sha: 4c61e0c
@@ -157,7 +157,7 @@
     build_type: Release
   sign: false
 
-- name: borealis2
+- name: borealis2-release
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
   sha: aefeefa

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -6,6 +6,15 @@
 # automation steps that rely on these names remaining consistent.
 # Change names carefully.
 #
+# Output files are created with this format:
+# ${name}-${build type}-${version tag}.${file extension}
+#
+# Build type is pulled from this config file and appended
+# to the output naming in auto_build.py,
+# the script that uses this config file.
+#
+# The version tag is provided as an input into auto_build.py.
+#
 - name: bootloader_signing_required
   description: Production Bootloader - Requires Sofar Signed App Images
   type: build_fw
@@ -24,7 +33,7 @@
     build_type: Release
   sign: false
 
-- name: bridge-debug
+- name: bridge
   description: Sofar BM Bridge - Debug
   type: build_fw
   args:
@@ -33,7 +42,7 @@
     build_type: Debug
   sign: true
 
-- name: bridge-release
+- name: bridge
   description: Sofar BM Bridge - Release
   type: build_fw
   args:
@@ -42,7 +51,7 @@
     build_type: Release
   sign: true
 
-- name: hello_world-debug
+- name: hello_world
   description: Hello World - Debug
   type: build_fw
   args:
@@ -51,7 +60,7 @@
     build_type: Debug
   sign: false
 
-- name: bm_soft_module-release
+- name: bm_soft_module
   description: BM Soft Module - Release
   type: build_fw
   args:
@@ -60,7 +69,7 @@
     build_type: Release
   sign: true
 
-- name: serial_bridge-debug
+- name: serial_bridge
   description: Serial Bridge - Debug
   type: build_fw
   args:
@@ -69,7 +78,7 @@
     build_type: Debug
   sign: false
 
-- name: bringup_mote-debug
+- name: bringup_mote
   description: Bringup Mote - Debug
   type: build_fw
   args:
@@ -88,7 +97,7 @@
   sign: false
   legacy: true
 
-- name: bringup_bridge-debug
+- name: bringup_bridge
   description: Bringup Bridge - Debug
   type: build_fw
   args:
@@ -107,7 +116,7 @@
   sign: false
   legacy: true
 
-- name: bm_rbr-release
+- name: bm_rbr
   description: BM RBR - Release
   type: build_fw
   args:
@@ -116,7 +125,7 @@
     build_type: Release
   sign: true
 
-- name: seapoint_turbidity-release
+- name: seapoint_turbidity
   description: BM Seapoint Turbidity - Release
   type: build_fw
   args:
@@ -125,7 +134,7 @@
     build_type: Release
   sign: true
 
-- name: aanderaa-release
+- name: aanderaa
   description: Aanderaa Current Meter - Release
   type: build_fw
   args:
@@ -134,7 +143,7 @@
     build_type: Release
   sign: true
 
-- name: aanderaa_salinity-release
+- name: aanderaa_salinity
   description: Aanderaa Salinity Sensor - Release
   type: build_fw
   args:
@@ -143,7 +152,7 @@
     build_type: Release
   sign: true
 
-- name: pme_do_sensor-release
+- name: pme_do_sensor
   type: build_fw
   args:
     app: pme_do_sensor
@@ -151,7 +160,7 @@
     build_type: Release
   sign: false
 
-- name: borealis-release
+- name: borealis
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
   sha: 4c61e0c
@@ -161,7 +170,7 @@
     build_type: Release
   sign: false
 
-- name: borealis2-release
+- name: borealis2
   type: ext_fw
   repo: git@github.com:appliedoceansciences/borealis_mote_firmware.git
   sha: aefeefa
@@ -172,7 +181,7 @@
     external_init: true
   sign: false
 
-- name: mavlink_bridge-release
+- name: mavlink_bridge
   type: build_fw
   args:
     app: mavlink_bridge

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -29,7 +29,7 @@
     build_type: Debug
   sign: true
 
-- name: bridge_release
+- name: bridge-release
   description: Sofar BM Bridge - Release
   type: build_fw
   args:
@@ -47,7 +47,7 @@
     build_type: Debug
   sign: false
 
-- name: bm_soft_module_release
+- name: bm_soft_module-release
   description: BM Soft Module - Release
   type: build_fw
   args:
@@ -103,7 +103,7 @@
   sign: false
   legacy: true
 
-- name: bm_rbr_release
+- name: bm_rbr-release
   description: BM RBR - Release
   type: build_fw
   args:
@@ -112,7 +112,7 @@
     build_type: Release
   sign: true
 
-- name: seapoint_turbidity_release
+- name: seapoint_turbidity-release
   description: BM Seapoint Turbidity - Release
   type: build_fw
   args:
@@ -121,7 +121,7 @@
     build_type: Release
   sign: true
 
-- name: aanderaa_release
+- name: aanderaa-release
   description: Aanderaa Current Meter - Release
   type: build_fw
   args:
@@ -130,7 +130,7 @@
     build_type: Release
   sign: true
 
-- name: aanderaa_salinity_release
+- name: aanderaa_salinity-release
   description: Aanderaa Salinity Sensor - Release
   type: build_fw
   args:
@@ -139,7 +139,7 @@
     build_type: Release
   sign: true
 
-- name: pme_do_sensor_release
+- name: pme_do_sensor-release
   type: build_fw
   args:
     app: pme_do_sensor
@@ -168,7 +168,7 @@
     external_init: true
   sign: false
 
-- name: mavlink_bridge_release
+- name: mavlink_bridge-release
   type: build_fw
   args:
     app: mavlink_bridge

--- a/tools/scripts/release/configs/default.yml
+++ b/tools/scripts/release/configs/default.yml
@@ -20,7 +20,7 @@
     build_type: Release
   sign: false
 
-- name: bridge_debug
+- name: bridge-debug
   description: Sofar BM Bridge - Debug
   type: build_fw
   args:
@@ -38,7 +38,7 @@
     build_type: Release
   sign: true
 
-- name: hello_world_debug
+- name: hello_world-debug
   description: Hello World - Debug
   type: build_fw
   args:
@@ -56,7 +56,7 @@
     build_type: Release
   sign: true
 
-- name: serial_bridge_debug
+- name: serial_bridge-debug
   description: Serial Bridge - Debug
   type: build_fw
   args:
@@ -65,7 +65,7 @@
     build_type: Debug
   sign: false
 
-- name: bringup_mote_debug
+- name: bringup_mote-debug
   description: Bringup Mote - Debug
   type: build_fw
   args:
@@ -84,7 +84,7 @@
   sign: false
   legacy: true
 
-- name: bringup_bridge_debug
+- name: bringup_bridge-debug
   description: Bringup Bridge - Debug
   type: build_fw
   args:


### PR DESCRIPTION
## What changed?
Changes the naming of release artifacts to follow: `{name}-{build_type}-{version}`. This makes sure that the artifacts follow a pattern and does not require us to remember to put "_release" or "-release" in the name of the config.


## How does it make Bristlemouth better?
Removes our need to remember naming conventions.


## Where should reviewers focus?
### Testing:
Here is the resulting names after I ran auto_build.py locally on my machine:
```
(bristlemouth-ci) ➜  bm_protocol git:(chore/update_release_naming) ✗ ls cmake-build/bm_release_naming_testing
aanderaa_salinity-release-ENG-v0.13.12.zip           bootloader_signing_required-release-ENG-v0.13.12.zip bringup_bridge-debug-ENG-v0.13.12.zip                pme_do_sensor-release-ENG-v0.13.12.zip
aanderaa-release-ENG-v0.13.12.zip                    borealis-release-ENG-v0.13.12.zip                    bringup_mote_legacy-debug-ENG-v0.13.12.zip           seapoint_turbidity-release-ENG-v0.13.12.zip
bm_rbr-release-ENG-v0.13.12.zip                      borealis2-release-ENG-v0.13.12.zip                   bringup_mote-debug-ENG-v0.13.12.zip                  serial_bridge-debug-ENG-v0.13.12.zip
bm_soft_module-release-ENG-v0.13.12.zip              bridge-release-ENG-v0.13.12.zip                      hello_world-debug-ENG-v0.13.12.zip
bootloader_development-release-ENG-v0.13.12.zip      bringup_bridge_legacy-debug-ENG-v0.13.12.zip         mavlink_bridge-release-ENG-v0.13.12.zip
```

## Checklist

- [ ] Add or update unit tests for changed code
- [ ] Ensure all submodules up to date. If this PR relies on changes in submodules, merge those PRs first, then point this PR at/after the merge commit
- [ ] Ensure code is formatted correctly with clang-format. If there are large formatting changes, they should happen in a separate whitespace-only commit on this PR after all approvals.
